### PR TITLE
Separate out "running locally" section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ so don't commit or post anything that isn't ready for the entire world to see.
   - [Prerequisites](#prerequisites)
   - [Git workflow](#git-workflow)
   - [Testing](#testing)
+  - [Running locally](#running-locally)
 - [Releases](#releases)
   - [Creating a changeset](#creating-a-changeset)
   - [Publishing a release](#publishing-a-release)
@@ -131,7 +132,9 @@ yarn test:template greeter
 rm -fr ../tmp-greeter
 ```
 
-If you want to test out any changes to the **skuba** CLI on itself,
+### Running locally
+
+If you want to try out the **skuba** CLI on itself,
 a `yarn skuba` script is configured:
 
 ```shell
@@ -145,7 +148,7 @@ yarn skuba version
 yarn skuba build
 ```
 
-If you want to test out any changes to the **skuba** CLI on another local repo,
+If you want to try out the **skuba** CLI on another local repo,
 you can use [npm link] to register your local copy as a global shell command:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Related reading:
 - [Development API reference](#development-api-reference)
 - [Runtime API reference](#runtime-api-reference)
 - [Design](#design)
-- [Development](#development)
+- [Contributing](https://github.com/seek-oss/skuba/tree/master/CONTRIBUTING.md)
 
 ## Getting started
 
@@ -396,40 +396,3 @@ Here are some highlights:
 [seek-koala]: https://github.com/seek-oss/koala
 [s2sauth]: https://github.com/SEEK-Jobs/s2sauth
 [ssod]: https://github.com/SEEK-Jobs/seek-ssod-ingress
-
-## Development
-
-### Prerequisites
-
-- Node.js 12+
-- Yarn 1.x
-
-```shell
-yarn install
-```
-
-### Lint
-
-```shell
-# fix
-yarn format
-
-# check
-yarn lint
-```
-
-### Test
-
-```shell
-# skuba itself
-yarn test
-
-# skuba templates
-yarn test:template
-```
-
-### Build
-
-```shell
-yarn build
-```


### PR DESCRIPTION
This also drops the duplicated "development" section from the README.