### PR TITLE
Split up mega-configure function

### DIFF
--- a/src/cli/configure/applyConfiguration.ts
+++ b/src/cli/configure/applyConfiguration.ts
@@ -1,0 +1,59 @@
+import path from 'path';
+
+import chalk from 'chalk';
+import { Confirm } from 'enquirer';
+import fs from 'fs-extra';
+
+import { exec } from '../../utils/exec';
+
+import { FileDiff } from './types';
+
+const CONFIRMATION_PROMPT = new Confirm({
+  message: 'Apply changes?',
+  name: 'confirmation',
+});
+
+interface Props {
+  files: FileDiff;
+}
+
+export const applyConfiguration = async ({ files }: Props) => {
+  if (Object.keys(files).length === 0) {
+    return console.log(chalk.green('Project already configured.'));
+  }
+
+  Object.entries(files)
+    .sort(([filenameA], [filenameB]) => filenameA.localeCompare(filenameB))
+    .forEach(([filename, { operation }]) =>
+      console.log(`${operation} ${filename}`),
+    );
+
+  console.log();
+
+  const shouldContinue = await CONFIRMATION_PROMPT.run();
+
+  if (!shouldContinue) {
+    return;
+  }
+
+  const dirnames = [
+    ...new Set(Object.keys(files).map((filename) => path.dirname(filename))),
+  ];
+
+  await Promise.all(dirnames.map((dirname) => fs.ensureDir(dirname)));
+
+  await Promise.all(
+    Object.entries(files).map(([filename, { data }]) =>
+      typeof data === 'undefined'
+        ? fs.remove(filename)
+        : fs.writeFile(filename, data),
+    ),
+  );
+
+  await exec('yarn', 'install', '--silent');
+
+  console.log();
+  console.log(chalk.green('Project configured!'));
+  console.log();
+  console.log(`Try running ${chalk.bold('skuba format')}.`);
+};

--- a/src/cli/configure/ensureTemplateCompletion.ts
+++ b/src/cli/configure/ensureTemplateCompletion.ts
@@ -1,0 +1,64 @@
+import path from 'path';
+
+import chalk from 'chalk';
+import fs from 'fs-extra';
+import { NormalizedReadResult } from 'read-pkg-up';
+
+import { copyFiles, createInclusionFilter } from '../../utils/copy';
+import {
+  BASE_TEMPLATE_DIR,
+  TemplateConfig,
+  ensureTemplateConfigDeletion,
+} from '../../utils/template';
+import { hasStringProp } from '../../utils/validation';
+import { getTemplateConfig, runForm } from '../init/getConfig';
+
+import { formatObject } from './processing/json';
+
+interface Props {
+  destinationRoot: string;
+  manifest: NormalizedReadResult;
+}
+
+export const ensureTemplateCompletion = async ({
+  destinationRoot,
+  manifest,
+}: Props): Promise<TemplateConfig> => {
+  const templateConfig = getTemplateConfig(destinationRoot);
+
+  if (templateConfig.fields.length === 0) {
+    return templateConfig;
+  }
+
+  const templateName = hasStringProp(manifest.packageJson.skuba, 'template')
+    ? manifest.packageJson.skuba.template
+    : 'template';
+
+  const templateData = await runForm({
+    choices: templateConfig.fields,
+    message: chalk.bold(`Complete ${chalk.cyan(templateName)}:`),
+    name: 'customAnswers',
+  });
+
+  const updatedPackageJson = formatObject(manifest.packageJson);
+  const packageJsonFilepath = path.join(destinationRoot, 'package.json');
+  await fs.writeFile(packageJsonFilepath, updatedPackageJson);
+
+  const include = await createInclusionFilter([
+    path.join(destinationRoot, '.gitignore'),
+    path.join(BASE_TEMPLATE_DIR, '_.gitignore'),
+  ]);
+
+  await copyFiles({
+    sourceRoot: destinationRoot,
+    destinationRoot,
+    include,
+    templateData,
+  });
+
+  await ensureTemplateConfigDeletion(destinationRoot);
+
+  console.log(chalk.green('Finished templating.'));
+
+  return templateConfig;
+};

--- a/src/cli/configure/getEntryPoint.ts
+++ b/src/cli/configure/getEntryPoint.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+
+import chalk from 'chalk';
+import { Input } from 'enquirer';
+import { NormalizedReadResult } from 'read-pkg-up';
+
+import { TemplateConfig } from '../../utils/template';
+import { hasStringProp } from '../../utils/validation';
+
+import { tsFileExists } from './analysis/files';
+
+interface Props {
+  destinationRoot: string;
+  manifest: NormalizedReadResult;
+  templateConfig: TemplateConfig;
+}
+export const getEntryPoint = ({
+  destinationRoot,
+  manifest,
+  templateConfig,
+}: Props) => {
+  if (hasStringProp(manifest.packageJson.skuba, 'entryPoint')) {
+    return manifest.packageJson.skuba.entryPoint;
+  }
+
+  if (typeof templateConfig.entryPoint !== 'undefined') {
+    return templateConfig.entryPoint;
+  }
+
+  const entryPointPrompt = new Input({
+    initial: 'src/app.ts',
+    message: 'Entry point:',
+    name: 'entryPoint',
+    result: (value) => (value.endsWith('.ts') ? value : `${value}.ts`),
+    validate: async (value) => {
+      const exists = await tsFileExists(path.join(destinationRoot, value));
+
+      return exists || `${chalk.bold(value)} is not a TypeScript file.`;
+    },
+  });
+
+  return entryPointPrompt.run();
+};

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -1,29 +1,16 @@
 import path from 'path';
 
 import chalk from 'chalk';
-import { Confirm, Input } from 'enquirer';
-import fs from 'fs-extra';
 
-import { copyFiles, createInclusionFilter } from '../../utils/copy';
-import { ensureCommands, exec } from '../../utils/exec';
+import { ensureCommands } from '../../utils/exec';
 import { showLogo } from '../../utils/logo';
-import {
-  BASE_TEMPLATE_DIR,
-  ensureTemplateConfigDeletion,
-} from '../../utils/template';
-import { hasStringProp } from '../../utils/validation';
-import { getTemplateConfig, runForm } from '../init/getConfig';
 
-import { tsFileExists } from './analysis/files';
 import { auditWorkingTree } from './analysis/git';
 import { getDestinationManifest } from './analysis/package';
 import { diffFiles } from './analysis/project';
-import { formatObject } from './processing/json';
-
-const CONFIRMATION_PROMPT = new Confirm({
-  message: 'Apply changes?',
-  name: 'confirmation',
-});
+import { applyConfiguration } from './applyConfiguration';
+import { ensureTemplateCompletion } from './ensureTemplateCompletion';
+import { getEntryPoint } from './getEntryPoint';
 
 export const configure = async () => {
   await showLogo();
@@ -40,63 +27,16 @@ export const configure = async () => {
 
   await auditWorkingTree();
 
-  const entryPointPrompt = new Input({
-    initial: 'src/app.ts',
-    message: 'Entry point:',
-    name: 'entryPoint',
-    result: (value) => (value.endsWith('.ts') ? value : `${value}.ts`),
-    validate: async (value) => {
-      const exists = await tsFileExists(path.join(destinationRoot, value));
-
-      return exists || `${chalk.bold(value)} is not a TypeScript file.`;
-    },
+  const templateConfig = await ensureTemplateCompletion({
+    destinationRoot,
+    manifest,
   });
 
-  const templateConfig = getTemplateConfig(destinationRoot);
-
-  const manifestConfig =
-    hasStringProp(manifest.packageJson.skuba, 'template') &&
-    hasStringProp(manifest.packageJson.skuba, 'entryPoint')
-      ? {
-          entryPoint: manifest.packageJson.skuba.entryPoint,
-          template: manifest.packageJson.skuba.template,
-        }
-      : undefined;
-
-  if (templateConfig.fields.length > 0) {
-    const templateName = manifestConfig?.template ?? 'template';
-
-    const templateData = await runForm({
-      choices: templateConfig.fields,
-      message: chalk.bold(`Complete ${chalk.cyan(templateName)}:`),
-      name: 'customAnswers',
-    });
-
-    const updatedPackageJson = formatObject(manifest.packageJson);
-    const packageJsonFilepath = path.join(destinationRoot, 'package.json');
-    await fs.writeFile(packageJsonFilepath, updatedPackageJson);
-
-    const include = await createInclusionFilter([
-      path.join(destinationRoot, '.gitignore'),
-      path.join(BASE_TEMPLATE_DIR, '_.gitignore'),
-    ]);
-
-    await copyFiles({
-      sourceRoot: destinationRoot,
-      destinationRoot,
-      include,
-      templateData,
-    });
-
-    await ensureTemplateConfigDeletion(destinationRoot);
-
-    console.log(chalk.green('Finished templating.'));
-  }
-
-  const entryPoint =
-    manifestConfig?.entryPoint ??
-    templateConfig.entryPoint ??
-    (await entryPointPrompt.run());
+  const entryPoint = await getEntryPoint({
+    destinationRoot,
+    manifest,
+    templateConfig,
+  });
 
   console.log();
   console.log('Analysing project...');
@@ -107,42 +47,5 @@ export const configure = async () => {
     entryPoint,
   });
 
-  if (Object.keys(files).length === 0) {
-    return console.log(chalk.green('Project already configured.'));
-  }
-
-  Object.entries(files)
-    .sort(([filenameA], [filenameB]) => filenameA.localeCompare(filenameB))
-    .forEach(([filename, { operation }]) =>
-      console.log(`${operation} ${filename}`),
-    );
-
-  console.log();
-
-  const shouldContinue = await CONFIRMATION_PROMPT.run();
-
-  if (!shouldContinue) {
-    return;
-  }
-
-  const dirnames = [
-    ...new Set(Object.keys(files).map((filename) => path.dirname(filename))),
-  ];
-
-  await Promise.all(dirnames.map((dirname) => fs.ensureDir(dirname)));
-
-  await Promise.all(
-    Object.entries(files).map(([filename, { data }]) =>
-      typeof data === 'undefined'
-        ? fs.remove(filename)
-        : fs.writeFile(filename, data),
-    ),
-  );
-
-  await exec('yarn', 'install', '--silent');
-
-  console.log();
-  console.log(chalk.green('Project configured!'));
-  console.log();
-  console.log(`Try running ${chalk.bold('skuba format')}.`);
+  return applyConfiguration({ files });
 };


### PR DESCRIPTION
This was kinda scary, and we can't keep it that way; we're looking at possibly capturing more info as part of the configure flow to support package and monorepo configurations.