### PR TITLE
Include tsx files in ESLint linting

### DIFF
--- a/.changeset/ninety-crabs-tell.md
+++ b/.changeset/ninety-crabs-tell.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-Include tsx files in ESLint linting
+**format, lint:** Include tsx files in ESLint linting

--- a/.changeset/ninety-crabs-tell.md
+++ b/.changeset/ninety-crabs-tell.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+Include tsx files in ESLint linting

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -2,7 +2,7 @@ import { exec } from '../utils/exec';
 import { log } from '../utils/logging';
 
 export const format = async () => {
-  await exec('eslint', '--ext=js,ts', '--fix', '.');
+  await exec('eslint', '--ext=js,ts,tsx', '--fix', '.');
   log.ok('✔ ESLint');
 
   await exec('prettier', '--write', '.');

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -3,7 +3,7 @@ import { execConcurrently } from '../utils/exec';
 export const lint = () =>
   execConcurrently([
     {
-      command: 'eslint --ext=js,ts .',
+      command: 'eslint --ext=js,ts,tsx .',
       name: 'ESLint',
     },
     {


### PR DESCRIPTION
The current calls for ESLint for both checking and fixing linting errors include an explicit list of extensions to check: `js` and `ts`.

An appropriately configured skuba project is able to compile tsx files to js. Typically resolving JSX to React.createElement commands. As it's possible to write and use tsx files I'd like to have eslint run over these files.

This change will include tsx in files that are checked and fixed for eslint.