### PR TITLE
Redact Authorization from logs

### DIFF
--- a/.changeset/cold-ghosts-poke.md
+++ b/.changeset/cold-ghosts-poke.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Redact `Authorization` headers in logs

--- a/template/koa-rest-api/src/framework/logging.ts
+++ b/template/koa-rest-api/src/framework/logging.ts
@@ -20,9 +20,12 @@ export const rootLogger = pino({
   redact: {
     censor: '🤿 REDACTED 🚩',
     paths: [
+      'err.config.headers.Authorization',
       'err.config.headers.authorization',
       'err.request.headers.authorization',
+      'err.request.config.headers.Authorization',
       'err.request.config.headers.authorization',
+      'err.response.config.headers.Authorization',
       'err.response.config.headers.authorization',
       'err.response.headers.authorization',
       'err.response.request.headers.authorization',

--- a/template/lambda-sqs-worker/src/framework/handler.test.ts
+++ b/template/lambda-sqs-worker/src/framework/handler.test.ts
@@ -38,7 +38,7 @@ describe('createHandler', () => {
 
     const handler = createHandler(() => Promise.reject(err));
 
-    await expect(handler(input, ctx)).rejects.toThrow(err);
+    await expect(handler(input, ctx)).rejects.toThrow('invoke error');
 
     expect(contextLogger.error.mock.calls).toEqual([[{ err }, 'request']]);
 
@@ -52,7 +52,7 @@ describe('createHandler', () => {
       throw err;
     });
 
-    await expect(handler(input, ctx)).rejects.toThrow(err);
+    await expect(handler(input, ctx)).rejects.toThrow('invoke error');
 
     expect(contextLogger.error.mock.calls).toEqual([[{ err }, 'request']]);
 

--- a/template/lambda-sqs-worker/src/framework/handler.ts
+++ b/template/lambda-sqs-worker/src/framework/handler.ts
@@ -20,6 +20,6 @@ export const createHandler = <Event, Output = unknown>(
 
       logger.error({ err }, 'request');
 
-      throw err;
+      throw new Error('invoke error');
     }
   };

--- a/template/lambda-sqs-worker/src/framework/logging.ts
+++ b/template/lambda-sqs-worker/src/framework/logging.ts
@@ -21,9 +21,12 @@ export const rootLogger = pino({
   redact: {
     censor: '🤿 REDACTED 🚩',
     paths: [
+      'err.config.headers.Authorization',
       'err.config.headers.authorization',
       'err.request.headers.authorization',
+      'err.request.config.headers.Authorization',
       'err.request.config.headers.authorization',
+      'err.response.config.headers.Authorization',
       'err.response.config.headers.authorization',
       'err.response.headers.authorization',
       'err.response.request.headers.authorization',


### PR DESCRIPTION
Headers are often represented with this capitalisation.

At some point we may have to bite the bullet and ratify aggressive redaction in a package that wraps Pino (e.g. `logger-js`).