### PR TITLE
Fix `build-package` naming under help

### DIFF
--- a/.changeset/dull-oranges-sparkle.md
+++ b/.changeset/dull-oranges-sparkle.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**help:** Show `build-package` correctly

--- a/src/skuba.ts
+++ b/src/skuba.ts
@@ -3,7 +3,7 @@
 import path from 'path';
 
 import { parseArgs } from './utils/args';
-import { COMMAND_DIR, COMMAND_SET } from './utils/command';
+import { COMMAND_DIR, COMMAND_SET, commandToModule } from './utils/command';
 import { handleCliError } from './utils/error';
 import { showHelp } from './utils/help';
 import { log } from './utils/logging';
@@ -11,23 +11,28 @@ import { showLogo } from './utils/logo';
 import { hasProp } from './utils/validation';
 
 const skuba = async () => {
-  const { command } = parseArgs(process.argv);
+  const { commandName } = parseArgs(process.argv);
 
-  if (COMMAND_SET.has(command)) {
+  if (COMMAND_SET.has(commandName)) {
+    const moduleName = commandToModule(commandName);
+
     /* eslint-disable @typescript-eslint/no-var-requires */
-    const commandModule = require(path.join(COMMAND_DIR, command)) as unknown;
+    const commandModule = require(path.join(
+      COMMAND_DIR,
+      moduleName,
+    )) as unknown;
 
-    if (!hasProp(commandModule, command)) {
-      log.err(log.bold(command), "couldn't run! Please submit an issue.");
+    if (!hasProp(commandModule, moduleName)) {
+      log.err(log.bold(commandName), "couldn't run! Please submit an issue.");
       process.exit(1);
     }
 
-    const run = commandModule[command] as () => Promise<unknown>;
+    const run = commandModule[moduleName] as () => Promise<unknown>;
 
     return run();
   }
 
-  log.err(log.bold(command), 'is not recognised as a command.');
+  log.err(log.bold(commandName), 'is not recognised as a command.');
   await showLogo();
   showHelp();
 

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -10,7 +10,7 @@ describe('parseArgs', () => {
     ];
 
     expect(parseArgs(argv)).toStrictEqual({
-      command: 'start',
+      commandName: 'start',
       args: ['--xyz'],
     });
   });
@@ -23,7 +23,7 @@ describe('parseArgs', () => {
     ];
 
     expect(parseArgs(argv)).toStrictEqual({
-      command: 'start',
+      commandName: 'start',
       args: [],
     });
   });
@@ -37,7 +37,7 @@ describe('parseArgs', () => {
     ];
 
     expect(parseArgs(argv)).toStrictEqual({
-      command: 'start',
+      commandName: 'start',
       args: ['--xyz'],
     });
   });
@@ -50,7 +50,7 @@ describe('parseArgs', () => {
     ];
 
     expect(parseArgs(argv)).toStrictEqual({
-      command: 'start',
+      commandName: 'start',
       args: [],
     });
   });

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -22,10 +22,10 @@ export const parseArgs = (args = process.argv) => {
 
   const rawCommand = (args[skubaIdx + 1] ?? 'help').toLocaleLowerCase();
 
-  const command = COMMAND_ALIASES[rawCommand] ?? rawCommand;
+  const commandName = COMMAND_ALIASES[rawCommand] ?? rawCommand;
 
   const payload = {
-    command,
+    commandName,
     args: args.slice(skubaIdx + 2),
   };
 

--- a/src/utils/command.test.ts
+++ b/src/utils/command.test.ts
@@ -1,0 +1,9 @@
+import { commandToModule } from './command';
+
+describe('commandToModule', () => {
+  it('handles one-word command', () =>
+    expect(commandToModule('build')).toBe('build'));
+
+  it('handles hyphened command', () =>
+    expect(commandToModule('build-package')).toBe('buildPackage'));
+});

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -7,14 +7,13 @@ export const COMMAND_ALIASES: Record<string, Command> = {
   '--help': 'help',
   '-v': 'version',
   '--version': 'version',
-  'build-package': 'buildPackage',
 };
 
 export const COMMAND_DIR = path.join(__dirname, '..', 'cli');
 
 export const COMMAND_LIST = [
   'build',
-  'buildPackage',
+  'build-package',
   'configure',
   'format',
   'help',
@@ -27,3 +26,13 @@ export const COMMAND_LIST = [
 ] as const;
 
 export const COMMAND_SET = new Set<string>(COMMAND_LIST);
+
+export const commandToModule = (command: Command): string =>
+  command
+    .split('-')
+    .map((segment, index) =>
+      index === 0
+        ? segment
+        : `${segment[0].toLocaleUpperCase()}${segment.slice(1)}`,
+    )
+    .join('');


### PR DESCRIPTION
This was hacked around because the command makes sense in kebab-case, but we use camelCase for modules and exports. Previously `buildPackage` was displayed as the canonical command name when you ran `skuba help`, but it wouldn't actually work. This makes `build-package` the actual command and introduces a simple kebab-case -> camelCase conversion that could be used for future commands.