### PR TITLE
Restore `--silent` arg for `yarn add`

### DIFF
--- a/.changeset/breezy-dancers-think.md
+++ b/.changeset/breezy-dancers-think.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**init:** Restore `--silent` arg for `yarn add`

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -63,7 +63,7 @@ export const init = async () => {
 
   await Promise.all([
     exec('git', 'init'),
-    exec('yarn', 'add', '--dev', '--exact', 'skuba'),
+    exec('yarn', 'add', '--dev', '--exact', '--silent', 'skuba'),
   ]);
 
   console.log(`Created '${destinationDir}'!`);


### PR DESCRIPTION
This is super noisy on Yarn 1.x otherwise.