### PR TITLE
Remove custom logging support from start

### DIFF
--- a/.changeset/odd-steaks-fry.md
+++ b/.changeset/odd-steaks-fry.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**start:** Remove support for a custom port logging function

--- a/README.md
+++ b/README.md
@@ -210,11 +210,6 @@ interface Export {
   callback?: () => http.RequestListener;
   requestListener?: http.RequestListener;
 
-  // optional; falls back to console.debug
-  logger?: {
-    debug: (message: string) => void;
-  };
-
   // optional; falls back to an available port
   port?: number;
 }

--- a/src/cli/start/http.ts
+++ b/src/cli/start/http.ts
@@ -12,9 +12,6 @@ interface Config {
 
   requestListener?: http.RequestListener;
 
-  logger?: {
-    debug: (msg: string) => void;
-  };
   port?: number;
 }
 
@@ -55,11 +52,6 @@ const start = () => {
     process.exit(1);
   }
 
-  const writeDebugLog = (message: string) =>
-    typeof config.logger === 'undefined'
-      ? console.debug(message)
-      : config.logger.debug(message);
-
   const server = http.createServer(requestListener);
 
   return new Promise((resolve, reject) =>
@@ -70,7 +62,7 @@ const start = () => {
       .on('listening', () => {
         const address = server.address() as AddressInfo;
 
-        writeDebugLog(`listening on port ${address.port}`);
+        console.debug(`listening on port ${address.port}`);
       }),
   );
 };


### PR DESCRIPTION
This only logs the port; it's not worth the potential confusion.