### PR TITLE
Redact `err.config.agent` path from error logs

### DIFF
--- a/.changeset/fluffy-moose-cry.md
+++ b/.changeset/fluffy-moose-cry.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Redact `err.config.agent` path from logs

--- a/template/koa-rest-api/src/framework/logging.ts
+++ b/template/koa-rest-api/src/framework/logging.ts
@@ -20,6 +20,7 @@ export const rootLogger = pino({
   redact: {
     censor: '🤿 REDACTED 🚩',
     paths: [
+      'err.config.agent',
       'err.config.headers.Authorization',
       'err.config.headers.authorization',
       'err.config.sockets',

--- a/template/lambda-sqs-worker/src/framework/logging.ts
+++ b/template/lambda-sqs-worker/src/framework/logging.ts
@@ -21,6 +21,7 @@ export const rootLogger = pino({
   redact: {
     censor: '🤿 REDACTED 🚩',
     paths: [
+      'err.config.agent',
       'err.config.headers.Authorization',
       'err.config.headers.authorization',
       'err.config.sockets',


### PR DESCRIPTION
This appears to be a thing in Gaxios / Node Fetch errors. There's lots of internal state that isn't suitable for logs.