### PR TITLE
Exclude `lib-` directories from compilation

### DIFF
--- a/.changeset/cyan-papayas-swim.md
+++ b/.changeset/cyan-papayas-swim.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure, init**: Exclude `lib-` directories from compilation

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ By convention, this points to a `tsconfig.build.json` that excludes tests from y
   "compilerOptions": {
     "outDir": "lib"
   },
-  "exclude": ["lib/**/*"]
+  "exclude": ["lib*/**/*"]
 }
 ```
 

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -156,7 +156,7 @@ module.exports = {
       \\"src\\": [\\"src\\"]
     }
   },
-  \\"exclude\\": [\\"lib/**/*\\"],
+  \\"exclude\\": [\\"lib*/**/*\\"],
   \\"extends\\": \\"skuba/config/tsconfig.json\\"
 }
 ",

--- a/src/cli/configure/modules/tsconfig.test.ts
+++ b/src/cli/configure/modules/tsconfig.test.ts
@@ -88,7 +88,7 @@ describe('tsconfigModule', () => {
     assertDefined(outputData);
     expect(outputData.compilerOptions!.outDir).toBe('lib');
     expect(outputData.compilerOptions!.target).toBe('ES2020');
-    expect(outputData.exclude).toContain('lib/**/*');
+    expect(outputData.exclude).toContain('lib*/**/*');
     expect(outputData.exclude).toContain('.idea');
     expect(outputData.extends).toBe('skuba/config/tsconfig.json');
     expect(outputData.include).toBeUndefined();

--- a/template/base/tsconfig.json
+++ b/template/base/tsconfig.json
@@ -7,6 +7,6 @@
     },
     "target": "ES2019"
   },
-  "exclude": ["lib/**/*"],
+  "exclude": ["lib*/**/*"],
   "extends": "skuba/config/tsconfig.json"
 }

--- a/template/oss-npm-package/tsconfig.json
+++ b/template/oss-npm-package/tsconfig.json
@@ -3,6 +3,6 @@
     "outDir": "lib",
     "target": "ES2019"
   },
-  "exclude": ["lib/**/*"],
+  "exclude": ["lib*/**/*"],
   "extends": "skuba/config/tsconfig.json"
 }

--- a/template/private-npm-package/tsconfig.json
+++ b/template/private-npm-package/tsconfig.json
@@ -3,6 +3,6 @@
     "outDir": "lib",
     "target": "ES2019"
   },
-  "exclude": ["lib/**/*"],
+  "exclude": ["lib*/**/*"],
   "extends": "skuba/config/tsconfig.json"
 }


### PR DESCRIPTION
This makes sense as the default given that `skuba build-package` builds to e.g. `/lib-es2015`.