### PR TITLE
Extract ESLint docs

### DIFF
--- a/docs/eslint.md
+++ b/docs/eslint.md
@@ -1,0 +1,50 @@
+# ESLint
+
+[ESLint] is _the_ JavaScript linter.
+You may be familiar with it from SEEK's frontend development toolkit,
+[sku].
+
+If you're coming from your own bespoke backend configuration or `seek-module-toolkit`,
+you may have been using [TSLint].
+[TSLint is deprecated and will go out of support by December 2020.]
+
+Our ESLint configuration introduces stricter rules around unsafe type usage.
+Here are some tips for making the move.
+
+[eslint]: https://eslint.org/
+[eslint guide]: ./eslint.md
+[sku]: https://github.com/seek-oss/sku
+[tslint]: https://palantir.github.io/tslint/
+[tslint is deprecated and will go out of support by december 2020.]: https://github.com/palantir/tslint/issues/4534
+
+## Avoid `any` and `object`
+
+Consider the following alternatives:
+
+- Use `unknown` for a value whose type is truly unknown. This is a type-safe alternative to `any` that the TypeScript ecosystem is moving towards.
+
+  ```diff
+  - const data = JSON.parse(str);
+  + const data = JSON.parse(str) as unknown;
+  ```
+
+- Prove the value has a specific type using a [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) or runtime validation library.
+
+  ```diff
+  - const safeData = inputData as any;
+  + const safeData = RuntimeValidator.check(inputData);
+  ```
+
+- Use `Record<PropertyKey, unknown>` to indicate an object with unknown properties.
+
+  ```diff
+  - const isObject = (data: unknown): data is object => { ... };
+  + const isObject = (data: unknown): data is Record<PropertyKey, unknown> => { ... };
+  ```
+
+- Disable the specific ESLint rule for the problematic line.
+
+  ```typescript
+  /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
+  const takeAnyBody = ctx.request.body;
+  ```

--- a/docs/migrating-from-seek-module-toolkit.md
+++ b/docs/migrating-from-seek-module-toolkit.md
@@ -61,49 +61,15 @@ smt format:check → skuba lint
 smt lint → skuba lint
 ```
 
-`seek-module-toolkit` retained support for [TSLint] configurations.
+`seek-module-toolkit <= 4` retained support for [TSLint] configurations.
 [TSLint is deprecated and will go out of support by December 2020.](https://github.com/palantir/tslint/issues/4534)
 
 `skuba` enforces [ESLint] and bundles a more modern set of linting rules.
-We've included some general tips below;
-if you're stuck on something, feel free to reach out in `#typescriptification`.
+See our [ESLint guide] for some tips, and reach out in `#typescriptification` if you get stuck on anything.
 
 [eslint]: https://eslint.org/
+[eslint guide]: ./eslint.md
 [tslint]: https://palantir.github.io/tslint/
-
-### Avoid `any` and `object`
-
-Our ESLint configuration introduces stricter rules around unsafe type usage.
-
-Consider the following alternatives:
-
-- Use `unknown` for a value whose type is truly unknown. This is a type-safe alternative to `any` that the TypeScript ecosystem is moving towards.
-
-  ```diff
-  - const data = JSON.parse(str);
-  + const data = JSON.parse(str) as unknown;
-  ```
-
-- Prove the value has a specific type using a [type guard](https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards) or runtime validation library.
-
-  ```diff
-  - const safeData = inputData as any;
-  + const safeData = RuntimeValidator.check(inputData);
-  ```
-
-- Use `Record<PropertyKey, unknown>` to indicate an object with unknown properties.
-
-  ```diff
-  - const isObject = (data: unknown): data is object => { ... };
-  + const isObject = (data: unknown): data is Record<PropertyKey, unknown> => { ... };
-  ```
-
-- Disable the specific ESLint rule for the problematic line.
-
-  ```typescript
-  /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
-  const takeAnyBody = ctx.request.body;
-  ```
 
 ## Committing and releasing
 

--- a/docs/migrating-from-seek-skuba.md
+++ b/docs/migrating-from-seek-skuba.md
@@ -7,8 +7,9 @@ If you haven't configured Renovate on your repository,
 reach out in `#github`.
 
 We've introduced some new linting rules via ESLint 7 + `typescript-eslint` 3.
-If you're stuck on something and the tips in the [`seek-module-toolkit` guide](./migrating-from-seek-module-toolkit.md#formatting-and-linting) aren't helping,
-reach out in `#typescriptification`.
+See our [ESLint guide] for some tips, and reach out in `#typescriptification` if you get stuck on anything.
+
+[eslint guide]: ./eslint.md
 
 ## 2. Switch out packages
 


### PR DESCRIPTION
Spoiler: we'll force a migration to ESLint in `seek-module-toolkit` so that the path from there to `skuba` is smoother.

I wish we had more documentation around the move but I'm hoping this can be community-contributed. I can't make much up off the top of my head.