### PR TITLE
Relax linting on Jest config files

### DIFF
--- a/.changeset/red-trains-explode.md
+++ b/.changeset/red-trains-explode.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**format, lint:** Relax on Jest config files

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -6,9 +6,10 @@ module.exports = {
   ignorePatterns: ['**/.eslintrc.js'],
   overrides: [
     {
-      files: ['**/jest.config.js'],
+      files: ['**/jest.*config*.js'],
       rules: {
         '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
         'import/no-unresolved': 'off',
       },
     },


### PR DESCRIPTION
- Allows `require('skuba/config/jest').someProperty`
- Allows additional filenames like `jest.config.int.js` and `jest.int.config.js`