### PR TITLE
Format `package.json` consistently

### DIFF
--- a/.changeset/rare-apples-know.md
+++ b/.changeset/rare-apples-know.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure, init:** Format `package.json` consistently

--- a/src/cli/configure/processing/json.test.ts
+++ b/src/cli/configure/processing/json.test.ts
@@ -16,6 +16,27 @@ describe('formatObject', () => {
       }
       "
     `));
+
+  it('handles ordinary JSON array formatting', () =>
+    expect(formatObject({ files: ['1', '2', '3'] })).toMatchInlineSnapshot(`
+      "{
+        \\"files\\": [\\"1\\", \\"2\\", \\"3\\"]
+      }
+      "
+    `));
+
+  it('handles special-cased package.json array formatting', () =>
+    expect(formatObject({ files: ['1', '2', '3'] }, 'package.json'))
+      .toMatchInlineSnapshot(`
+      "{
+        \\"files\\": [
+          \\"1\\",
+          \\"2\\",
+          \\"3\\"
+        ]
+      }
+      "
+    `));
 });
 
 describe('parseObject', () => {

--- a/src/cli/configure/processing/json.ts
+++ b/src/cli/configure/processing/json.ts
@@ -2,7 +2,10 @@ import prettier from 'prettier';
 
 import { isObject } from '../../../utils/validation';
 
-export const formatObject = (data: Record<PropertyKey, unknown>) => {
+export const formatObject = (
+  data: Record<PropertyKey, unknown>,
+  filepath?: string,
+) => {
   const sortedData = Object.fromEntries(
     Object.entries(data).sort(([keyA], [keyB]) =>
       String(keyA).localeCompare(String(keyB)),
@@ -11,7 +14,10 @@ export const formatObject = (data: Record<PropertyKey, unknown>) => {
 
   const output = JSON.stringify(sortedData, null, 2);
 
-  return prettier.format(output, { parser: 'json' });
+  return prettier.format(
+    output,
+    typeof filepath === 'undefined' ? { parser: 'json' } : { filepath },
+  );
 };
 
 export const parseObject = (

--- a/src/cli/configure/processing/package.test.ts
+++ b/src/cli/configure/processing/package.test.ts
@@ -138,7 +138,10 @@ describe('withPackage', () => {
           \\"d\\": \\"4\\",
           \\"e\\": \\"5\\"
         },
-        \\"files\\": [\\"b\\", \\"a\\"],
+        \\"files\\": [
+          \\"b\\",
+          \\"a\\"
+        ],
         \\"scripts\\": {
           \\"prebuild\\": \\"rm -rf system32\\",
           \\"build\\": \\"npm install freebsd\\"

--- a/src/cli/configure/processing/package.ts
+++ b/src/cli/configure/processing/package.ts
@@ -35,7 +35,7 @@ export const formatPackage = (data: PackageJson) => {
     delete data.version;
   }
 
-  return formatObject(data);
+  return formatObject(data, 'package.json');
 };
 
 export const parsePackage = (


### PR DESCRIPTION
Prettier appears to have some special casing around the formatting of `package.json` files that isn't applied to just any JSON file. This ensures that a `package.json` manipulated via `skuba configure` or `skuba init` will pass Prettier format checking.