### PR TITLE
Remove duplicate lib exclusions from tsconfig.json

### DIFF
--- a/.changeset/large-moles-add.md
+++ b/.changeset/large-moles-add.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Remove duplicate `lib` exclusions from `tsconfig.json`

--- a/src/cli/configure/modules/tsconfig.test.ts
+++ b/src/cli/configure/modules/tsconfig.test.ts
@@ -116,6 +116,27 @@ describe('tsconfigModule', () => {
     expect(outputData.compilerOptions!.outDir).toBe('lib');
   });
 
+  it('removes duplicate lib patterns from  exclude option', async () => {
+    const inputFiles = {
+      'tsconfig.json':
+        '{"extends": "skuba/config/tsconfig.json", "exclude": ["lib", "lib/**/*"]}',
+    };
+
+    const outputFiles = await executeModule(
+      tsconfigModule,
+      inputFiles,
+      defaultOpts,
+    );
+
+    const outputData = parseObject(
+      outputFiles['tsconfig.json'],
+    ) as TsConfigJson;
+
+    assertDefined(outputData);
+    expect(outputData.extends).toBe('skuba/config/tsconfig.json');
+    expect(outputData.exclude).toStrictEqual(['lib*/**/*']);
+  });
+
   it('retains include option after initial setup', async () => {
     const inputFiles = {
       'tsconfig.json':

--- a/src/cli/configure/modules/tsconfig.ts
+++ b/src/cli/configure/modules/tsconfig.ts
@@ -55,6 +55,17 @@ export const tsconfigModule = async ({ type }: Options): Promise<Module> => {
 
       const outputData = merge(inputData ?? {}, baseData);
 
+      // Remove `lib/**/*` and `lib`, which duplicate `lib*/**/*`
+      if (Array.isArray(outputData.exclude)) {
+        const { exclude } = outputData;
+
+        const hasLibStar = exclude.includes('lib*/**/*');
+
+        outputData.exclude = exclude.filter(
+          (pattern) => !(hasLibStar && ['lib', 'lib/**/*'].includes(pattern)),
+        );
+      }
+
       // for optimal ESLinting, base config should compile all files and leave
       // exclusions to .eslintignore and tsconfig.build.json
       if (


### PR DESCRIPTION
This is purely cosmetic, but `skuba configure` was leaving old skubified `tsconfig.json`s like:

```json
{
  "exclude": ["lib*/**/*", "lib/**/*"]
}
```