### PR TITLE
Remove `test:build` and `test:jest` scripts

### DIFF
--- a/.changeset/blue-pianos-camp.md
+++ b/.changeset/blue-pianos-camp.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Delete `test:build` and `test:jest` scripts

--- a/src/cli/configure/modules/package.test.ts
+++ b/src/cli/configure/modules/package.test.ts
@@ -114,7 +114,10 @@ describe('packageModule', () => {
           'pino-pretty': '0.0.1',
         },
         license: 'MIT',
-        scripts: {},
+        scripts: {
+          'test:jest': 'jest --coverage',
+          'test:build': 'tsc --noEmit --incremental false',
+        },
       }),
     };
 
@@ -130,6 +133,8 @@ describe('packageModule', () => {
     expect(outputData.license).toBe('MIT');
     expect(outputData.private).toBe(true);
     expect(outputData.scripts).toHaveProperty('build');
+    expect(outputData.scripts).not.toHaveProperty('test:build');
+    expect(outputData.scripts).not.toHaveProperty('test:jest');
   });
 
   it('overhauls seek-module-toolkit configuration', async () => {

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -52,6 +52,13 @@ export const packageModule = async ({
       );
 
       outputData.license = outputData.license ?? 'UNLICENSED';
+      outputData.scripts = outputData.scripts ?? {};
+
+      delete outputData.scripts.commit;
+      delete outputData.scripts['format:check'];
+      delete outputData.scripts['test:build'];
+      delete outputData.scripts['test:jest'];
+      delete outputData.typings;
 
       if (type === 'package') {
         outputData.files = (
@@ -62,8 +69,6 @@ export const packageModule = async ({
 
         outputData.version =
           outputData.version ?? '0.0.0-semantically-released';
-
-        outputData.scripts = outputData.scripts ?? {};
 
         // User-defined pre- and post-scripts are confusing and dropped by e.g.
         // Yarn 2.
@@ -93,11 +98,8 @@ export const packageModule = async ({
           outputData.types = './lib/index.d.ts';
         }
 
-        delete outputData.scripts.commit;
-        delete outputData.scripts['format:check'];
         delete outputData.scripts.prepublish;
         delete outputData.scripts.prerelease;
-        delete outputData.typings;
       }
 
       return outputData;


### PR DESCRIPTION
These are holdovers from `seek-module-toolkit` and bespoke configs that didn't roll type checking into their `lint` script.