### PR TITLE
Use connection reuse environment variable in Lambda

### DIFF
--- a/.changeset/eighty-monkeys-rush.md
+++ b/.changeset/eighty-monkeys-rush.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/lambda-sqs-worker: Use connection reuse environment variable

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -59,6 +59,7 @@ functions:
     reservedConcurrency: 20
     timeout: 30
     environment:
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
       DESTINATION_SNS_TOPIC_ARN: !Ref DestinationTopic
       ENVIRONMENT: ${env:ENVIRONMENT}
       REGION: ${self:provider.region}

--- a/template/lambda-sqs-worker/src/services/aws.ts
+++ b/template/lambda-sqs-worker/src/services/aws.ts
@@ -3,7 +3,6 @@ import { Agent } from 'https';
 import { SNS } from 'aws-sdk';
 
 const agent = new Agent({
-  keepAlive: true,
   rejectUnauthorized: true,
 });
 

--- a/template/lambda-sqs-worker/src/services/aws.ts
+++ b/template/lambda-sqs-worker/src/services/aws.ts
@@ -1,12 +1,5 @@
-import { Agent } from 'https';
-
 import { SNS } from 'aws-sdk';
-
-const agent = new Agent({
-  rejectUnauthorized: true,
-});
 
 export const sns = new SNS({
   apiVersion: '2010-03-31',
-  httpOptions: { agent },
 });


### PR DESCRIPTION
Replaces `keepAlive` property of https agent