### PR TITLE
Remove private deps from built-in templates

### DIFF
--- a/.changeset/gold-phones-sneeze.md
+++ b/.changeset/gold-phones-sneeze.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+Switch to `seek-datadog-custom-metrics` + `seek-koala`

--- a/README.md
+++ b/README.md
@@ -336,28 +336,28 @@ SEEK's developer community maintains an assortment of targeted packages.
 
 Here are some highlights:
 
-| Package                             | Description                                            |
-| :---------------------------------- | :----------------------------------------------------- |
-| [@seek/db-client]                   | Connect to databases with credential (rotation) smarts |
-| [@seek/graphql-utils]               | Add observability to GraphQL servers                   |
-| [@seek/koala]                       | Add SEEK-standard observability to Koa servers         |
-| [@seek/logger-js]                   | Write application logs in a standardised format        |
-| [@seek/node-authentication]         | Validate SEEK JWTs                                     |
-| [@seek/node-datadog-custom-metrics] | Write Datadog metrics in [Gantry] and Lambda           |
-| [@seek/node-s2sauth-issuer]         | Call an [s2sauth]-protected service                    |
-| [@seek/typegen]                     | Generate TypeScript types from a JSON schema           |
-| [@seek/zactive-directory]           | Authenticate and authorise [SSOd] users                |
+| Package                        | Description                                            |
+| :----------------------------- | :----------------------------------------------------- |
+| [seek-datadog-custom-metrics]  | Write Datadog metrics in [Gantry] and Lambda           |
+| [seek-koala]                   | Add SEEK-standard observability to Koa servers         |
+| 🔒 [@seek/db-client]           | Connect to databases with credential (rotation) smarts |
+| 🔒 [@seek/graphql-utils]       | Add observability to GraphQL servers                   |
+| 🔒 [@seek/logger-js]           | Write application logs in a standardised format        |
+| 🔒 [@seek/node-authentication] | Validate SEEK JWTs                                     |
+| 🔒 [@seek/node-s2sauth-issuer] | Call an [s2sauth]-protected service                    |
+| 🔒 [@seek/typegen]             | Generate TypeScript types from a JSON schema           |
+| 🔒 [@seek/zactive-directory]   | Authenticate and authorise [SSOd] users                |
 
 [@seek/db-client]: https://github.com/SEEK-Jobs/db-client
 [@seek/graphql-utils]: https://github.com/SEEK-Jobs/graphql-utils
-[@seek/koala]: https://github.com/SEEK-Jobs/koala
 [@seek/logger-js]: https://github.com/SEEK-Jobs/logger-js
 [@seek/node-authentication]: https://github.com/SEEK-Jobs/node-authentication
-[@seek/node-datadog-custom-metrics]: https://github.com/SEEK-Jobs/node-datadog-custom-metrics
 [@seek/node-s2sauth-issuer]: https://github.com/SEEK-Jobs/node-s2sauth-issuer
 [@seek/typegen]: https://github.com/SEEK-Jobs/typegen
 [@seek/zactive-directory]: https://github.com/SEEK-Jobs/zactive-directory
 [gantry]: https://github.com/SEEK-Jobs/gantry
+[seek-datadog-custom-metrics]: https://github.com/seek-oss/datadog-custom-metrics
+[seek-koala]: https://github.com/seek-oss/koala
 [s2sauth]: https://github.com/SEEK-Jobs/s2sauth
 [ssod]: https://github.com/SEEK-Jobs/seek-ssod-ingress
 

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -1,8 +1,6 @@
 {
   "dependencies": {
     "@koa/router": "^8.0.8",
-    "@seek/koala": "^4.0.0",
-    "@seek/node-datadog-custom-metrics": "^2.2.3",
     "skuba-dive": "^1.0.2",
     "hot-shots": "^7.4.2",
     "koa": "^2.12.0",
@@ -10,6 +8,8 @@
     "koa-cluster": "^1.1.0",
     "koa-compose": "^4.1.0",
     "pino": "^6.2.1",
+    "seek-datadog-custom-metrics": "^2.2.4",
+    "seek-koala": "^4.0.1",
     "uuid": "^8.0.0",
     "yup": "^0.28.5"
   },

--- a/template/koa-rest-api/src/framework/logging.ts
+++ b/template/koa-rest-api/src/framework/logging.ts
@@ -1,6 +1,6 @@
-import { RequestLogging } from '@seek/koala';
 import { Context } from 'koa';
 import pino from 'pino';
+import { RequestLogging } from 'seek-koala';
 
 import { config } from 'src/config';
 

--- a/template/koa-rest-api/src/framework/metrics.ts
+++ b/template/koa-rest-api/src/framework/metrics.ts
@@ -1,4 +1,4 @@
-import { createStatsDClient } from '@seek/node-datadog-custom-metrics';
+import { createStatsDClient } from 'seek-datadog-custom-metrics';
 
 import { config } from 'src/config';
 

--- a/template/koa-rest-api/src/framework/server.ts
+++ b/template/koa-rest-api/src/framework/server.ts
@@ -1,10 +1,10 @@
+import Koa, { Context, DefaultState, Middleware } from 'koa';
+import compose from 'koa-compose';
 import {
   MetricsMiddleware,
   RequestLogging,
   VersionMiddleware,
-} from '@seek/koala';
-import Koa, { Context, DefaultState, Middleware } from 'koa';
-import compose from 'koa-compose';
+} from 'seek-koala';
 
 import { config } from 'src/config';
 import { rootLogger } from 'src/framework/logging';

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@seek/node-datadog-custom-metrics": "^2.2.3",
+    "seek-datadog-custom-metrics": "^2.2.4",
     "skuba-dive": "^1.0.2",
     "pino": "^6.2.1",
     "runtypes": "^4.2.0",

--- a/template/lambda-sqs-worker/src/framework/metrics.ts
+++ b/template/lambda-sqs-worker/src/framework/metrics.ts
@@ -1,4 +1,4 @@
-import { createCloudWatchClient } from '@seek/node-datadog-custom-metrics';
+import { createCloudWatchClient } from 'seek-datadog-custom-metrics';
 
 import { config } from 'src/config';
 


### PR DESCRIPTION
- Enables us to run integration tests in CI without a token
- Reduces barrier to entry for new `skuba` users