### PR TITLE
Abstract text processing during file copy

### DIFF
--- a/src/cli/configure/applyConfiguration.ts
+++ b/src/cli/configure/applyConfiguration.ts
@@ -6,7 +6,7 @@ import fs from 'fs-extra';
 import { exec } from '../../utils/exec';
 import { log } from '../../utils/logging';
 
-import { FileDiff } from './types';
+import { diffFiles } from './analysis/project';
 
 const CONFIRMATION_PROMPT = new Confirm({
   message: 'Apply changes?',
@@ -14,10 +14,13 @@ const CONFIRMATION_PROMPT = new Confirm({
 });
 
 interface Props {
-  files: FileDiff;
+  destinationRoot: string;
+  entryPoint: string;
 }
 
-export const applyConfiguration = async ({ files }: Props) => {
+export const applyConfiguration = async (props: Props) => {
+  const files = await diffFiles(props);
+
   log.newline();
 
   if (Object.keys(files).length === 0) {

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -1,6 +1,10 @@
 import path from 'path';
 
-import { copyFiles, createInclusionFilter } from '../../utils/copy';
+import {
+  copyFiles,
+  createEjsRenderer,
+  createInclusionFilter,
+} from '../../utils/copy';
 import { createExec, ensureCommands } from '../../utils/exec';
 import { log } from '../../utils/logging';
 import { showLogo } from '../../utils/logo';
@@ -30,11 +34,13 @@ export const init = async () => {
     path.join(BASE_TEMPLATE_DIR, '_.gitignore'),
   ]);
 
+  const processors = [createEjsRenderer(templateData)];
+
   await copyFiles({
     sourceRoot: destinationDir,
     destinationRoot: destinationDir,
     include,
-    templateData,
+    processors,
   });
 
   // prefer skuba /template/base files
@@ -42,7 +48,7 @@ export const init = async () => {
     sourceRoot: BASE_TEMPLATE_DIR,
     destinationRoot: destinationDir,
     include,
-    templateData,
+    processors,
   });
 
   await Promise.all([

--- a/src/utils/copy.test.ts
+++ b/src/utils/copy.test.ts
@@ -1,6 +1,10 @@
 import path from 'path';
 
-import { createInclusionFilter } from './copy';
+import {
+  createEjsRenderer,
+  createInclusionFilter,
+  createStringReplacer,
+} from './copy';
 import { BASE_TEMPLATE_DIR } from './template';
 
 describe('createInclusionFilter', () => {
@@ -41,5 +45,73 @@ describe('createInclusionFilter', () => {
       'README.md',
       'src/app.ts',
     ])('includes %s', (filename) => expect(include(filename)).toBe(true));
+  });
+});
+
+describe('createEjsRenderer', () => {
+  it('renders typical skuba placeholders', () => {
+    const input = {
+      name: '<%- packageName %>',
+      repository: {
+        url: 'git+https://github.com/<%- orgName %>/<%- repoName %>.git',
+      },
+    };
+
+    const templateData = {
+      orgName: 'seek-oss',
+      packageName: 'seek-koala',
+      repoName: 'koala',
+    };
+
+    const render = createEjsRenderer(templateData);
+
+    const output = render(JSON.stringify(input));
+
+    expect(JSON.parse(output)).toEqual({
+      name: 'seek-koala',
+      repository: {
+        url: 'git+https://github.com/seek-oss/koala.git',
+      },
+    });
+  });
+});
+
+describe('createStringReplacer', () => {
+  it('replaces multiple instances of a global pattern', () => {
+    const input = 'red green blue red green blue red green';
+
+    const replace = createStringReplacer([
+      {
+        input: new RegExp('green', 'g'),
+        output: 'yellow',
+      },
+    ]);
+
+    const output = replace(input);
+
+    expect(output).toBe('red yellow blue red yellow blue red yellow');
+  });
+
+  it('runs through multiple patterns', () => {
+    const input = 'red green blue';
+
+    const replace = createStringReplacer([
+      {
+        input: new RegExp('red', 'g'),
+        output: 'cyan',
+      },
+      {
+        input: new RegExp('green', 'g'),
+        output: 'magenta',
+      },
+      {
+        input: new RegExp('blue', 'g'),
+        output: 'yellow',
+      },
+    ]);
+
+    const output = replace(input);
+
+    expect(output).toBe('cyan magenta yellow');
   });
 });


### PR DESCRIPTION
The intent here is to support naive string replacements, which could be used to e.g. replace all instances of `@seek/skuba` with plain `skuba`.