### PR TITLE
fix: Ignore gantry folder

### DIFF
--- a/.changeset/happy-seals-push.md
+++ b/.changeset/happy-seals-push.md
@@ -1,0 +1,6 @@
+---
+'skuba': patch
+---
+
+Ignore the .gantry folder when copying into the Docker container.
+This should decrease build times.

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -4,6 +4,7 @@ exports[`diffFiles works from scratch 1`] = `
 Object {
   ".dockerignore": Object {
     "data": "# managed by skuba
+.gantry/
 .git/
 .idea/
 .serverless/

--- a/template/base/_.dockerignore
+++ b/template/base/_.dockerignore
@@ -1,4 +1,5 @@
 # managed by skuba
+.gantry/
 .git/
 .idea/
 .serverless/


### PR DESCRIPTION
Ignore the .gantry folder when copying into the Docker container.
This should decrease build times.