### PR TITLE
Isolate modules internally

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,3 @@
 process.env.FORCE_COLOR = '0';
+
+export {};

--- a/src/cli/configure/types.ts
+++ b/src/cli/configure/types.ts
@@ -1,4 +1,4 @@
-export { PackageJson, TsConfigJson } from 'type-fest';
+export type { PackageJson, TsConfigJson } from 'type-fest';
 
 import { ProjectType } from '../../utils/manifest';
 

--- a/template/lambda-sqs-worker/src/framework/logging.ts
+++ b/template/lambda-sqs-worker/src/framework/logging.ts
@@ -3,7 +3,7 @@ import pino from 'pino';
 
 import { config } from 'src/config';
 
-export { Logger } from 'pino';
+export type { Logger } from 'pino';
 
 export const rootLogger = pino({
   base: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": "src",
-    "incremental": true,
-    "moduleResolution": "node",
+    // TODO: set in /config/tsconfig.json
+    "isolatedModules": true,
     "removeComments": false
   },
   "exclude": ["lib*/**/*", "template/**/*"],


### PR DESCRIPTION
This is recommended to flatten the curve and for Babel builds. We won't promote this to the default config just yet.