### PR TITLE
Declare `@types/jest` as a peer dependency

### DIFF
--- a/.changeset/pretty-moose-argue.md
+++ b/.changeset/pretty-moose-argue.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**deps:** Declare `@types/jest` as a peer dependency

--- a/package.json
+++ b/package.json
@@ -72,10 +72,14 @@
     "typescript": "3.9.3"
   },
   "peerDependencies": {
-    "@seek/skuba-dive": "1"
+    "@seek/skuba-dive": "1",
+    "@types/jest": ">= 25 < 27"
   },
   "peerDependenciesMeta": {
     "@seek/skuba-dive": {
+      "optional": true
+    },
+    "@types/jest": {
       "optional": true
     }
   }


### PR DESCRIPTION
Package managers like pnpm are "strict" about implicit transitive dependencies; this may help to explain how to get things working in similar environments.