### PR TITLE
Use simple ESLint extends syntax

### DIFF
--- a/.changeset/swift-adults-sell.md
+++ b/.changeset/swift-adults-sell.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Use simple ESLint extends syntax

--- a/config/prettier.d.ts
+++ b/config/prettier.d.ts
@@ -1,0 +1,3 @@
+export const singleQuote: boolean;
+export const tabWidth: number;
+export const trailingComma: 'all';

--- a/src/cli/configure/modules/eslint.test.ts
+++ b/src/cli/configure/modules/eslint.test.ts
@@ -56,10 +56,10 @@ describe('eslintModule', () => {
     expect(outputFiles['.eslintrc.js']).not.toContain('skydive');
   });
 
-  it('preserves config extending module import', async () => {
+  it('preserves config extending old module import', async () => {
     const inputFiles = {
       '.eslintrc.js':
-        "module.exports = { extends: [require.resolve('skuba/config/eslint')], rules: { 'no-process-exit': 'off' } }",
+        "module.exports = { extends: [require.resolve('@seek/skuba/config/eslint')], rules: { 'no-process-exit': 'off' } }",
     };
 
     const outputFiles = await executeModule(
@@ -68,13 +68,34 @@ describe('eslintModule', () => {
       defaultOpts,
     );
 
-    expect(outputFiles['.eslintrc.js']).toBe(inputFiles['.eslintrc.js']);
+    expect(outputFiles['.eslintrc.js']).toMatchInlineSnapshot(`
+      "module.exports = { extends: ['skuba'], rules: { 'no-process-exit': 'off' } };
+      "
+    `);
+  });
+
+  it('preserves config extending new module import', async () => {
+    const inputFiles = {
+      '.eslintrc.js': `module.exports = { extends: [
+          require.resolve("skuba/config/eslint")], rules: { "no-process-exit": "off" } }`,
+    };
+
+    const outputFiles = await executeModule(
+      eslintModule,
+      inputFiles,
+      defaultOpts,
+    );
+
+    expect(outputFiles['.eslintrc.js']).toMatchInlineSnapshot(`
+      "module.exports = { extends: ['skuba'], rules: { 'no-process-exit': 'off' } };
+      "
+    `);
   });
 
   it('preserves config extending shareable config', async () => {
     const inputFiles = {
       '.eslintrc.js':
-        "module.exports = { extends: ['skuba'], rules: { 'no-process-exit': 'off' } }",
+        "module.exports = { extends: ['skuba'], rules: { 'no-process-exit': 'off' } };\n",
     };
 
     const outputFiles = await executeModule(

--- a/src/cli/configure/modules/eslint.ts
+++ b/src/cli/configure/modules/eslint.ts
@@ -2,6 +2,7 @@ import { readBaseTemplateFile } from '../../../utils/template';
 import { deleteFiles } from '../processing/deleteFiles';
 import { mergeWithIgnoreFile } from '../processing/ignoreFile';
 import { withPackage } from '../processing/package';
+import { formatPrettier } from '../processing/prettier';
 import { Module } from '../types';
 
 export const eslintModule = async (): Promise<Module> => {
@@ -20,8 +21,18 @@ export const eslintModule = async (): Promise<Module> => {
     ),
 
     // allow customised ESLint configs that extend skuba
-    '.eslintrc.js': (inputFile) =>
-      inputFile?.includes('skuba') ? inputFile : configFile,
+    '.eslintrc.js': (inputFile) => {
+      if (inputFile?.includes('skuba')) {
+        const processedFile = inputFile.replace(
+          /require.resolve\(['"](@seek\/)?skuba\/config\/eslint['"]\)/,
+          "'skuba'",
+        );
+
+        return formatPrettier(processedFile, { parser: 'typescript' });
+      }
+
+      return configFile;
+    },
 
     '.eslintignore': mergeWithIgnoreFile(ignoreFile),
 

--- a/src/cli/configure/modules/renovate.ts
+++ b/src/cli/configure/modules/renovate.ts
@@ -1,8 +1,7 @@
-import prettier from 'prettier';
-
 import { readBaseTemplateFile } from '../../../utils/template';
 import { deleteFiles } from '../processing/deleteFiles';
 import { withPackage } from '../processing/package';
+import { formatPrettier } from '../processing/prettier';
 import { getFirstDefined } from '../processing/record';
 import { Module, Options } from '../types';
 
@@ -29,12 +28,7 @@ export const renovateModule = async ({ type }: Options): Promise<Module> => {
 
       // allow customised Renovate configs that extend a SEEK configuration
       return inputFile?.includes('seek')
-        ? prettier.format(inputFile, {
-            parser: 'json5',
-            singleQuote: true,
-            tabWidth: 2,
-            trailingComma: 'all',
-          })
+        ? formatPrettier(inputFile, { parser: 'json5' })
         : configFile;
     },
 

--- a/src/cli/configure/processing/json.ts
+++ b/src/cli/configure/processing/json.ts
@@ -1,6 +1,6 @@
-import prettier from 'prettier';
-
 import { isObject } from '../../../utils/validation';
+
+import { formatPrettier } from './prettier';
 
 export const formatObject = (
   data: Record<PropertyKey, unknown>,
@@ -14,7 +14,7 @@ export const formatObject = (
 
   const output = JSON.stringify(sortedData, null, 2);
 
-  return prettier.format(
+  return formatPrettier(
     output,
     typeof filepath === 'undefined' ? { parser: 'json' } : { filepath },
   );

--- a/src/cli/configure/processing/prettier.ts
+++ b/src/cli/configure/processing/prettier.ts
@@ -1,0 +1,11 @@
+import prettier from 'prettier';
+
+import prettierConfig from '../../../../config/prettier';
+
+type Options = Pick<prettier.Options, 'filepath' | 'parser'>;
+
+export const formatPrettier = (source: string, options: Options) =>
+  prettier.format(source, {
+    ...options,
+    ...prettierConfig,
+  });

--- a/src/cli/configure/processing/typescript.ts
+++ b/src/cli/configure/processing/typescript.ts
@@ -1,5 +1,6 @@
-import prettier from 'prettier';
 import ts from 'typescript';
+
+import { formatPrettier } from './prettier';
 
 type Props = ts.NodeArray<ts.ObjectLiteralElementLike>;
 
@@ -119,10 +120,5 @@ export const transformModuleExports = (
     .createPrinter()
     .printNode(ts.EmitHint.SourceFile, transformedFile, sourceFile);
 
-  return prettier.format(text, {
-    parser: 'typescript',
-    singleQuote: true,
-    tabWidth: 2,
-    trailingComma: 'all',
-  });
+  return formatPrettier(text, { parser: 'typescript' });
 };


### PR DESCRIPTION
This replaces `extends: [require.resolve('skuba/config/eslint')]` with `extends: ['skuba']`, which is possible now that we have a dedicated shareable config `eslint-config-skuba`.