### PR TITLE
fix: Ignore git folder

### DIFF
--- a/.changeset/tame-mangos-lie.md
+++ b/.changeset/tame-mangos-lie.md
@@ -1,0 +1,6 @@
+---
+'skuba': patch
+---
+
+Ignore the .git folder when copying into the Docker container.
+This should decrease build times.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git/
 .idea/
 .serverless/
 .vscode/

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -4,6 +4,7 @@ exports[`diffFiles works from scratch 1`] = `
 Object {
   ".dockerignore": Object {
     "data": "# managed by skuba
+.git/
 .idea/
 .serverless/
 .vscode/

--- a/template/base/_.dockerignore
+++ b/template/base/_.dockerignore
@@ -1,4 +1,5 @@
 # managed by skuba
+.git/
 .idea/
 .serverless/
 .vscode/


### PR DESCRIPTION
The `.git` folder should not be copied into the docker container.
This should improve build speed.