### PR TITLE
Install matching skuba version on init

### DIFF
--- a/.changeset/little-balloons-cheat.md
+++ b/.changeset/little-balloons-cheat.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**init:** Install matching skuba version

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Related reading:
 To create a new project:
 
 ```shell
-npx skuba@3.7.0-beta.4 init
+npx skuba@3.7.0-beta.6 init
 ```
 
 To bootstrap an existing project:
 
 ```shell
-npx skuba@3.7.0-beta.4 configure
+npx skuba@3.7.0-beta.6 configure
 ```
 
 ## CLI reference

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -72,7 +72,14 @@ export const init = async () => {
 
   log.newline();
   await initialiseRepo(exec, templateData);
-  await exec('yarn', 'add', '--dev', '--exact', '--silent', 'skuba');
+  await exec(
+    'yarn',
+    'add',
+    '--dev',
+    '--exact',
+    '--silent',
+    `skuba@${skubaVersion}`,
+  );
   await commitChanges(exec, `Clone ${templateName}`);
 
   log.newline();


### PR DESCRIPTION
This allows us to properly distribute self-consistent betas.