### PR TITLE
Store project type to tailor configuration

### DIFF
--- a/.changeset/famous-carpets-matter.md
+++ b/.changeset/famous-carpets-matter.md
@@ -1,0 +1,8 @@
+---
+'skuba': minor
+---
+
+**configure:** Support migration from `seek-module-toolkit`
+
+`seek-module-toolkit` users can now install `skuba` and run `skuba configure` to migrate their configuration.
+Care should be taken around the [change in build directories](https://github.com/seek-oss/skuba/blob/master/docs/migrating-from-seek-module-toolkit.md#building).

--- a/src/cli/configure/analyseConfiguration.ts
+++ b/src/cli/configure/analyseConfiguration.ts
@@ -3,12 +3,14 @@ import path from 'path';
 import fs from 'fs-extra';
 
 import { log } from '../../utils/logging';
+import { ProjectType } from '../../utils/manifest';
 
 import { diffFiles } from './analysis/project';
 
 interface Props {
   destinationRoot: string;
   entryPoint: string;
+  type: ProjectType;
 }
 
 export const analyseConfiguration = async (

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -136,6 +136,7 @@ module.exports = {
   \\"skuba\\": {
     \\"entryPoint\\": \\"src/app.ts\\",
     \\"template\\": null,
+    \\"type\\": \\"application\\",
     \\"version\\": \\"0.0.0-semantically-released\\"
   }
 }

--- a/src/cli/configure/getEntryPoint.ts
+++ b/src/cli/configure/getEntryPoint.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import { Input } from 'enquirer';
 import { NormalizedReadResult } from 'read-pkg-up';
 
+import { ProjectType } from '../../utils/manifest';
 import { TemplateConfig } from '../../utils/template';
 import { hasStringProp } from '../../utils/validation';
 
@@ -13,11 +14,13 @@ interface Props {
   destinationRoot: string;
   manifest: NormalizedReadResult;
   templateConfig: TemplateConfig;
+  type: ProjectType;
 }
 export const getEntryPoint = ({
   destinationRoot,
   manifest,
   templateConfig,
+  type,
 }: Props) => {
   if (hasStringProp(manifest.packageJson.skuba, 'entryPoint')) {
     return manifest.packageJson.skuba.entryPoint;
@@ -28,7 +31,7 @@ export const getEntryPoint = ({
   }
 
   const entryPointPrompt = new Input({
-    initial: 'src/app.ts',
+    initial: type === 'package' ? 'src/index.ts' : 'src/app.ts',
     message: 'Entry point:',
     name: 'entryPoint',
     result: (value) => (value.endsWith('.ts') ? value : `${value}.ts`),

--- a/src/cli/configure/getProjectType.ts
+++ b/src/cli/configure/getProjectType.ts
@@ -1,0 +1,42 @@
+import { Select } from 'enquirer';
+import { NormalizedReadResult } from 'read-pkg-up';
+
+import { PROJECT_TYPES, ProjectType } from '../../utils/manifest';
+import { TemplateConfig } from '../../utils/template';
+import { hasProp } from '../../utils/validation';
+
+interface Props {
+  manifest: NormalizedReadResult;
+  templateConfig: TemplateConfig;
+}
+
+export const getProjectType = async ({
+  manifest,
+  templateConfig,
+}: Props): Promise<ProjectType> => {
+  if (
+    hasProp(manifest.packageJson.skuba, 'type') &&
+    ProjectType.guard(manifest.packageJson.skuba.type)
+  ) {
+    return manifest.packageJson.skuba.type;
+  }
+
+  if (typeof templateConfig.type !== 'undefined') {
+    return templateConfig.type;
+  }
+
+  const initial: ProjectType =
+    manifest.packageJson.devDependencies?.['@seek/seek-module-toolkit'] ||
+    manifest.packageJson.files
+      ? 'package'
+      : 'application';
+
+  const projectTypePrompt = new Select({
+    choices: PROJECT_TYPES,
+    message: 'Project type:',
+    name: 'projectType',
+    initial,
+  });
+
+  return projectTypePrompt.run();
+};

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -14,6 +14,7 @@ import { auditWorkingTree } from './analysis/git';
 import { getDestinationManifest } from './analysis/package';
 import { ensureTemplateCompletion } from './ensureTemplateCompletion';
 import { getEntryPoint } from './getEntryPoint';
+import { getProjectType } from './getProjectType';
 
 const shouldApply = async (name: string) => {
   const prompt = new Select({
@@ -54,10 +55,16 @@ export const configure = async () => {
     manifest,
   });
 
+  const type = await getProjectType({
+    manifest,
+    templateConfig,
+  });
+
   const entryPoint = await getEntryPoint({
     destinationRoot,
     manifest,
     templateConfig,
+    type,
   });
 
   const fixDependencies = await analyseDependencies({
@@ -77,6 +84,7 @@ export const configure = async () => {
   const fixConfiguration = await analyseConfiguration({
     destinationRoot,
     entryPoint,
+    type,
   });
 
   if (fixConfiguration) {

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -1,9 +1,10 @@
 import { getSkubaVersion } from '../../../utils/version';
 import { createDependencyFilter, withPackage } from '../processing/package';
 import { merge } from '../processing/record';
-import { Module } from '../types';
+import { Module, Options } from '../types';
 
 const BUNDLED_DEPENDENCIES = [
+  '@seek/seek-module-toolkit',
   '@types/jest',
   'concurrently',
   'eslint',
@@ -17,6 +18,12 @@ const BUNDLED_DEPENDENCIES = [
   'typescript',
 ] as const;
 
+const DEFAULT_PACKAGE_FILES = [
+  'lib*/**/*.d.ts',
+  'lib*/**/*.js',
+  'lib*/**/*.js.map',
+];
+
 const filterDevDependencies = createDependencyFilter(
   BUNDLED_DEPENDENCIES,
   'devDependencies',
@@ -24,27 +31,27 @@ const filterDevDependencies = createDependencyFilter(
 
 export const packageModule = async ({
   entryPoint,
-}: {
-  entryPoint: string;
-}): Promise<Module> => {
+  type,
+}: Options): Promise<Module> => {
   const version = await getSkubaVersion();
 
   const initialData = {
     devDependencies: {
       skuba: version,
     },
-    license: 'UNLICENSED',
-    private: true,
+    private: type !== 'package',
+
     scripts: {
-      build: 'skuba build',
+      build: type === 'package' ? 'skuba build-package' : 'skuba build',
       format: 'skuba format',
       lint: 'skuba lint',
-      start: 'ENVIRONMENT=local skuba start',
+      ...(type === 'package' ? {} : { start: 'ENVIRONMENT=local skuba start' }),
       test: 'skuba test',
     },
     skuba: {
       entryPoint,
       template: null,
+      type,
       version,
     },
   };
@@ -55,6 +62,7 @@ export const packageModule = async ({
     },
     skuba: {
       entryPoint,
+      type,
       version,
     },
   };
@@ -65,6 +73,55 @@ export const packageModule = async ({
         inputData,
         'skuba' in inputData ? recurringData : initialData,
       );
+
+      outputData.license = outputData.license ?? 'UNLICENSED';
+
+      if (type === 'package') {
+        outputData.files = (
+          outputData.files ?? DEFAULT_PACKAGE_FILES
+        ).flatMap((filePattern) =>
+          filePattern === 'lib' ? DEFAULT_PACKAGE_FILES : [filePattern],
+        );
+
+        outputData.version =
+          outputData.version ?? '0.0.0-semantically-released';
+
+        outputData.scripts = outputData.scripts ?? {};
+
+        // User-defined pre- and post-scripts are confusing and dropped by e.g.
+        // Yarn 2.
+        outputData.scripts.release = [
+          outputData.scripts.prepublish,
+          outputData.scripts.prerelease,
+          outputData.scripts.release ?? 'skuba release',
+        ]
+          .filter((script): script is string => typeof script === 'string')
+          .map((script) =>
+            script
+              .replace(/^smt build$/, 'yarn build')
+              .replace(/^smt /, 'skuba ')
+              .trim(),
+          )
+          .filter(Boolean)
+          .join(' && ');
+
+        // Align with the required syntax for package.json#/paths
+        if (outputData.scripts.build === 'skuba build-package') {
+          outputData.main = './lib-commonjs/index.js';
+          outputData.module = './lib-es2015/index.js';
+          outputData.types = './lib-types/index.d.ts';
+        } else {
+          outputData.main = './lib/index.js';
+          outputData.module = './lib/index.js';
+          outputData.types = './lib/index.d.ts';
+        }
+
+        delete outputData.scripts.commit;
+        delete outputData.scripts['format:check'];
+        delete outputData.scripts.prepublish;
+        delete outputData.scripts.prerelease;
+        delete outputData.typings;
+      }
 
       return filterDevDependencies(outputData);
     }),

--- a/src/cli/configure/modules/renovate.test.ts
+++ b/src/cli/configure/modules/renovate.test.ts
@@ -1,4 +1,8 @@
-import { defaultOpts, executeModule } from '../testing/module';
+import {
+  defaultOpts,
+  defaultPackageOpts,
+  executeModule,
+} from '../testing/module';
 
 import { renovateModule } from './renovate';
 
@@ -16,6 +20,25 @@ describe('renovateModule', () => {
       'seek-oss/rynovate',
     );
     expect(outputFiles['package.json']).toContain('"private": true');
+  });
+
+  it('makes packages publishable', async () => {
+    const inputFiles = {
+      'package.json': JSON.stringify({
+        private: true,
+      }),
+    };
+
+    const outputFiles = await executeModule(
+      renovateModule,
+      inputFiles,
+      defaultPackageOpts,
+    );
+
+    expect(outputFiles['.github/renovate.json5']).toContain(
+      'seek-oss/rynovate',
+    );
+    expect(outputFiles['package.json']).toContain('"private": false');
   });
 
   it('deletes rogue configs', async () => {

--- a/src/cli/configure/modules/renovate.ts
+++ b/src/cli/configure/modules/renovate.ts
@@ -2,7 +2,7 @@ import { readBaseTemplateFile } from '../../../utils/template';
 import { loadFiles } from '../processing/loadFiles';
 import { withPackage } from '../processing/package';
 import { getFirstDefined } from '../processing/record';
-import { Module } from '../types';
+import { Module, Options } from '../types';
 
 const OTHER_CONFIG_FILENAMES = [
   '.github/renovate.json',
@@ -12,7 +12,7 @@ const OTHER_CONFIG_FILENAMES = [
   'renovate.json5',
 ];
 
-export const renovateModule = async (): Promise<Module> => {
+export const renovateModule = async ({ type }: Options): Promise<Module> => {
   const configFile = await readBaseTemplateFile('.github/renovate.json5');
 
   return {
@@ -42,7 +42,7 @@ export const renovateModule = async (): Promise<Module> => {
      */
     'package.json': withPackage(({ private: _, renovate, ...data }) => ({
       ...data,
-      private: true,
+      private: type !== 'package',
     })),
   };
 };

--- a/src/cli/configure/modules/skubaDive.test.ts
+++ b/src/cli/configure/modules/skubaDive.test.ts
@@ -1,5 +1,10 @@
 import { parsePackage } from '../processing/package';
-import { assertDefined, defaultOpts, executeModule } from '../testing/module';
+import {
+  assertDefined,
+  defaultOpts,
+  defaultPackageOpts,
+  executeModule,
+} from '../testing/module';
 
 import { skubaDiveModule } from './skubaDive';
 
@@ -24,6 +29,30 @@ describe('skubaDiveModule', () => {
 
     assertDefined(outputData);
     expect(outputData.dependencies).toHaveProperty('skuba-dive');
+  });
+
+  it('disables itself on packages', async () => {
+    const inputFiles = {
+      'package.json': JSON.stringify({
+        dependencies: {},
+      }),
+      'src/app.ts': 'console.log();\n',
+      'src/index.ts': 'console.log();\n',
+    };
+
+    const outputFiles = await executeModule(
+      skubaDiveModule,
+      inputFiles,
+      defaultPackageOpts,
+    );
+
+    expect(outputFiles['src/app.ts']).toBe(inputFiles['src/app.ts']);
+    expect(outputFiles['src/index.ts']).toBe(inputFiles['src/index.ts']);
+
+    const outputData = parsePackage(outputFiles['package.json']);
+
+    assertDefined(outputData);
+    expect(outputData.dependencies).not.toHaveProperty('skuba-dive');
   });
 
   it('registers entry point directly under src', async () => {

--- a/src/cli/configure/modules/skubaDive.ts
+++ b/src/cli/configure/modules/skubaDive.ts
@@ -6,7 +6,7 @@ import { prependImport, stripImports } from '../processing/javascript';
 import { loadFiles } from '../processing/loadFiles';
 import { createDependencyFilter, withPackage } from '../processing/package';
 import { merge } from '../processing/record';
-import { Module } from '../types';
+import { Module, Options } from '../types';
 
 const BUNDLED_DEPENDENCIES = ['module-alias', 'source-map-support'] as const;
 
@@ -19,9 +19,13 @@ const filterDependencies = createDependencyFilter(
 
 export const skubaDiveModule = async ({
   entryPoint,
-}: {
-  entryPoint: string;
-}): Promise<Module> => {
+  type,
+}: Options): Promise<Module> => {
+  // skuba-dive is a runtime component; it's not appropriate for packages
+  if (type === 'package') {
+    return {};
+  }
+
   const skubaDiveVersion = await latestVersion('skuba-dive');
 
   const skubaDiveData = {

--- a/src/cli/configure/modules/tsconfig.test.ts
+++ b/src/cli/configure/modules/tsconfig.test.ts
@@ -1,5 +1,10 @@
 import { parseObject } from '../processing/json';
-import { assertDefined, defaultOpts, executeModule } from '../testing/module';
+import {
+  assertDefined,
+  defaultOpts,
+  defaultPackageOpts,
+  executeModule,
+} from '../testing/module';
 import { TsConfigJson } from '../types';
 
 import { tsconfigModule } from './tsconfig';
@@ -18,6 +23,37 @@ describe('tsconfigModule', () => {
     expect(outputFiles['tsconfig.json']).toContain(
       'skuba/config/tsconfig.json',
     );
+
+    const outputData = parseObject(
+      outputFiles['tsconfig.json'],
+    ) as TsConfigJson;
+
+    assertDefined(outputData);
+    expect(outputData.compilerOptions!.baseUrl).toBe('.');
+    expect(outputData.compilerOptions!.paths).toEqual({ src: ['src'] });
+  });
+
+  it('disables module aliasing for packages', async () => {
+    const inputFiles = {};
+
+    const outputFiles = await executeModule(
+      tsconfigModule,
+      inputFiles,
+      defaultPackageOpts,
+    );
+
+    expect(outputFiles['tsconfig.build.json']).toContain('./tsconfig.json');
+    expect(outputFiles['tsconfig.json']).toContain(
+      'skuba/config/tsconfig.json',
+    );
+
+    const outputData = parseObject(
+      outputFiles['tsconfig.json'],
+    ) as TsConfigJson;
+
+    assertDefined(outputData);
+    expect(outputData.compilerOptions!.baseUrl).toBeUndefined();
+    expect(outputData.compilerOptions!.paths).toBeUndefined();
   });
 
   it('augments existing config', async () => {

--- a/src/cli/configure/modules/tsconfig.ts
+++ b/src/cli/configure/modules/tsconfig.ts
@@ -1,11 +1,11 @@
 import { readBaseTemplateFile } from '../../../utils/template';
-import { hasProp, hasStringProp } from '../../../utils/validation';
+import { hasProp, hasStringProp, isObject } from '../../../utils/validation';
 import { formatObject, parseObject } from '../processing/json';
 import { loadFiles } from '../processing/loadFiles';
 import { merge } from '../processing/record';
-import { Module } from '../types';
+import { Module, Options } from '../types';
 
-export const tsconfigModule = async (): Promise<Module> => {
+export const tsconfigModule = async ({ type }: Options): Promise<Module> => {
   const [buildFile, baseFile] = await Promise.all([
     readBaseTemplateFile('tsconfig.build.json'),
     readBaseTemplateFile('tsconfig.json'),
@@ -19,6 +19,16 @@ export const tsconfigModule = async (): Promise<Module> => {
     hasProp(baseData.compilerOptions, 'target')
   ) {
     delete baseData.compilerOptions.target;
+  }
+
+  // packages should not use module aliases
+  if (
+    type === 'package' &&
+    hasProp(baseData, 'compilerOptions') &&
+    isObject(baseData.compilerOptions)
+  ) {
+    delete baseData.compilerOptions.baseUrl;
+    delete baseData.compilerOptions.paths;
   }
 
   return {

--- a/src/cli/configure/testing/module.ts
+++ b/src/cli/configure/testing/module.ts
@@ -7,6 +7,13 @@ export function assertDefined<T>(value?: T): asserts value is T {
 export const defaultOpts: Options = {
   destinationRoot: '/tmp',
   entryPoint: 'src/app.ts',
+  type: 'application',
+};
+
+export const defaultPackageOpts: Options = {
+  destinationRoot: '/tmp',
+  entryPoint: 'src/index.ts',
+  type: 'package',
 };
 
 export const executeModule = async (

--- a/src/cli/configure/types.ts
+++ b/src/cli/configure/types.ts
@@ -1,5 +1,7 @@
 export { PackageJson, TsConfigJson } from 'type-fest';
 
+import { ProjectType } from '../../utils/manifest';
+
 export interface DependencySet {
   dependencies: Record<string, string>;
   devDependencies: Record<string, string>;
@@ -28,4 +30,5 @@ export type Module = Record<string, FileProcessor>;
 export interface Options {
   destinationRoot: string;
   entryPoint: string;
+  type: ProjectType;
 }

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -20,7 +20,7 @@ import {
   SHOULD_CONTINUE_PROMPT,
   TEMPLATE_PROMPT,
 } from './prompts';
-import { InitConfig } from './types';
+import { InitConfig, InitConfigInput } from './types';
 
 export const runForm = <T = Record<string, string>>(props: {
   choices: Readonly<FormChoice[]>;
@@ -132,6 +132,7 @@ export const getTemplateConfig = (dir: string): TemplateConfig => {
       return {
         entryPoint: undefined,
         fields: [],
+        type: undefined,
       };
     }
 
@@ -158,7 +159,7 @@ export const configureFromPrompt = async (): Promise<InitConfig> => {
 
   await cloneTemplate(templateName, destinationDir);
 
-  const { entryPoint, fields } = getTemplateConfig(
+  const { entryPoint, fields, type } = getTemplateConfig(
     path.join(process.cwd(), destinationDir),
   );
 
@@ -169,6 +170,7 @@ export const configureFromPrompt = async (): Promise<InitConfig> => {
       templateComplete: true,
       templateData: baseAnswers,
       templateName,
+      type,
     };
   }
 
@@ -188,6 +190,7 @@ export const configureFromPrompt = async (): Promise<InitConfig> => {
       templateComplete: true,
       templateData: { ...baseAnswers, ...customAnswers },
       templateName,
+      type,
     };
   }
 
@@ -202,6 +205,7 @@ export const configureFromPrompt = async (): Promise<InitConfig> => {
     templateComplete: false,
     templateData: { ...baseAnswers, ...customAnswers },
     templateName,
+    type,
   };
 };
 
@@ -228,7 +232,7 @@ const configureFromPipe = async (): Promise<InitConfig> => {
     process.exit(1);
   }
 
-  const result = InitConfig.validate(value);
+  const result = InitConfigInput.validate(value);
 
   if (!result.success) {
     log.err('Invalid data from stdin:');
@@ -251,7 +255,7 @@ const configureFromPipe = async (): Promise<InitConfig> => {
 
   await cloneTemplate(templateName, destinationDir);
 
-  const { entryPoint, fields } = getTemplateConfig(
+  const { entryPoint, fields, type } = getTemplateConfig(
     path.join(process.cwd(), destinationDir),
   );
 
@@ -263,6 +267,7 @@ const configureFromPipe = async (): Promise<InitConfig> => {
         ...templateData,
         ...generatePlaceholders(fields),
       },
+      type,
     };
   }
 
@@ -282,6 +287,7 @@ const configureFromPipe = async (): Promise<InitConfig> => {
   return {
     ...result.value,
     entryPoint,
+    type,
   };
 };
 

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -28,6 +28,7 @@ export const init = async () => {
     templateComplete,
     templateData,
     templateName,
+    type,
   } = await getConfig();
 
   const include = await createInclusionFilter([
@@ -61,6 +62,7 @@ export const init = async () => {
       cwd: destinationDir,
       entryPoint,
       template: templateName,
+      type,
       version: skubaVersion,
     }),
   ]);

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -2,11 +2,10 @@
 
 import * as t from 'runtypes';
 
-export type InitConfig = t.Static<typeof InitConfig>;
+import { ProjectType } from '../../utils/manifest';
 
-export const InitConfig = t.Record({
+const INIT_CONFIG_INPUT_FIELDS = {
   destinationDir: t.String,
-  entryPoint: t.String.Or(t.Undefined),
   templateComplete: t.Boolean,
   templateData: t
     .Record({
@@ -16,4 +15,17 @@ export const InitConfig = t.Record({
     })
     .And(t.Dictionary(t.String, 'string')),
   templateName: t.String,
+};
+
+export type InitConfigInput = t.Static<typeof InitConfigInput>;
+
+export const InitConfigInput = t.Record(INIT_CONFIG_INPUT_FIELDS);
+
+export type InitConfig = t.Static<typeof InitConfig>;
+
+export const InitConfig = t.Record({
+  ...INIT_CONFIG_INPUT_FIELDS,
+
+  entryPoint: t.String.Or(t.Undefined),
+  type: ProjectType.Or(t.Undefined),
 });

--- a/src/cli/init/writePackageJson.test.ts
+++ b/src/cli/init/writePackageJson.test.ts
@@ -28,6 +28,7 @@ describe('writePackageJson', () => {
         cwd: '/',
         entryPoint: 'src/app.ts',
         template: 'hello-world',
+        type: 'package',
         version: '0.0.1',
       }),
     ).resolves.toBeUndefined();
@@ -40,6 +41,7 @@ describe('writePackageJson', () => {
         \\"skuba\\": {
           \\"entryPoint\\": \\"src/app.ts\\",
           \\"template\\": \\"hello-world\\",
+          \\"type\\": \\"package\\",
           \\"version\\": \\"0.0.1\\"
         }
       }

--- a/src/cli/init/writePackageJson.ts
+++ b/src/cli/init/writePackageJson.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 
+import { ProjectType } from '../../utils/manifest';
 import { getDestinationManifest } from '../configure/analysis/package';
 import { formatPackage } from '../configure/processing/package';
 
@@ -7,6 +8,7 @@ interface WritePackageJsonProps {
   cwd: string;
   entryPoint?: string;
   template: string;
+  type?: ProjectType;
   version: string;
 }
 
@@ -17,6 +19,7 @@ export const writePackageJson = async ({
   cwd,
   entryPoint,
   template,
+  type,
   version,
 }: WritePackageJsonProps) => {
   const manifest = await getDestinationManifest({ cwd });
@@ -24,6 +27,7 @@ export const writePackageJson = async ({
   manifest.packageJson.skuba = {
     entryPoint: entryPoint ?? null,
     template,
+    type,
     version,
   };
 

--- a/src/enquirer.d.ts
+++ b/src/enquirer.d.ts
@@ -51,6 +51,7 @@ declare module 'enquirer' {
       name: string;
       message: string;
       choices: ReadonlyArray<T>;
+      initial?: T;
     });
 
     run(): Promise<T>;

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -1,4 +1,16 @@
+/* eslint-disable new-cap */
+
 import readPkgUp, { NormalizedPackageJson } from 'read-pkg-up';
+import * as t from 'runtypes';
+
+export type ProjectType = t.Static<typeof ProjectType>;
+
+export const ProjectType = t.Union(
+  t.Literal('application'),
+  t.Literal('package'),
+);
+
+export const PROJECT_TYPES = ['application', 'package'] as const;
 
 interface PackageJson extends NormalizedPackageJson {
   skuba?: {

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -5,6 +5,8 @@ import path from 'path';
 import fs from 'fs-extra';
 import * as t from 'runtypes';
 
+import { ProjectType } from './manifest';
+
 export type TemplateConfig = t.Static<typeof TemplateConfig>;
 
 export const TemplateConfig = t.Record({
@@ -17,6 +19,7 @@ export const TemplateConfig = t.Record({
       validate: t.Function.Or(t.Undefined),
     }),
   ),
+  type: ProjectType.Or(t.Undefined),
 });
 
 export const TEMPLATE_CONFIG_FILENAME = 'skuba.template.js';

--- a/template/greeter/skuba.template.js
+++ b/template/greeter/skuba.template.js
@@ -12,4 +12,5 @@ module.exports = {
       validate: (value) => /^.+:.+$/.test(value),
     },
   ],
+  type: 'application',
 };

--- a/template/koa-rest-api/skuba.template.js
+++ b/template/koa-rest-api/skuba.template.js
@@ -44,4 +44,5 @@ module.exports = {
       validate: (value) => /^\d{12}$/.test(value),
     },
   ],
+  type: 'application',
 };

--- a/template/lambda-sqs-worker/skuba.template.js
+++ b/template/lambda-sqs-worker/skuba.template.js
@@ -33,4 +33,5 @@ module.exports = {
       validate: (value) => /^.+:.+$/.test(value),
     },
   ],
+  type: 'application',
 };

--- a/template/private-npm-package/skuba.template.js
+++ b/template/private-npm-package/skuba.template.js
@@ -18,4 +18,5 @@ module.exports = {
       initial: 'This is my first module',
     },
   ],
+  type: 'package',
 };


### PR DESCRIPTION
This introduces a new `package.json#/skuba/type` field that is used by `skuba configure` to tailor logic based on whether we're dealing with an application or package. This could be extended in future to somehow enable a monorepo type, but it's probably too early to say.