### PR TITLE
Use snippet prompt for initial details

### DIFF
--- a/.changeset/neat-lobsters-suffer.md
+++ b/.changeset/neat-lobsters-suffer.md
@@ -2,7 +2,9 @@
 'skuba': minor
 ---
 
-Add template for private npm packages
+**template/private-npm-package:** Add new template
+
+The `private-npm-package` template replaces `smt init`.
 
 This change also defaults TypeScript's `moduleResolution` to `node`.
 This shouldn't break any existing consumers as it is the default resolution strategy for CommonJS.

--- a/.changeset/pretty-dolls-tap.md
+++ b/.changeset/pretty-dolls-tap.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**init:** Redesign first prompt

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -14,8 +14,7 @@ import {
 
 import { downloadGitHubTemplate } from './git';
 import {
-  BASE_CHOICES,
-  BaseFields,
+  BASE_PROMPT,
   GIT_PATH_PROMPT,
   SHOULD_CONTINUE_PROMPT,
   TEMPLATE_PROMPT,
@@ -133,13 +132,14 @@ export const getTemplateConfig = (dir: string): TemplateConfig => {
 };
 
 export const configureFromPrompt = async (): Promise<InitConfig> => {
-  const baseAnswers = await runForm<BaseFields>({
-    choices: BASE_CHOICES,
-    message: 'For starters:',
-    name: 'baseAnswers',
-  });
-
-  Object.values(baseAnswers).forEach((value) => log.plain(chalk.cyan(value)));
+  const { values: baseAnswers } = await BASE_PROMPT.run();
+  log.plain(
+    chalk.cyan(baseAnswers.repoName),
+    'by',
+    chalk.cyan(baseAnswers.teamName),
+    'in',
+    chalk.cyan(baseAnswers.orgName),
+  );
 
   const destinationDir = baseAnswers.repoName;
 

--- a/src/cli/init/prompts.ts
+++ b/src/cli/init/prompts.ts
@@ -1,14 +1,17 @@
-import { Input, Select } from 'enquirer';
+import { Input, Select, Snippet } from 'enquirer';
 import fs from 'fs-extra';
 
-export type BaseFields = Record<typeof BASE_CHOICES[number]['name'], string>;
+type BaseFields = Record<typeof BASE_CHOICES[number]['name'], string>;
 
-export const BASE_CHOICES = [
+const BASE_CHOICES = [
   {
     name: 'repoName',
-    message: 'Repository',
-    initial: 'prefix-my-project',
-    validate: async (value: string) => {
+    message: 'repo',
+    validate: async (value: unknown) => {
+      if (typeof value !== 'string') {
+        return 'required';
+      }
+
       const exists = await fs.pathExists(value);
 
       return !exists || `'${value}' is an existing directory`;
@@ -16,15 +19,25 @@ export const BASE_CHOICES = [
   },
   {
     name: 'orgName',
-    message: 'Github org name',
-    initial: 'my-org',
+    message: 'org',
+    initial: 'SEEK-Jobs',
   },
   {
     name: 'teamName',
-    message: 'GitHub team',
-    initial: 'my-team',
+    message: 'team',
   },
 ] as const;
+
+export const BASE_PROMPT = new Snippet<BaseFields>({
+  fields: BASE_CHOICES,
+  message: 'For starters:',
+  name: 'baseAnswers',
+  required: true,
+  template: [
+    'https://github.com/${orgName}/${repoName}',
+    'https://github.com/orgs/${orgName}/teams/${teamName}',
+  ].join('\n'),
+});
 
 export const SHOULD_CONTINUE_PROMPT = new Select({
   choices: ['yes', 'no'] as const,

--- a/src/enquirer.d.ts
+++ b/src/enquirer.d.ts
@@ -60,13 +60,18 @@ declare module 'enquirer' {
     constructor(opts: {
       name: string;
       message: string;
-      fields: Array<{
+      fields: ReadonlyArray<{
         name: string;
         message?: string;
+        initial?: string;
+        validate?: (
+          values: Record<string, string>,
+        ) => boolean | string | Promise<boolean | string>;
       }>;
+      required?: boolean;
       template: string;
     });
 
-    run(): Promise<T>;
+    run(): Promise<{ result: string; values: T }>;
   }
 }


### PR DESCRIPTION
Enquirer bundles a prompt type that is a really good fit for us here. This also lets us work around the aggressive `runForm` validation that prevented us from defaulting the org field to SEEK-Jobs.

---

Bonus: some terminals even let you click on the URLs!

<img width="368" alt="Screen Shot 2020-06-11 at 6 56 55 pm" src="https://user-images.githubusercontent.com/25572311/84365832-5d6df780-ac15-11ea-8dab-d5c9117f3800.png">
