### PR TITLE
Document local Lambda deployment

### DIFF
--- a/.changeset/calm-buckets-cheat.md
+++ b/.changeset/calm-buckets-cheat.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Default VERSION to local

--- a/.changeset/sweet-colts-boil.md
+++ b/.changeset/sweet-colts-boil.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Add basic deployment documentation

--- a/template/koa-rest-api/README.md
+++ b/template/koa-rest-api/README.md
@@ -6,7 +6,12 @@
 
 - [Design](#design)
 - [Development](#development)
+  - [Test](#test)
+  - [Lint](#lint)
+  - [Deploy](#deploy)
 - [Support](#support)
+  - [Dev](#dev)
+  - [Prod](#prod)
 
 ## Design
 

--- a/template/koa-rest-api/README.md
+++ b/template/koa-rest-api/README.md
@@ -2,29 +2,59 @@
 
 [![Powered by skuba](https://img.shields.io/badge/🤿%20skuba-powered-009DC4)](https://github.com/seek-oss/skuba)
 
-<!--
-
 ## Table of contents
 
-- [Usage](#usage)
 - [Design](#design)
 - [Development](#development)
 - [Support](#support)
 
-## Usage
-
-...
-
 ## Design
 
-...
+TODO: explain the design of your API here.
 
 ## Development
 
-...
+### Test
+
+```shell
+yarn test
+```
+
+### Lint
+
+```shell
+# fix
+yarn format
+
+# check
+yarn lint
+```
+
+### Deploy
+
+This project is deployed through a [Buildkite pipeline](.buildkite/pipeline.yml).
+
+- Branch commits can be deployed to the dev environment by unblocking a step in the Buildkite UI
+- Master commits are automatically deployed to the dev and prod environments in sequence
 
 ## Support
 
-...
+### Dev
 
+TODO: add support links for the dev environment.
+
+<!--
+- CloudWatch dashboard
+- Datadog dashboard
+- Splunk logs
+-->
+
+### Prod
+
+TODO: add support links for the prod environment.
+
+<!--
+- CloudWatch dashboard
+- Datadog dashboard
+- Splunk logs
 -->

--- a/template/lambda-sqs-worker/README.md
+++ b/template/lambda-sqs-worker/README.md
@@ -6,7 +6,12 @@
 
 - [Design](#design)
 - [Development](#development)
+  - [Test](#test)
+  - [Lint](#lint)
+  - [Deploy](#deploy)
 - [Support](#support)
+  - [Dev](#dev)
+  - [Prod](#prod)
 
 ## Design
 

--- a/template/lambda-sqs-worker/README.md
+++ b/template/lambda-sqs-worker/README.md
@@ -2,29 +2,70 @@
 
 [![Powered by skuba](https://img.shields.io/badge/🤿%20skuba-powered-009DC4)](https://github.com/seek-oss/skuba)
 
-<!--
-
 ## Table of contents
 
-- [Usage](#usage)
 - [Design](#design)
 - [Development](#development)
 - [Support](#support)
 
-## Usage
-
-...
-
 ## Design
 
-...
+TODO: explain the design of your worker here.
 
 ## Development
 
-...
+### Test
+
+```shell
+yarn test
+```
+
+### Lint
+
+```shell
+# fix
+yarn format
+
+# check
+yarn lint
+```
+
+### Deploy
+
+This project is deployed through a [Buildkite pipeline](.buildkite/pipeline.yml).
+
+- Branch commits can be deployed to the dev environment by unblocking a step in the Buildkite UI
+- Master commits are automatically deployed to the dev and prod environments in sequence
+
+To deploy from your local machine:
+
+```shell
+# authenticate to your dev account
+awsauth
+
+yarn build
+
+ENVIRONMENT=dev yarn deploy
+```
 
 ## Support
 
-...
+### Dev
 
+TODO: add support links for the dev environment.
+
+<!--
+- CloudWatch dashboard
+- Datadog dashboard
+- Splunk logs
+-->
+
+### Prod
+
+TODO: add support links for the prod environment.
+
+<!--
+- CloudWatch dashboard
+- Datadog dashboard
+- Splunk logs
 -->

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -64,7 +64,7 @@ functions:
       ENVIRONMENT: ${env:ENVIRONMENT}
       REGION: ${self:provider.region}
       SERVICE: ${self:service}
-      VERSION: ${env:VERSION}
+      VERSION: ${env:VERSION, 'local'}
     events:
       - sqs:
           arn: !GetAtt MessageQueue.Arn


### PR DESCRIPTION
This was raised by @BryceKK as we don't document how to do this.

To keep it a simple single-variable matter, we now default the `VERSION` environment variable to `local` if it is not supplied. I generally don't like defaults but this one is mostly harmless, and we do a similar thing with `BUILDKITE_COMMIT`.

I took the opportunity to make our READMEs slightly less bad, but they are still pretty bad.