### PR TITLE
Drop unsupported Yarn 2 flags

### DIFF
--- a/.changeset/heavy-kangaroos-carry.md
+++ b/.changeset/heavy-kangaroos-carry.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Drop `--ignore-optional` from `yarn install`

--- a/.changeset/olive-zebras-love.md
+++ b/.changeset/olive-zebras-love.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**init:** Drop `--ignore-optional --silent` from `yarn add`

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -142,7 +142,7 @@ export const configure = async () => {
     ),
   );
 
-  await exec('yarn', 'install', '--ignore-optional', '--silent');
+  await exec('yarn', 'install', '--silent');
 
   console.log();
   console.log(chalk.green('Project configured!'));

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -63,15 +63,7 @@ export const init = async () => {
 
   await Promise.all([
     exec('git', 'init'),
-    exec(
-      'yarn',
-      'add',
-      '--dev',
-      '--exact',
-      '--ignore-optional',
-      '--silent',
-      'skuba',
-    ),
+    exec('yarn', 'add', '--dev', '--exact', 'skuba'),
   ]);
 
   console.log(`Created '${destinationDir}'!`);


### PR DESCRIPTION
I can't promise full Yarn 2.x + PnP support, but this is a small step.