### PR TITLE
Reduce unintended stripping of `_` filename prefix

### DIFF
--- a/.changeset/young-deers-rescue.md
+++ b/.changeset/young-deers-rescue.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure, init:** Reduce unintended stripping of `_` filename prefix

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -92,7 +92,10 @@ export const copyFiles = async (
   const filenames = await fs.readdir(currentSourceDir);
 
   const toDestinationPath = (filename: string) =>
-    path.join(currentDestinationDir, filename.replace(/^_/, ''));
+    path.join(
+      currentDestinationDir,
+      filename.replace(/^_\./, '.').replace(/^_package\.json/, 'package.json'),
+    );
 
   const filteredFilenames = filenames.filter((filename) =>
     opts.include(


### PR DESCRIPTION
Turns out that this is rather hurtful to `__mocks__` and such.