### PR TITLE
Disable yup input coercion

### DIFF
--- a/.changeset/rare-ducks-leave.md
+++ b/.changeset/rare-ducks-leave.md
@@ -1,0 +1,21 @@
+---
+'skuba': patch
+---
+
+**template/koa-rest-api:** Disable yup input coercion
+
+By default, `yup` is ridiculously permissive in coercing inputs to match a schema:
+
+```typescript
+const birb = yup.object().shape({
+  name: yup.string().notRequired(),
+});
+
+birb.validateSync({ name: 123 });
+// { name: '123' }
+
+birb.validateSync({ name: [{ areYouKiddingMe: no }] });
+// { name: '[object Object]' }
+```
+
+This is surprising behaviour so we turn this off via `strict` mode.

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -39,6 +39,22 @@ describe('validate', () => {
       .expect(200, idDescription);
   });
 
+  it('does not coerce props', () => {
+    const idDescription = mockIdDescription();
+
+    return agent()
+      .post('/')
+      .send({ ...idDescription, id: 123 })
+      .expect(422, {
+        errors: [
+          {
+            path: 'body.id',
+            type: 'string',
+          },
+        ],
+      });
+  });
+
   it('blocks mistyped prop', () => {
     const idDescription = mockIdDescription();
 

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -27,6 +27,7 @@ export const validate = async <T>({
   try {
     return await schema.validate(input, {
       abortEarly: false,
+      strict: true,
       stripUnknown: true,
     });
   } catch (err) {


### PR DESCRIPTION
This may be the final straw. Should I just switch this over to Runtypes + `runtypes-filter`?