### PR TITLE
Migrate select Jest options

### DIFF
--- a/.changeset/popular-clouds-train.md
+++ b/.changeset/popular-clouds-train.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Migrate select Jest options

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "release": "yarn build && changeset publish",
     "stage": "changeset version && yarn format",
     "skuba": "ts-node src/skuba",
-    "test": "jest",
+    "test": "yarn skuba test",
     "test:template": "scripts/test-template.sh"
   },
   "repository": {

--- a/src/cli/configure/modules/jest.test.ts
+++ b/src/cli/configure/modules/jest.test.ts
@@ -53,6 +53,32 @@ describe('jestModule', () => {
     expect(outputFiles['jest.setup.ts']).toBe(inputFiles['jest.setup.ts']);
   });
 
+  it('migrates Jest options', async () => {
+    const inputFiles = {
+      'jest.config.js': `module.exports = {
+        collectCoverage: true,
+        coverageThreshold: {},
+        globalSetup: "./globalSetup.js",
+      };`,
+      'jest.setup.ts': "process.env.ENVIRONMENT = 'myMachine'",
+    };
+
+    const outputFiles = await executeModule(
+      jestModule,
+      inputFiles,
+      defaultOpts,
+    );
+
+    expect(outputFiles['jest.config.js']).toContain('skuba');
+    expect(outputFiles['jest.config.js']).toContain('coverageThreshold');
+    expect(outputFiles['jest.config.js']).toContain(
+      "globalSetup: './globalSetup.js',",
+    );
+    expect(outputFiles['jest.config.js']).not.toContain('collectCoverage');
+    expect(outputFiles['jest.config.js']).not.toContain('skydive');
+    expect(outputFiles['jest.setup.ts']).toBe(inputFiles['jest.setup.ts']);
+  });
+
   it('preserves config extending module import', async () => {
     const inputFiles = {
       'jest.config.js':

--- a/src/cli/configure/modules/package.test.ts
+++ b/src/cli/configure/modules/package.test.ts
@@ -109,6 +109,9 @@ describe('packageModule', () => {
   it('overhauls divergent config', async () => {
     const inputFiles = {
       '.npmignore': '**/*\n',
+      'jest.config.js': `module.exports = {
+        collectCoverage: true,
+      };`,
       'package.json': JSON.stringify({
         $name: 'secret-service',
         devDependencies: {
@@ -136,6 +139,7 @@ describe('packageModule', () => {
     expect(outputData.license).toBe('MIT');
     expect(outputData.private).toBe(true);
     expect(outputData.scripts).toHaveProperty('build');
+    expect(outputData.scripts).toHaveProperty('test', 'skuba test --coverage');
     expect(outputData.scripts).not.toHaveProperty('test:build');
     expect(outputData.scripts).not.toHaveProperty('test:jest');
   });

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -1,5 +1,6 @@
 import { getSkubaVersion } from '../../../utils/version';
 import { deleteFiles } from '../processing/deleteFiles';
+import { loadFiles } from '../processing/loadFiles';
 import { withPackage } from '../processing/package';
 import { merge } from '../processing/record';
 import { Module, Options } from '../types';
@@ -44,65 +45,78 @@ export const packageModule = async ({
 
   return {
     ...deleteFiles('.npmignore'),
+    ...loadFiles('jest.config.js'),
 
-    'package.json': withPackage((inputData) => {
-      const outputData = merge(
-        inputData,
-        'skuba' in inputData ? recurringData : initialData,
-      );
+    'package.json': (inputFile, _, initialFiles) => {
+      const jestConfig = initialFiles['jest.config.js'];
 
-      outputData.license = outputData.license ?? 'UNLICENSED';
-      outputData.scripts = outputData.scripts ?? {};
-
-      delete outputData.scripts.commit;
-      delete outputData.scripts['format:check'];
-      delete outputData.scripts['test:build'];
-      delete outputData.scripts['test:jest'];
-      delete outputData.typings;
-
-      if (type === 'package') {
-        outputData.files = (
-          outputData.files ?? DEFAULT_PACKAGE_FILES
-        ).flatMap((filePattern) =>
-          filePattern === 'lib' ? DEFAULT_PACKAGE_FILES : [filePattern],
-        );
-
-        outputData.version =
-          outputData.version ?? '0.0.0-semantically-released';
-
-        // User-defined pre- and post-scripts are confusing and dropped by e.g.
-        // Yarn 2.
-        outputData.scripts.release = [
-          outputData.scripts.prepublish,
-          outputData.scripts.prerelease,
-          outputData.scripts.release ?? 'skuba release',
-        ]
-          .filter((script): script is string => typeof script === 'string')
-          .map((script) =>
-            script
-              .replace(/^smt build$/, 'yarn build')
-              .replace(/^smt /, 'skuba ')
-              .trim(),
-          )
-          .filter(Boolean)
-          .join(' && ');
-
-        // Align with the required syntax for package.json#/paths
-        if (outputData.scripts.build === 'skuba build-package') {
-          outputData.main = './lib-commonjs/index.js';
-          outputData.module = './lib-es2015/index.js';
-          outputData.types = './lib-types/index.d.ts';
-        } else {
-          outputData.main = './lib/index.js';
-          outputData.module = './lib/index.js';
-          outputData.types = './lib/index.d.ts';
-        }
-
-        delete outputData.scripts.prepublish;
-        delete outputData.scripts.prerelease;
+      if (
+        typeof jestConfig === 'string' &&
+        /collectCoverage: true/.test(jestConfig)
+      ) {
+        // naughty mutation
+        initialData.scripts.test = 'skuba test --coverage';
       }
 
-      return outputData;
-    }),
+      return withPackage((inputData) => {
+        const outputData = merge(
+          inputData,
+          'skuba' in inputData ? recurringData : initialData,
+        );
+
+        outputData.license = outputData.license ?? 'UNLICENSED';
+        outputData.scripts = outputData.scripts ?? {};
+
+        delete outputData.scripts.commit;
+        delete outputData.scripts['format:check'];
+        delete outputData.scripts['test:build'];
+        delete outputData.scripts['test:jest'];
+        delete outputData.typings;
+
+        if (type === 'package') {
+          outputData.files = (
+            outputData.files ?? DEFAULT_PACKAGE_FILES
+          ).flatMap((filePattern) =>
+            filePattern === 'lib' ? DEFAULT_PACKAGE_FILES : [filePattern],
+          );
+
+          outputData.version =
+            outputData.version ?? '0.0.0-semantically-released';
+
+          // User-defined pre- and post-scripts are confusing and dropped by e.g.
+          // Yarn 2.
+          outputData.scripts.release = [
+            outputData.scripts.prepublish,
+            outputData.scripts.prerelease,
+            outputData.scripts.release ?? 'skuba release',
+          ]
+            .filter((script): script is string => typeof script === 'string')
+            .map((script) =>
+              script
+                .replace(/^smt build$/, 'yarn build')
+                .replace(/^smt /, 'skuba ')
+                .trim(),
+            )
+            .filter(Boolean)
+            .join(' && ');
+
+          // Align with the required syntax for package.json#/paths
+          if (outputData.scripts.build === 'skuba build-package') {
+            outputData.main = './lib-commonjs/index.js';
+            outputData.module = './lib-es2015/index.js';
+            outputData.types = './lib-types/index.d.ts';
+          } else {
+            outputData.main = './lib/index.js';
+            outputData.module = './lib/index.js';
+            outputData.types = './lib/index.d.ts';
+          }
+
+          delete outputData.scripts.prepublish;
+          delete outputData.scripts.prerelease;
+        }
+
+        return outputData;
+      })(inputFile);
+    },
   };
 };

--- a/src/cli/configure/processing/typescript.test.ts
+++ b/src/cli/configure/processing/typescript.test.ts
@@ -1,0 +1,103 @@
+import ts from 'typescript';
+
+import { assertDefined } from '../testing/module';
+
+import {
+  createPropAppender,
+  createPropFilter,
+  readModuleExports,
+  transformModuleExports,
+} from './typescript';
+
+const JEST_CONFIG = `module.exports = {
+  collectCoverage: true,
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+    },
+  },
+  preset: 'ts-jest',
+  globalSetup: './jest.globalSetup.js',
+  setupFilesAfterEnv: ['./jest.setup.js'],
+};
+`;
+
+describe('transformModuleExports', () => {
+  it('works with a no-op transformer', () => {
+    const result = transformModuleExports(JEST_CONFIG, (props) => props);
+
+    expect(result).toBe(JEST_CONFIG);
+  });
+
+  it('works with a prop appender', () => {
+    const append = createPropAppender(
+      ts.createNodeArray([
+        ts.createPropertyAssignment(
+          ts.createIdentifier('globalSetup'),
+          ts.createStringLiteral('I should not take precedence'),
+        ),
+        ts.createPropertyAssignment(
+          ts.createIdentifier('a'),
+          ts.createStringLiteral('b'),
+        ),
+      ]),
+    );
+
+    const result = transformModuleExports(JEST_CONFIG, append);
+
+    expect(result).toMatchInlineSnapshot(`
+      "module.exports = {
+        collectCoverage: true,
+        coverageThreshold: {
+          global: {
+            branches: 80,
+            functions: 80,
+            lines: 80,
+          },
+        },
+        preset: 'ts-jest',
+        globalSetup: './jest.globalSetup.js',
+        setupFilesAfterEnv: ['./jest.setup.js'],
+        a: 'b',
+      };
+      "
+    `);
+  });
+
+  it('works with a prop filter', () => {
+    const filter = createPropFilter([
+      'coverageThreshold',
+      'setupFilesAfterEnv',
+      'globalSetup',
+    ]);
+
+    const result = transformModuleExports(JEST_CONFIG, filter);
+
+    expect(result).toMatchInlineSnapshot(`
+      "module.exports = {
+        coverageThreshold: {
+          global: {
+            branches: 80,
+            functions: 80,
+            lines: 80,
+          },
+        },
+        globalSetup: './jest.globalSetup.js',
+        setupFilesAfterEnv: ['./jest.setup.js'],
+      };
+      "
+    `);
+  });
+});
+
+describe('readModuleExports', () => {
+  it('extracts props from a module.exports expression', () => {
+    const result = readModuleExports(JEST_CONFIG);
+
+    assertDefined(result);
+    expect(result).toHaveLength(5);
+    result.forEach((node) => expect(ts.isPropertyAssignment(node)).toBe(true));
+  });
+});

--- a/src/cli/configure/processing/typescript.ts
+++ b/src/cli/configure/processing/typescript.ts
@@ -1,0 +1,128 @@
+import prettier from 'prettier';
+import ts from 'typescript';
+
+type Props = ts.NodeArray<ts.ObjectLiteralElementLike>;
+
+type Transformer<T> = (props: T) => T;
+
+/**
+ * Create the following expression:
+ *
+ * ```javascript
+ * module.exports = {};
+ * ```
+ */
+const createModuleExportsExpression = (props: Props): ts.ExpressionStatement =>
+  ts.createExpressionStatement(
+    ts.createBinary(
+      ts.createPropertyAccess(
+        ts.createIdentifier('module'),
+        ts.createIdentifier('exports'),
+      ),
+      ts.createToken(ts.SyntaxKind.EqualsToken),
+      ts.createObjectLiteral(props, true),
+    ),
+  );
+
+const getPropName = (prop: ts.ObjectLiteralElementLike) =>
+  ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)
+    ? prop.name.escapedText.toString()
+    : undefined;
+
+/**
+ * Create a transformer to mutate `module.exports` props in a source file.
+ *
+ * There's no recursion needed here as we expect the `module.exports` statement
+ * to be a top-level node and therefore an immediate child of the source file.
+ */
+const createModuleExportsTransformer = (
+  transformProps: Transformer<Props>,
+): ts.TransformerFactory<ts.Node> => (context) => (rootNode) =>
+  ts.visitEachChild(
+    rootNode,
+    (node) => {
+      if (
+        !ts.isExpressionStatement(node) ||
+        !ts.isBinaryExpression(node.expression) ||
+        !ts.isPropertyAccessExpression(node.expression.left) ||
+        !ts.isIdentifier(node.expression.left.expression) ||
+        node.expression.left.expression.escapedText !== 'module' ||
+        node.expression.left.name.text !== 'exports' ||
+        node.expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
+        !ts.isObjectLiteralExpression(node.expression.right)
+      ) {
+        return node;
+      }
+
+      const props = transformProps(node.expression.right.properties);
+
+      return createModuleExportsExpression(props);
+    },
+    context,
+  );
+
+/**
+ * Create a transformer to filter out unspecified props from an object literal.
+ */
+export const createPropFilter = (names: string[]): Transformer<Props> => (
+  props,
+) => {
+  const nameSet = new Set<unknown>(names);
+
+  return ts.createNodeArray(
+    props.filter((prop) => nameSet.has(getPropName(prop))),
+  );
+};
+
+export const createPropAppender = (
+  appendingProps: Props,
+): Transformer<Props> => (props) => {
+  const nameSet = new Set<unknown>(
+    props.map(getPropName).filter((prop) => typeof prop === 'string'),
+  );
+
+  return ts.createNodeArray([
+    ...props,
+    ...appendingProps.filter((prop) => !nameSet.has(getPropName(prop))),
+  ]);
+};
+
+/**
+ * Read out `module.exports` props from a source file.
+ *
+ * The props can then be used when transforming another source file.
+ */
+export const readModuleExports = (inputFile: string): Props | undefined => {
+  let result: Props | undefined;
+
+  transformModuleExports(inputFile, (props) => (result = props));
+
+  return result;
+};
+
+/**
+ * Mutate `module.exports` props in a source file.
+ */
+export const transformModuleExports = (
+  inputFile: string,
+  transformProps: Transformer<Props>,
+): string => {
+  const sourceFile = ts.createSourceFile('', inputFile, ts.ScriptTarget.Latest);
+
+  const transformer = createModuleExportsTransformer(transformProps);
+
+  const result = ts.transform(sourceFile, [transformer]);
+
+  const [transformedFile] = result.transformed;
+
+  const text = ts
+    .createPrinter()
+    .printNode(ts.EmitHint.SourceFile, transformedFile, sourceFile);
+
+  return prettier.format(text, {
+    parser: 'typescript',
+    singleQuote: true,
+    tabWidth: 2,
+    trailingComma: 'all',
+  });
+};

--- a/src/cli/configure/processing/typescript.ts
+++ b/src/cli/configure/processing/typescript.ts
@@ -42,21 +42,21 @@ const createModuleExportsTransformer = (
     rootNode,
     (node) => {
       if (
-        !ts.isExpressionStatement(node) ||
-        !ts.isBinaryExpression(node.expression) ||
-        !ts.isPropertyAccessExpression(node.expression.left) ||
-        !ts.isIdentifier(node.expression.left.expression) ||
-        node.expression.left.expression.escapedText !== 'module' ||
-        node.expression.left.name.text !== 'exports' ||
-        node.expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken ||
-        !ts.isObjectLiteralExpression(node.expression.right)
+        ts.isExpressionStatement(node) &&
+        ts.isBinaryExpression(node.expression) &&
+        ts.isPropertyAccessExpression(node.expression.left) &&
+        ts.isIdentifier(node.expression.left.expression) &&
+        node.expression.left.expression.escapedText === 'module' &&
+        node.expression.left.name.text === 'exports' &&
+        node.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isObjectLiteralExpression(node.expression.right)
       ) {
-        return node;
+        const props = transformProps(node.expression.right.properties);
+
+        return createModuleExportsExpression(props);
       }
 
-      const props = transformProps(node.expression.right.properties);
-
-      return createModuleExportsExpression(props);
+      return node;
     },
     context,
   );


### PR DESCRIPTION
After many half-hearted attempts, I've finally mustered the will to get TypeScript ASTing. This extracts a blessed list of Jest options from the input `jest.config.js` and merges that with our base config. We also naively set the `--coverage` flag in `package.json#/scripts/test` when we see the `collectCoverage` option.

---

And yes, Jest configuration is _JavaScript_, but this may be a better investment if we end up doing something smart with `.ts` sources in future.