### PR TITLE
Avoid stripping of `_` filename prefixes

### DIFF
--- a/.changeset/large-donuts-teach.md
+++ b/.changeset/large-donuts-teach.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Avoid stripping of `_` filename prefixes

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -100,6 +100,8 @@ const cloneTemplate = async (templateName: string, destinationDir: string) => {
     sourceRoot: templateDir,
     destinationRoot: destinationDir,
     processors: [],
+    // built-in templates have files like _package.json
+    stripUnderscorePrefix: true,
   });
 };
 

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -45,6 +45,8 @@ export const init = async () => {
     // prefer template-specific files
     overwrite: false,
     processors,
+    // base template has files like _.eslintrc.js
+    stripUnderscorePrefix: true,
   });
 
   await copyFiles({

--- a/src/utils/copy.ts
+++ b/src/utils/copy.ts
@@ -67,6 +67,7 @@ interface CopyFilesOptions {
   include: (pathname: string) => boolean;
   overwrite?: boolean;
   processors: Array<TextProcessor>;
+  stripUnderscorePrefix?: boolean;
 }
 
 export const createEjsRenderer = (
@@ -94,7 +95,11 @@ export const copyFiles = async (
   const toDestinationPath = (filename: string) =>
     path.join(
       currentDestinationDir,
-      filename.replace(/^_\./, '.').replace(/^_package\.json/, 'package.json'),
+      opts.stripUnderscorePrefix
+        ? filename
+            .replace(/^_\./, '.')
+            .replace(/^_package\.json/, 'package.json')
+        : filename,
     );
 
   const filteredFilenames = filenames.filter((filename) =>


### PR DESCRIPTION
This filename manipulation has haunted me as `copyFiles` gets used in more places. #106 tightened up the matching patterns but a target repository _could_ have some legitimate reason for storing a filename with a prefix of `_.` that would still get chomped.

Instead, only trigger this logic on `skuba init` of a built-in template. There's no reason to do this on `skuba configure`, and external GitHub-hosted templates shouldn't run into the packaging troubles that necessitate a `_package.json`.