### PR TITLE
Add `Jest.mergePreset` helper function

### DIFF
--- a/.changeset/neat-toes-burn.md
+++ b/.changeset/neat-toes-burn.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-**test:** Add `Jest.extends` helper function
+**test:** Add `Jest.extend` helper function

--- a/.changeset/neat-toes-burn.md
+++ b/.changeset/neat-toes-burn.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**test:** Add `Jest.extends` helper function

--- a/.changeset/neat-toes-burn.md
+++ b/.changeset/neat-toes-burn.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-**test:** Add `Jest.preset` helper function
+**test:** Add `Jest.mergePreset` helper function

--- a/.changeset/neat-toes-burn.md
+++ b/.changeset/neat-toes-burn.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-**test:** Add `Jest.extend` helper function
+**test:** Add `Jest.preset` helper function

--- a/README.md
+++ b/README.md
@@ -272,6 +272,26 @@ Echoes the installed version of `skuba`.
 
 Its Node.js API can be used in build and test code.
 
+### `Jest.extend`
+
+Extend the `skuba` preset with custom options.
+
+This concatenates array options like `testPathIgnorePatterns`.
+
+```js
+// jest.config.js
+
+const { Jest } = require('skuba');
+
+module.exports = Jest.extend({
+  coveragePathIgnorePatterns: ['src/testing'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+
+  // this is concatenated to the end of the built-in skuba patterns
+  testPathIgnorePatterns: ['/test\\.ts'],
+});
+```
+
 ### `Net.waitFor`
 
 Wait for a resource to start listening on a socket address.

--- a/README.md
+++ b/README.md
@@ -272,9 +272,25 @@ Echoes the installed version of `skuba`.
 
 Its Node.js API can be used in build and test code.
 
-### `Jest.extend`
+### `Jest.preset`
 
-Extend the `skuba` preset with custom options.
+The Jest preset for `skuba`.
+
+```js
+// jest.config.js
+
+const { Jest } = require('skuba');
+
+module.exports = Jest.preset;
+
+// this also works
+
+module.exports = {
+  preset: 'skuba',
+};
+```
+
+You can extend the preset by passing in additional options.
 
 This concatenates array options like `testPathIgnorePatterns`.
 
@@ -283,11 +299,11 @@ This concatenates array options like `testPathIgnorePatterns`.
 
 const { Jest } = require('skuba');
 
-module.exports = Jest.extend({
+module.exports = Jest.preset({
   coveragePathIgnorePatterns: ['src/testing'],
   setupFiles: ['<rootDir>/jest.setup.ts'],
 
-  // this is concatenated to the end of the built-in skuba patterns
+  // this is concatenated to the end of the built-in patterns
   testPathIgnorePatterns: ['/test\\.ts'],
 });
 ```

--- a/README.md
+++ b/README.md
@@ -272,25 +272,9 @@ Echoes the installed version of `skuba`.
 
 Its Node.js API can be used in build and test code.
 
-### `Jest.preset`
+### `Jest.mergePreset`
 
-The Jest preset for `skuba`.
-
-```js
-// jest.config.js
-
-const { Jest } = require('skuba');
-
-module.exports = Jest.preset;
-
-// this also works
-
-module.exports = {
-  preset: 'skuba',
-};
-```
-
-You can extend the preset by passing in additional options.
+Merge additional Jest options into the `skuba` preset.
 
 This concatenates array options like `testPathIgnorePatterns`.
 
@@ -299,7 +283,7 @@ This concatenates array options like `testPathIgnorePatterns`.
 
 const { Jest } = require('skuba');
 
-module.exports = Jest.preset({
+module.exports = Jest.mergePreset({
   coveragePathIgnorePatterns: ['src/testing'],
   setupFiles: ['<rootDir>/jest.setup.ts'],
 

--- a/jest-preset.d.ts
+++ b/jest-preset.d.ts
@@ -1,0 +1,5 @@
+import { Config } from '@jest/types';
+
+declare const moduleExports: Config.InitialOptions;
+
+export = moduleExports;

--- a/src/api/jest/index.test.ts
+++ b/src/api/jest/index.test.ts
@@ -1,8 +1,8 @@
-import { extend } from '.';
+import { preset } from '.';
 
-describe('extend', () => {
-  it('handles no props', () => {
-    const config = extend();
+describe('preset', () => {
+  it('handles static usage', () => {
+    const config = preset;
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).not.toContain('abc');
@@ -10,7 +10,7 @@ describe('extend', () => {
   });
 
   it('adds non-colliding props', () => {
-    const config = extend({ setupFiles: ['abc'] });
+    const config = preset({ setupFiles: ['abc'] });
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).not.toContain('abc');
@@ -18,7 +18,7 @@ describe('extend', () => {
   });
 
   it('merges colliding props', () => {
-    const config = extend({ collectCoverageFrom: ['abc'] });
+    const config = preset({ collectCoverageFrom: ['abc'] });
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).toContain('abc');

--- a/src/api/jest/index.test.ts
+++ b/src/api/jest/index.test.ts
@@ -1,8 +1,8 @@
-import { preset } from '.';
+import { mergePreset } from '.';
 
-describe('preset', () => {
-  it('handles static usage', () => {
-    const config = preset;
+describe('mergePreset', () => {
+  it('handles no props', () => {
+    const config = mergePreset({});
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).not.toContain('abc');
@@ -10,7 +10,7 @@ describe('preset', () => {
   });
 
   it('adds non-colliding props', () => {
-    const config = preset({ setupFiles: ['abc'] });
+    const config = mergePreset({ setupFiles: ['abc'] });
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).not.toContain('abc');
@@ -18,7 +18,7 @@ describe('preset', () => {
   });
 
   it('merges colliding props', () => {
-    const config = preset({ collectCoverageFrom: ['abc'] });
+    const config = mergePreset({ collectCoverageFrom: ['abc'] });
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).toContain('abc');

--- a/src/api/jest/index.test.ts
+++ b/src/api/jest/index.test.ts
@@ -1,0 +1,27 @@
+import { extend } from '.';
+
+describe('extend', () => {
+  it('handles no props', () => {
+    const config = extend();
+
+    expect(config).toHaveProperty('testEnvironment', 'node');
+    expect(config.collectCoverageFrom).not.toContain('abc');
+    expect(config.setupFiles).toBeUndefined();
+  });
+
+  it('adds non-colliding props', () => {
+    const config = extend({ setupFiles: ['abc'] });
+
+    expect(config).toHaveProperty('testEnvironment', 'node');
+    expect(config.collectCoverageFrom).not.toContain('abc');
+    expect(config.setupFiles).toEqual(['abc']);
+  });
+
+  it('merges colliding props', () => {
+    const config = extend({ collectCoverageFrom: ['abc'] });
+
+    expect(config).toHaveProperty('testEnvironment', 'node');
+    expect(config.collectCoverageFrom).toContain('abc');
+    expect(config.setupFiles).toEqual(['abc']);
+  });
+});

--- a/src/api/jest/index.ts
+++ b/src/api/jest/index.ts
@@ -1,0 +1,27 @@
+import { Config } from '@jest/types';
+
+import jestPreset from '../../../jest-preset';
+import { mergeRaw } from '../../cli/configure/processing/record';
+
+type Props = Pick<
+  Config.InitialOptions,
+  | 'collectCoverage'
+  | 'collectCoverageFrom'
+  | 'collectCoverageOnlyFrom'
+  | 'coveragePathIgnorePatterns'
+  | 'coverageThreshold'
+  | 'globals'
+  | 'globalSetup'
+  | 'globalTeardown'
+  | 'setupFiles'
+  | 'setupFilesAfterEnv'
+  | 'testPathIgnorePatterns'
+>;
+
+/**
+ * Extend the **skuba** preset with custom options.
+ *
+ * This concatenates array options like `testPathIgnorePatterns`.
+ */
+export const extend = (props?: Props): Config.InitialOptions =>
+  mergeRaw(jestPreset, props);

--- a/src/api/jest/index.ts
+++ b/src/api/jest/index.ts
@@ -19,9 +19,23 @@ type Props = Pick<
 >;
 
 /**
- * Extend the **skuba** preset with custom options.
+ * The Jest preset for **skuba**. Also accessible via:
  *
- * This concatenates array options like `testPathIgnorePatterns`.
+ * ```javascript
+ * module.exports = {
+ *   preset: 'skuba',
+ * };
+ * ```
+ *
+ * You can extend the preset by passing in additional options.
  */
-export const extend = (props?: Props): Config.InitialOptions =>
-  mergeRaw(jestPreset, props);
+export const preset = Object.assign(
+  jestPreset,
+
+  /**
+   * Extend the **skuba** Jest preset with additional options.
+   *
+   * This concatenates array options like `testPathIgnorePatterns`.
+   */
+  (props: Props): Config.InitialOptions => mergeRaw(jestPreset, props),
+);

--- a/src/api/jest/index.ts
+++ b/src/api/jest/index.ts
@@ -19,23 +19,9 @@ type Props = Pick<
 >;
 
 /**
- * The Jest preset for **skuba**. Also accessible via:
+ * Merge additional Jest options into the **skuba** preset.
  *
- * ```javascript
- * module.exports = {
- *   preset: 'skuba',
- * };
- * ```
- *
- * You can extend the preset by passing in additional options.
+ * This concatenates array options like `testPathIgnorePatterns`.
  */
-export const preset = Object.assign(
-  jestPreset,
-
-  /**
-   * Extend the **skuba** Jest preset with additional options.
-   *
-   * This concatenates array options like `testPathIgnorePatterns`.
-   */
-  (props: Props): Config.InitialOptions => mergeRaw(jestPreset, props),
-);
+export const mergePreset = (props: Props): Config.InitialOptions =>
+  mergeRaw(jestPreset, props);

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -101,14 +101,13 @@ gantry*.yml
     "operation": "A",
   },
   "jest.config.js": Object {
-    "data": "const { testPathIgnorePatterns } = require('skuba/config/jest');
+    "data": "const { Jest } = require('skuba');
 
-module.exports = {
+module.exports = Jest.extend({
   coveragePathIgnorePatterns: ['src/testing'],
-  preset: 'skuba',
   setupFiles: ['<rootDir>/jest.setup.ts'],
-  testPathIgnorePatterns: [...testPathIgnorePatterns, '/test\\\\\\\\.ts'],
-};
+  testPathIgnorePatterns: ['/test\\\\\\\\.ts'],
+});
 ",
     "operation": "A",
   },

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -103,7 +103,7 @@ gantry*.yml
   "jest.config.js": Object {
     "data": "const { Jest } = require('skuba');
 
-module.exports = Jest.extend({
+module.exports = Jest.preset({
   coveragePathIgnorePatterns: ['src/testing'],
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/test\\\\\\\\.ts'],

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -103,7 +103,7 @@ gantry*.yml
   "jest.config.js": Object {
     "data": "const { Jest } = require('skuba');
 
-module.exports = Jest.preset({
+module.exports = Jest.mergePreset({
   coveragePathIgnorePatterns: ['src/testing'],
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/test\\\\\\\\.ts'],

--- a/src/cli/configure/processing/record.test.ts
+++ b/src/cli/configure/processing/record.test.ts
@@ -1,4 +1,4 @@
-import { getFirstDefined, merge } from './record';
+import { getFirstDefined, merge, mergeRaw } from './record';
 
 describe('getFirstDefined', () => {
   it('handles no input', () => expect(getFirstDefined({}, [])).toBeUndefined());
@@ -25,5 +25,17 @@ describe('merge', () => {
   it('merges nested objects', () =>
     expect(
       merge({ a1: { b1: { c1: null } } }, { a1: { b1: {}, b2: true } }),
+    ).toStrictEqual({ a1: { b1: { c1: null }, b2: true } }));
+});
+
+describe('mergeRaw', () => {
+  it('concats arrays', () =>
+    expect(mergeRaw({ a: [1, 3] }, { a: [2, 4, 3] })).toStrictEqual({
+      a: [1, 3, 2, 4, 3],
+    }));
+
+  it('merges nested objects', () =>
+    expect(
+      mergeRaw({ a1: { b1: { c1: null } } }, { a1: { b1: {}, b2: true } }),
     ).toStrictEqual({ a1: { b1: { c1: null }, b2: true } }));
 });

--- a/src/cli/configure/processing/record.ts
+++ b/src/cli/configure/processing/record.ts
@@ -16,6 +16,11 @@ export const getFirstDefined = <T>(
   return;
 };
 
+/**
+ * Merge two objects together.
+ *
+ * Array properties are sorted and deduped.
+ */
 export const merge = <A, B>(obj: A, src: B) =>
   mergeWith(obj, src, (objValue: unknown, srcValue: unknown) => {
     if (isArray(objValue) && isArray(srcValue)) {
@@ -24,3 +29,13 @@ export const merge = <A, B>(obj: A, src: B) =>
 
     return;
   });
+
+/**
+ * Like `merge`, but arrays are not deduped or sorted to preserve order.
+ */
+export const mergeRaw = <A, B>(obj: A, src: B) =>
+  mergeWith(obj, src, (objValue: unknown, srcValue: unknown) =>
+    isArray(objValue) && isArray(srcValue)
+      ? objValue.concat(srcValue)
+      : undefined,
+  );

--- a/src/cli/configure/processing/typescript.test.ts
+++ b/src/cli/configure/processing/typescript.test.ts
@@ -25,6 +25,39 @@ const JEST_CONFIG = `module.exports = {
 `;
 
 describe('transformModuleExports', () => {
+  it('detects an object literal', () => {
+    const input = "module.exports = { key: 'value' };\n";
+
+    const result = transformModuleExports(input, () => ts.createNodeArray());
+
+    expect(result).toBe('module.exports = {};\n');
+  });
+
+  it('detects a single-arg call expression', () => {
+    const input = "module.exports = Jest.mergePreset({ key: 'value' });\n";
+
+    const result = transformModuleExports(input, () => ts.createNodeArray());
+
+    expect(result).toBe('module.exports = Jest.mergePreset({});\n');
+  });
+
+  it('ignores a multi-arg call expression', () => {
+    const input =
+      "module.exports = Jest.mergePreset({ key: 'value' }, null, 2);\n";
+
+    const result = transformModuleExports(input, () => ts.createNodeArray());
+
+    expect(result).toBe(input);
+  });
+
+  it('ignores a function', () => {
+    const input = 'module.exports = () => undefined;\n';
+
+    const result = transformModuleExports(input, () => ts.createNodeArray());
+
+    expect(result).toBe(input);
+  });
+
   it('works with a no-op transformer', () => {
     const result = transformModuleExports(JEST_CONFIG, (props) => props);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
-import * as Net from './api/net';
-
-export { Net };
+export * as Jest from './api/jest';
+export * as Net from './api/net';

--- a/template/base/jest.config.js
+++ b/template/base/jest.config.js
@@ -1,8 +1,7 @@
-const { testPathIgnorePatterns } = require('skuba/config/jest');
+const { Jest } = require('skuba');
 
-module.exports = {
+module.exports = Jest.extend({
   coveragePathIgnorePatterns: ['src/testing'],
-  preset: 'skuba',
   setupFiles: ['<rootDir>/jest.setup.ts'],
-  testPathIgnorePatterns: [...testPathIgnorePatterns, '/test\\.ts'],
-};
+  testPathIgnorePatterns: ['/test\\.ts'],
+});

--- a/template/base/jest.config.js
+++ b/template/base/jest.config.js
@@ -1,6 +1,6 @@
 const { Jest } = require('skuba');
 
-module.exports = Jest.extend({
+module.exports = Jest.preset({
   coveragePathIgnorePatterns: ['src/testing'],
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/test\\.ts'],

--- a/template/base/jest.config.js
+++ b/template/base/jest.config.js
@@ -1,6 +1,6 @@
 const { Jest } = require('skuba');
 
-module.exports = Jest.preset({
+module.exports = Jest.mergePreset({
   coveragePathIgnorePatterns: ['src/testing'],
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/test\\.ts'],


### PR DESCRIPTION
This concatenates array options, unlike Jest's built-in `preset` support which discards the original array elements.