### PR TITLE
Retain proper package.json fields with configure

### DIFF
--- a/.changeset/gorgeous-apples-join.md
+++ b/.changeset/gorgeous-apples-join.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Keep name, readme and version fields in package.json

--- a/src/cli/configure/processing/package.test.ts
+++ b/src/cli/configure/processing/package.test.ts
@@ -78,6 +78,31 @@ describe('withPackage', () => {
       "
     `));
 
+  it('preserves legitimate fields', () =>
+    expect(
+      withPackage((data) => {
+        data.$name = 'unit-test';
+
+        return data;
+      })(
+        JSON.stringify({
+          description: 'My Package',
+          name: 'my-package',
+          readme: 'https://github.com/my-org/my-package#readme',
+          version: '0.1.0',
+        }),
+      ),
+    ).toMatchInlineSnapshot(`
+      "{
+        \\"$name\\": \\"unit-test\\",
+        \\"description\\": \\"My Package\\",
+        \\"name\\": \\"my-package\\",
+        \\"readme\\": \\"https://github.com/my-org/my-package#readme\\",
+        \\"version\\": \\"0.1.0\\"
+      }
+      "
+    `));
+
   it('handles bad JSON gracefully', () =>
     expect(
       withPackage((data) => {

--- a/src/cli/configure/processing/package.ts
+++ b/src/cli/configure/processing/package.ts
@@ -8,10 +8,20 @@ export const formatPackage = (data: PackageJson) => {
   normalizeData(data);
 
   // normalize-package-data fields that aren't useful for applications
+
   delete data._id;
-  delete data.name;
-  delete data.readme;
-  delete data.version;
+
+  if (data.name === '') {
+    delete data.name;
+  }
+
+  if (data.readme === 'ERROR: No README data found!') {
+    delete data.readme;
+  }
+
+  if (data.version === '') {
+    delete data.version;
+  }
 
   return formatObject(data);
 };


### PR DESCRIPTION
This was overly aggressive. It matters now because we want to support packages, where this metadata actually has a use.