### PR TITLE
Delete `.npmignore`

### DIFF
--- a/.changeset/tidy-lamps-develop.md
+++ b/.changeset/tidy-lamps-develop.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Delete `.npmignore`

--- a/src/cli/configure/modules/package.test.ts
+++ b/src/cli/configure/modules/package.test.ts
@@ -108,6 +108,7 @@ describe('packageModule', () => {
 
   it('overhauls divergent config', async () => {
     const inputFiles = {
+      '.npmignore': '**/*\n',
       'package.json': JSON.stringify({
         $name: 'secret-service',
         devDependencies: {
@@ -123,6 +124,8 @@ describe('packageModule', () => {
       inputFiles,
       defaultOpts,
     );
+
+    expect(outputFiles['.npmignore']).toBeUndefined();
 
     const outputData = parsePackage(outputFiles['package.json']);
 

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -1,4 +1,5 @@
 import { getSkubaVersion } from '../../../utils/version';
+import { deleteFiles } from '../processing/deleteFiles';
 import { withPackage } from '../processing/package';
 import { merge } from '../processing/record';
 import { Module, Options } from '../types';
@@ -45,6 +46,8 @@ export const packageModule = async ({
   };
 
   return {
+    ...deleteFiles('.npmignore'),
+
     'package.json': withPackage((inputData) => {
       const outputData = merge(
         inputData,


### PR DESCRIPTION
`package.json#/files` takes precedence over this file so it's often confusing to leave it around.