### PR TITLE
Pass through Gantry environment as ENVIRONMENT

### DIFF
--- a/.changeset/tender-vans-bake.md
+++ b/.changeset/tender-vans-bake.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/koa-rest-api:** Pass through Gantry environment as ENVIRONMENT

--- a/template/koa-rest-api/.gantry/common.yml
+++ b/template/koa-rest-api/.gantry/common.yml
@@ -10,7 +10,7 @@ tags:
   # seek:data:consumers: internal
   # https://rfc.skinfra.xyz/RFC019-AWS-Tagging-Standard.html#seekdatatypes
   # seek:data:types:restricted: job-ads
-  seek:env:label: '{{values "env.ENVIRONMENT"}}'
+  seek:env:label: '{{.Environment}}'
   seek:env:production: '{{values "isProduction"}}'
   seek:owner:team: '<%- teamName %>'
   seek:source:sha: '{{.CommitSHA}}'

--- a/template/koa-rest-api/.gantry/dev.yml
+++ b/template/koa-rest-api/.gantry/dev.yml
@@ -1,5 +1,5 @@
 env:
-  ENVIRONMENT: dev
+  SOME_ENVIRONMENT_VARIABLE: dev-value
 
 isProduction: false
 

--- a/template/koa-rest-api/.gantry/prod.yml
+++ b/template/koa-rest-api/.gantry/prod.yml
@@ -1,5 +1,5 @@
 env:
-  ENVIRONMENT: prod
+  SOME_ENVIRONMENT_VARIABLE: prod-value
 
 isProduction: true
 

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -9,6 +9,7 @@ image: '{{values "image"}}'
 region: '{{values "region"}}'
 
 env:
+  ENVIRONMENT: '{{.Environment}}'
   REGION: '{{values "region"}}'
   SERVICE: '{{values "service"}}'
   {{range $key, $value := .Values.env}}

--- a/template/koa-rest-api/src/config.ts
+++ b/template/koa-rest-api/src/config.ts
@@ -14,7 +14,12 @@ interface Config {
 
 type Environment = typeof environments[number];
 
-const environments = ['local', 'test', 'dev', 'prod'] as const;
+const environments = [
+  'local',
+  'test',
+  '<%- devGantryEnvironmentName %>',
+  '<%- prodGantryEnvironmentName %>',
+] as const;
 
 const environment = Env.oneOf(environments)('ENVIRONMENT');
 
@@ -36,13 +41,13 @@ const configs: Record<Environment, () => Omit<Config, 'environment'>> = {
     version: 'test',
   }),
 
-  dev: () => ({
-    ...configs.prod(),
+  '<%- devGantryEnvironmentName %>': () => ({
+    ...configs['<%- prodGantryEnvironmentName %>'](),
 
     logLevel: 'debug',
   }),
 
-  prod: () => ({
+  '<%- prodGantryEnvironmentName %>': () => ({
     logLevel: 'info',
     name: Env.string('SERVICE'),
     region: Env.string('REGION'),


### PR DESCRIPTION
Defining an application environment that was different to the Gantry environment was potentially confusing, and led to tagging differences between built-in and custom metrics.