### PR TITLE
Make mentioned commands actually runnable

### DIFF
--- a/.changeset/smart-crews-appear.md
+++ b/.changeset/smart-crews-appear.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure, init:** Make mentioned commands actually runnable

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -102,6 +102,6 @@ export const configure = async () => {
 
   if (fixConfiguration || fixDependencies) {
     log.newline();
-    log.ok(`Try running ${log.bold('skuba format')}.`);
+    log.ok(`Try running ${log.bold('yarn format')}.`);
   }
 };

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -195,7 +195,7 @@ export const configureFromPrompt = async (): Promise<InitConfig> => {
   }
 
   log.newline();
-  log.warn(`Resume this later with ${chalk.bold('skuba configure')}.`);
+  log.warn(`Resume this later with ${chalk.bold('yarn skuba configure')}.`);
 
   const customAnswers = generatePlaceholders(fields);
 

--- a/src/cli/init/git.ts
+++ b/src/cli/init/git.ts
@@ -81,7 +81,7 @@ export const downloadGitHubTemplate = async (
   log.newline();
   log.warn(
     'You may need to run',
-    log.bold('skuba configure'),
+    log.bold('yarn skuba configure'),
     'once this is done.',
   );
 };


### PR DESCRIPTION
The old copy for these lines assumed that you understood that `skuba` would be installed locally and you had to use e.g. `yarn` or `npx` to point to its CLI.