### PR TITLE
Move skuba diving to appropriate step

### DIFF
--- a/.changeset/plenty-garlics-refuse.md
+++ b/.changeset/plenty-garlics-refuse.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Handle `skuba-dive` dependency upfront

--- a/src/cli/configure/analyseDependencies.ts
+++ b/src/cli/configure/analyseDependencies.ts
@@ -6,6 +6,7 @@ import { NormalizedReadResult } from 'read-pkg-up';
 
 import { TextProcessor, copyFiles } from '../../utils/copy';
 import { log } from '../../utils/logging';
+import { ProjectType } from '../../utils/manifest';
 import { getSkubaVersion } from '../../utils/version';
 
 import { diffDependencies } from './analysis/package';
@@ -55,12 +56,14 @@ interface Props {
   destinationRoot: string;
   include: (pathname: string) => boolean;
   manifest: NormalizedReadResult;
+  type: ProjectType;
 }
 
 export const analyseDependencies = async ({
   destinationRoot,
   include,
   manifest: { packageJson },
+  type,
 }: Props): Promise<undefined | (() => Promise<void>)> => {
   const input = {
     dependencies: packageJson.dependencies ?? {},
@@ -70,6 +73,7 @@ export const analyseDependencies = async ({
   const output = {
     dependencies: { ...input.dependencies },
     devDependencies: { ...input.devDependencies },
+    type,
   };
 
   const processors = Object.values(dependencyMutators).reduce<TextProcessor[]>(

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -118,9 +118,6 @@ module.exports = {
   },
   "package.json": Object {
     "data": "{
-  \\"dependencies\\": {
-    \\"skuba-dive\\": \\"0.0.1\\"
-  },
   \\"license\\": \\"UNLICENSED\\",
   \\"private\\": true,
   \\"scripts\\": {

--- a/src/cli/configure/analysis/project.test.ts
+++ b/src/cli/configure/analysis/project.test.ts
@@ -4,11 +4,6 @@ import { defaultOpts } from '../testing/module';
 import * as project from './project';
 import { diffFiles } from './project';
 
-jest.mock('latest-version', () => ({
-  __esModule: true,
-  default: () => Promise.resolve('0.0.1'),
-}));
-
 describe('diffFiles', () => {
   it('works from scratch', async () => {
     jest

--- a/src/cli/configure/dependencies/seekDatadogCustomMetrics.test.ts
+++ b/src/cli/configure/dependencies/seekDatadogCustomMetrics.test.ts
@@ -9,6 +9,7 @@ describe('seekDatadogCustomMetrics', () => {
       devDependencies: {
         'seek-datadog-custom-metrics': '1.0.0',
       },
+      type: 'application' as const,
     };
 
     const result = seekDatadogCustomMetrics(input);
@@ -21,6 +22,7 @@ describe('seekDatadogCustomMetrics', () => {
       devDependencies: {
         'seek-datadog-custom-metrics': '1.0.0',
       },
+      type: 'application',
     });
   });
 
@@ -32,6 +34,7 @@ describe('seekDatadogCustomMetrics', () => {
       devDependencies: {
         '@seek/node-datadog-custom-metrics': '1.0.0',
       },
+      type: 'application' as const,
     };
 
     const result = seekDatadogCustomMetrics(input);
@@ -44,6 +47,7 @@ describe('seekDatadogCustomMetrics', () => {
       devDependencies: {
         'seek-datadog-custom-metrics': '*',
       },
+      type: 'application',
     });
   });
 });

--- a/src/cli/configure/dependencies/seekKoala.test.ts
+++ b/src/cli/configure/dependencies/seekKoala.test.ts
@@ -9,6 +9,7 @@ describe('seekKoala', () => {
       devDependencies: {
         'seek-koala': '1.0.0',
       },
+      type: 'application' as const,
     };
 
     const result = seekKoala(input);
@@ -21,6 +22,7 @@ describe('seekKoala', () => {
       devDependencies: {
         'seek-koala': '1.0.0',
       },
+      type: 'application',
     });
   });
 
@@ -32,6 +34,7 @@ describe('seekKoala', () => {
       devDependencies: {
         '@seek/koala': '1.0.0',
       },
+      type: 'application' as const,
     };
 
     const result = seekKoala(input);
@@ -44,6 +47,7 @@ describe('seekKoala', () => {
       devDependencies: {
         'seek-koala': '*',
       },
+      type: 'application',
     });
   });
 });

--- a/src/cli/configure/dependencies/skuba.test.ts
+++ b/src/cli/configure/dependencies/skuba.test.ts
@@ -40,7 +40,7 @@ describe('skuba', () => {
       true,
     ],
   ])('%s', (_, input, expectReplacement = false) => {
-    const result = skuba(input);
+    const result = skuba({ ...input, type: 'application' });
 
     expect(result).toHaveLength(expectReplacement ? 1 : 0);
     expect(input).toEqual({

--- a/src/cli/configure/dependencies/skubaDeps.test.ts
+++ b/src/cli/configure/dependencies/skubaDeps.test.ts
@@ -11,6 +11,7 @@ describe('skubaDeps', () => {
         'pino-pretty': '0.0.1',
         typescript: '0.0.1',
       },
+      type: 'application' as const,
     };
 
     const result = skubaDeps(input);
@@ -23,6 +24,7 @@ describe('skubaDeps', () => {
       devDependencies: {
         'pino-pretty': '0.0.1',
       },
+      type: 'application',
     });
   });
 });

--- a/src/cli/configure/dependencies/skubaDive.test.ts
+++ b/src/cli/configure/dependencies/skubaDive.test.ts
@@ -7,6 +7,7 @@ describe('skubaDive', () => {
         'skuba-dive': '1.0.0',
       },
       devDependencies: {},
+      type: 'application' as const,
     };
 
     const result = skubaDive(input);
@@ -17,6 +18,7 @@ describe('skubaDive', () => {
         'skuba-dive': '1.0.0',
       },
       devDependencies: {},
+      type: 'application',
     });
   });
 
@@ -26,6 +28,7 @@ describe('skubaDive', () => {
       devDependencies: {
         'skuba-dive': '1.0.0',
       },
+      type: 'application' as const,
     };
 
     const result = skubaDive(input);
@@ -36,6 +39,7 @@ describe('skubaDive', () => {
         'skuba-dive': '1.0.0',
       },
       devDependencies: {},
+      type: 'application',
     });
   });
 
@@ -47,6 +51,7 @@ describe('skubaDive', () => {
       devDependencies: {
         '@seek/skuba-dive': '1.0.0',
       },
+      type: 'application' as const,
     };
 
     const result = skubaDive(input);
@@ -57,6 +62,38 @@ describe('skubaDive', () => {
         'skuba-dive': '*',
       },
       devDependencies: {},
+      type: 'application',
+    });
+  });
+
+  it('strips many things from packages', () => {
+    const input = {
+      dependencies: {
+        'skuba-dive': '1.0.0',
+        '@seek/skuba-dive': '1.0.0',
+        lodash: '1.0.0',
+        'module-alias': '1.0.0',
+      },
+      devDependencies: {
+        'source-map-support': '1.0.0',
+        'skuba-dive': '1.0.0',
+        '@seek/skuba-dive': '1.0.0',
+        nock: '1.0.0',
+      },
+      type: 'package' as const,
+    };
+
+    const result = skubaDive(input);
+
+    expect(result).toHaveLength(0);
+    expect(input).toEqual({
+      dependencies: {
+        lodash: '1.0.0',
+      },
+      devDependencies: {
+        nock: '1.0.0',
+      },
+      type: 'package',
     });
   });
 });

--- a/src/cli/configure/dependencies/skubaDive.ts
+++ b/src/cli/configure/dependencies/skubaDive.ts
@@ -4,21 +4,31 @@ import { DependencySet } from '../types';
 const OLD_NAME = '@seek/skuba-dive';
 const NEW_NAME = 'skuba-dive';
 
-export const skubaDive = ({ dependencies, devDependencies }: DependencySet) => {
-  // lazily upgrade to latest version of the new package
-  if (dependencies[OLD_NAME]) {
-    dependencies[NEW_NAME] = '*';
-  }
-  if (devDependencies[OLD_NAME]) {
-    devDependencies[NEW_NAME] = '*';
+export const SKUBA_DIVE_HOOKS = ['module-alias', 'source-map-support'] as const;
+
+export const skubaDive = ({
+  dependencies,
+  devDependencies,
+  type,
+}: DependencySet) => {
+  SKUBA_DIVE_HOOKS.forEach((hook) => {
+    delete dependencies[hook];
+    delete devDependencies[hook];
+  });
+
+  // skuba-dive is a runtime component; it's not appropriate for packages
+  if (type === 'package') {
+    delete dependencies[NEW_NAME];
+    delete devDependencies[NEW_NAME];
+    delete dependencies[OLD_NAME];
+    delete devDependencies[OLD_NAME];
+
+    return [];
   }
 
-  // ensure dependency
-  if (devDependencies[NEW_NAME]) {
-    dependencies[NEW_NAME] =
-      dependencies[NEW_NAME] || devDependencies[NEW_NAME];
-    delete devDependencies[NEW_NAME];
-  }
+  dependencies[NEW_NAME] =
+    dependencies[NEW_NAME] || devDependencies[NEW_NAME] || '*';
+  delete devDependencies[NEW_NAME];
 
   if (!dependencies[OLD_NAME] && !devDependencies[OLD_NAME]) {
     return [];

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -71,6 +71,7 @@ export const configure = async () => {
     destinationRoot,
     include,
     manifest,
+    type,
   });
 
   if (fixDependencies) {
@@ -95,9 +96,11 @@ export const configure = async () => {
     }
   }
 
-  if (fixConfiguration || fixDependencies) {
+  if (fixDependencies) {
     await exec('yarn', 'install', '--silent');
+  }
 
+  if (fixConfiguration || fixDependencies) {
     log.newline();
     log.ok(`Try running ${log.bold('skuba format')}.`);
   }

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -34,9 +34,6 @@ export const packageModule = async ({
   };
 
   const recurringData = {
-    devDependencies: {
-      skuba: version,
-    },
     skuba: {
       entryPoint,
       type,

--- a/src/cli/configure/modules/skubaDive.test.ts
+++ b/src/cli/configure/modules/skubaDive.test.ts
@@ -8,14 +8,17 @@ import {
 
 import { skubaDiveModule } from './skubaDive';
 
-jest.mock('latest-version', () => ({
-  __esModule: true,
-  default: () => Promise.resolve('0.0.1'),
-}));
-
 describe('skubaDiveModule', () => {
+  const SKUBA_DIVE_PACKAGE_JSON = JSON.stringify({
+    dependencies: {
+      'skuba-dive': '1.0.0',
+    },
+  });
+
   it('works from scratch', async () => {
-    const inputFiles = {};
+    const inputFiles = {
+      'package.json': SKUBA_DIVE_PACKAGE_JSON,
+    };
 
     const outputFiles = await executeModule(
       skubaDiveModule,
@@ -29,6 +32,30 @@ describe('skubaDiveModule', () => {
 
     assertDefined(outputData);
     expect(outputData.dependencies).toHaveProperty('skuba-dive');
+  });
+
+  it('disables itself on missing dependency', async () => {
+    const inputFiles = {
+      'package.json': JSON.stringify({
+        dependencies: {},
+      }),
+      'src/app.ts': 'console.log();\n',
+      'src/register.ts': 'console.log();\n',
+    };
+
+    const outputFiles = await executeModule(
+      skubaDiveModule,
+      inputFiles,
+      defaultOpts,
+    );
+
+    expect(outputFiles['src/app.ts']).toBe(inputFiles['src/app.ts']);
+    expect(outputFiles['src/register.ts']).toBe(inputFiles['src/register.ts']);
+
+    const outputData = parsePackage(outputFiles['package.json']);
+
+    assertDefined(outputData);
+    expect(outputData.dependencies).not.toHaveProperty('skuba-dive');
   });
 
   it('disables itself on packages', async () => {
@@ -57,6 +84,7 @@ describe('skubaDiveModule', () => {
 
   it('registers entry point directly under src', async () => {
     const inputFiles = {
+      'package.json': SKUBA_DIVE_PACKAGE_JSON,
       'src/app.ts': 'console.log();\n',
     };
 
@@ -73,6 +101,7 @@ describe('skubaDiveModule', () => {
 
   it('registers entry point indirectly under src', async () => {
     const inputFiles = {
+      'package.json': SKUBA_DIVE_PACKAGE_JSON,
       'src/register.ts': 'console.log();\n',
       'src/nested/index.ts': 'console.error();\n',
     };
@@ -88,29 +117,5 @@ describe('skubaDiveModule', () => {
     expect(outputFiles['src/nested/index.ts']).toBe(
       "import '../register';\n\nconsole.error();\n",
     );
-  });
-
-  it('drops bundled dependencies', async () => {
-    const inputFiles = {
-      'package.json': JSON.stringify({
-        dependencies: {
-          'module-alias': '0.0.1',
-          'something-else': '0.0.1',
-        },
-      }),
-    };
-
-    const outputFiles = await executeModule(
-      skubaDiveModule,
-      inputFiles,
-      defaultOpts,
-    );
-
-    const outputData = parsePackage(outputFiles['package.json']);
-
-    assertDefined(outputData);
-    expect(outputData.dependencies).toHaveProperty('skuba-dive');
-    expect(outputData.dependencies).not.toHaveProperty('module-alias');
-    expect(outputData.dependencies).toHaveProperty('something-else', '0.0.1');
   });
 });

--- a/src/cli/configure/types.ts
+++ b/src/cli/configure/types.ts
@@ -5,6 +5,7 @@ import { ProjectType } from '../../utils/manifest';
 export interface DependencySet {
   dependencies: Record<string, string>;
   devDependencies: Record<string, string>;
+  type: ProjectType;
 }
 
 export type DependencyDiff = Record<


### PR DESCRIPTION
This migrates the last of the dependency logic out of the "config" step into the earlier "dependency" step, so the dependency diff should be fully accurate now.

<img width="489" alt="Screen Shot 2020-06-19 at 2 53 05 am" src="https://user-images.githubusercontent.com/25572311/85049658-5710ea00-b1d8-11ea-8564-3eba04b3a395.png">

This only implements a simple switch of "package means no dive, application means dive". We can build on this to allow applications to opt-out, as described in #26.