### PR TITLE
Format Renovate config

### DIFF
--- a/.changeset/light-tomatoes-try.md
+++ b/.changeset/light-tomatoes-try.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Format Renovate config

--- a/src/cli/configure/modules/renovate.test.ts
+++ b/src/cli/configure/modules/renovate.test.ts
@@ -88,8 +88,10 @@ describe('renovateModule', () => {
 
   it('preserves extended config', async () => {
     const inputFiles = {
-      '.github/renovate.json5':
-        '{"extends": ["github>seek-oss/rynovate:non-critical"], "ignorePaths": []}',
+      '.github/renovate.json5': `{
+    "extends": ["github>seek-oss/rynovate:non-critical"],
+    "ignorePaths": []
+}`,
     };
 
     const outputFiles = await executeModule(
@@ -98,9 +100,11 @@ describe('renovateModule', () => {
       defaultOpts,
     );
 
-    expect(outputFiles['.github/renovate.json5']).toBe(
-      inputFiles['.github/renovate.json5'],
-    );
+    expect(outputFiles['.github/renovate.json5']).toBe(`{
+  extends: ['github>seek-oss/rynovate:non-critical'],
+  ignorePaths: [],
+}
+`);
   });
 
   it('migrates extended config', async () => {
@@ -115,7 +119,7 @@ describe('renovateModule', () => {
     );
 
     expect(outputFiles['.github/renovate.json5']).toBe(
-      inputFiles['renovate.json'],
+      "{ extends: ['seek'] }\n",
     );
 
     expect(outputFiles['renovate.json']).toBeUndefined();

--- a/src/cli/configure/modules/renovate.ts
+++ b/src/cli/configure/modules/renovate.ts
@@ -1,3 +1,5 @@
+import prettier from 'prettier';
+
 import { readBaseTemplateFile } from '../../../utils/template';
 import { deleteFiles } from '../processing/deleteFiles';
 import { withPackage } from '../processing/package';
@@ -26,7 +28,14 @@ export const renovateModule = async ({ type }: Options): Promise<Module> => {
       ]);
 
       // allow customised Renovate configs that extend a SEEK configuration
-      return inputFile?.includes('seek') ? inputFile : configFile;
+      return inputFile?.includes('seek')
+        ? prettier.format(inputFile, {
+            parser: 'json5',
+            singleQuote: true,
+            tabWidth: 2,
+            trailingComma: 'all',
+          })
+        : configFile;
     },
 
     /**


### PR DESCRIPTION
We support the migration of existing SEEK Renovate configurations, which are predominantly stored in JSON format. While JSON5 is fully compatible with JSON, Prettier prefers different formatting with JSON5 files.