### PR TITLE
Suppress dependency deprecation warnings

### DIFF
--- a/.changeset/thirty-bananas-build.md
+++ b/.changeset/thirty-bananas-build.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**cli:** Suppress dependency deprecation warnings

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { Select } from 'enquirer';
 
 import { createInclusionFilter } from '../../utils/copy';
-import { ensureCommands, exec } from '../../utils/exec';
+import { createExec, ensureCommands } from '../../utils/exec';
 import { log } from '../../utils/logging';
 import { showLogo } from '../../utils/logo';
 import { BASE_TEMPLATE_DIR } from '../../utils/template';
@@ -97,6 +97,12 @@ export const configure = async () => {
   }
 
   if (fixDependencies) {
+    const exec = createExec({
+      stdio: 'pipe',
+      streamStdio: 'yarn',
+    });
+
+    log.plain('Installing dependencies...');
     await exec('yarn', 'install', '--silent');
   }
 

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -68,10 +68,16 @@ export const init = async () => {
     }),
   ]);
 
-  const exec = createExec({ cwd: destinationDir });
+  const exec = createExec({
+    cwd: destinationDir,
+    stdio: 'pipe',
+    streamStdio: 'yarn',
+  });
 
   log.newline();
   await initialiseRepo(exec, templateData);
+
+  log.plain('Installing dependencies...');
   await exec(
     'yarn',
     'add',
@@ -80,6 +86,7 @@ export const init = async () => {
     '--silent',
     `skuba@${skubaVersion}`,
   );
+
   await commitChanges(exec, `Clone ${templateName}`);
 
   log.newline();


### PR DESCRIPTION
These are annoying and there's little that users can do about it. Most of these come from e.g. transitive Jest dependencies, and Jest has open issues tracking the migration to supported dependencies.