### PR TITLE
Remove passWithNoTests Jest option

### DIFF
--- a/.changeset/clean-cooks-behave.md
+++ b/.changeset/clean-cooks-behave.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**test:** Fix `passWithNoTests` warning

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -40,7 +40,6 @@ module.exports = {
     '^src$': '<rootDir>/src',
     '^src/(.+)$': '<rootDir>/src/$1',
   },
-  passWithNoTests: true,
   testEnvironment: 'node',
   testPathIgnorePatterns: [
     '/node_modules.*/',


### PR DESCRIPTION
I was deceived by `@jest/types`. It seems this is a CLI-only option.

This was throwing ugly warnings but didn't otherwise hurt anyone.