### PR TITLE
Switch to new-age Runtypes

### DIFF
--- a/.changeset/lucky-coins-dream.md
+++ b/.changeset/lucky-coins-dream.md
@@ -1,0 +1,9 @@
+---
+'skuba': patch
+---
+
+**template/koa-rest-api:** Switch to Runtypes
+
+Yup has overly permissive input coercion (see #151) and weaker type guarantees.
+
+We already use Runtypes in the Lambda template; other options could be explored in future.

--- a/.changeset/ninety-wasps-wave.md
+++ b/.changeset/ninety-wasps-wave.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Use better Runtypes syntax

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -8,10 +8,11 @@
     "koa-cluster": "^1.1.0",
     "koa-compose": "^4.1.0",
     "pino": "^6.3.2",
+    "runtypes": "^4.3.0",
+    "runtypes-filter": "^0.2.1",
     "seek-datadog-custom-metrics": "^3.0.0",
     "seek-koala": "^4.2.1",
-    "uuid": "^8.1.0",
-    "yup": "^0.29.1"
+    "uuid": "^8.1.0"
   },
   "devDependencies": {
     "@types/chance": "^1.1.0",
@@ -22,7 +23,6 @@
     "@types/pino": "^6.0.1",
     "@types/supertest": "^2.0.9",
     "@types/uuid": "^8.0.0",
-    "@types/yup": "^0.29.2",
     "chance": "^1.1.6",
     "pino-pretty": "^4.0.0",
     "skuba": "*",

--- a/template/koa-rest-api/src/api/jobs/postJob.test.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.test.ts
@@ -28,13 +28,6 @@ describe('postJobHandler', () => {
     return agent()
       .post('/')
       .send(jobInput)
-      .expect(422, {
-        errors: [
-          {
-            path: 'body.hirer.id',
-            type: 'required',
-          },
-        ],
-      });
+      .expect(422, 'Expected { id: string; }, but was undefined in hirer');
   });
 });

--- a/template/koa-rest-api/src/api/jobs/postJob.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.ts
@@ -4,10 +4,10 @@ import { contextLogger } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 import { validateRequestBody } from 'src/framework/validation';
 import * as storage from 'src/storage/jobs';
-import { jobInputSchema } from 'src/types/jobs';
+import { filterJobInput } from 'src/types/jobs';
 
 export const postJobHandler: Middleware = async (ctx) => {
-  const jobInput = await validateRequestBody(ctx, jobInputSchema);
+  const jobInput = validateRequestBody(ctx, filterJobInput);
 
   const job = await storage.createJob(jobInput);
 

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -1,19 +1,18 @@
 import { agentFromMiddleware } from 'src/testing/server';
 import {
   chance,
-  idDescriptionSchema,
+  filterIdDescription,
   mockIdDescription,
 } from 'src/testing/types';
 
 import { jsonBodyParser } from './middleware';
 import { validate } from './validation';
 
-const agent = agentFromMiddleware(jsonBodyParser, async (ctx) => {
-  const result = await validate({
+const agent = agentFromMiddleware(jsonBodyParser, (ctx) => {
+  const result = validate({
     ctx,
     input: ctx.request.body,
-    root: 'body',
-    schema: idDescriptionSchema,
+    filter: filterIdDescription,
   });
 
   ctx.body = result;
@@ -45,30 +44,12 @@ describe('validate', () => {
     return agent()
       .post('/')
       .send({ ...idDescription, id: null })
-      .expect(422, {
-        errors: [
-          {
-            path: 'body.id',
-            type: 'string',
-          },
-        ],
-      });
+      .expect(422, 'Expected string, but was null in id');
   });
 
   it('blocks missing props', () =>
     agent()
       .post('/')
       .send({})
-      .expect(422, {
-        errors: [
-          {
-            path: 'body.id',
-            type: 'required',
-          },
-          {
-            path: 'body.description',
-            type: 'required',
-          },
-        ],
-      }));
+      .expect(422, 'Expected string, but was undefined in id'));
 });

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -1,43 +1,23 @@
 import { Context } from 'koa';
-import * as yup from 'yup';
 
-const isObject = (value: unknown): value is Record<PropertyKey, unknown> =>
-  typeof value === 'object' && value !== null;
-
-const formatValidationError = (root: string, err: yup.ValidationError) => {
-  const errors = err.inner.map(({ params, path, type }) => ({
-    path: [root, err.path, path].filter(Boolean).join('.'),
-    type: (isObject(params) && params.type) || (type as unknown),
-  }));
-
-  return JSON.stringify({ errors }, null, 2);
-};
-
-export const validate = async <T>({
+export const validate = <T>({
   ctx,
   input,
-  root,
-  schema,
+  filter,
 }: {
   ctx: Context;
   input: unknown;
-  root: string;
-  schema: yup.Schema<T>;
+  filter: (input: unknown) => T;
 }) => {
   try {
-    return await schema.validate(input, {
-      abortEarly: false,
-      stripUnknown: true,
-    });
+    return filter(input);
   } catch (err) {
-    ctx.set('Content-Type', 'application/json');
-
-    return ctx.throw(422, formatValidationError(root, err));
+    // TODO: consider providing structured error messages for your consumers.
+    return ctx.throw(422, err instanceof Error ? err.message : String(err));
   }
 };
 
-export const validateRequestBody = async <T>(
+export const validateRequestBody = <T>(
   ctx: Context,
-  schema: yup.Schema<T>,
-): Promise<T> =>
-  validate({ ctx, input: ctx.request.body as unknown, root: 'body', schema });
+  filter: (input: unknown) => T,
+): T => validate({ ctx, input: ctx.request.body as unknown, filter });

--- a/template/koa-rest-api/src/testing/types.ts
+++ b/template/koa-rest-api/src/testing/types.ts
@@ -1,18 +1,23 @@
+/* eslint-disable new-cap */
+
 import { Chance } from 'chance';
-import * as yup from 'yup';
+import * as t from 'runtypes';
+import checkFilter from 'runtypes-filter';
 
 import { JobInput } from 'src/types/jobs';
 
+export type IdDescription = t.Static<typeof IdDescription>;
+
+const IdDescription = t.Record({
+  id: t.String,
+  description: t.String,
+});
+
+export const filterIdDescription = checkFilter(IdDescription);
+
 export const chance = new Chance();
 
-export const idDescriptionSchema = yup
-  .object({
-    id: yup.string().required(),
-    description: yup.string().required(),
-  })
-  .required();
-
-export const mockIdDescription = () => ({
+export const mockIdDescription = (): IdDescription => ({
   id: chance.guid({ version: 4 }),
   description: chance.sentence(),
 });

--- a/template/koa-rest-api/src/types/jobs.ts
+++ b/template/koa-rest-api/src/types/jobs.ts
@@ -1,4 +1,7 @@
-import * as yup from 'yup';
+/* eslint-disable new-cap */
+
+import * as t from 'runtypes';
+import checkFilter from 'runtypes-filter';
 
 export interface Job {
   id: string;
@@ -8,14 +11,12 @@ export interface Job {
   };
 }
 
-export type JobInput = yup.InferType<typeof jobInputSchema>;
+export type JobInput = t.Static<typeof JobInput>;
 
-export const jobInputSchema = yup
-  .object({
-    hirer: yup
-      .object({
-        id: yup.string().required(),
-      })
-      .required(),
-  })
-  .required();
+const JobInput = t.Record({
+  hirer: t.Record({
+    id: t.String,
+  }),
+});
+
+export const filterJobInput = checkFilter(JobInput);

--- a/template/lambda-sqs-worker/src/app.ts
+++ b/template/lambda-sqs-worker/src/app.ts
@@ -7,7 +7,7 @@ import { metricsClient } from 'src/framework/metrics';
 import { validateJson } from 'src/framework/validation';
 import { scoreJobPublishedEvent } from 'src/services/jobScorer';
 import { sendPipelineEvent } from 'src/services/pipelineEventSender';
-import { JobPublishedEvent } from 'src/types/pipelineEvents';
+import { filterJobPublishedEvent } from 'src/types/pipelineEvents';
 
 export const handler = createHandler<SQSEvent>(async (event, { logger }) => {
   const count = event.Records.length;
@@ -22,7 +22,11 @@ export const handler = createHandler<SQSEvent>(async (event, { logger }) => {
 
   const record = event.Records[0];
 
-  const publishedJob = validateJson(record.body, JobPublishedEvent);
+  // TODO: this throws an error, which will cause the Lambda function to retry
+  // the event and eventually send it to your dead-letter queue. If you don't
+  // trust your source to provide consistently well-formed input, consider
+  // catching and handling this error in code.
+  const publishedJob = validateJson(record.body, filterJobPublishedEvent);
 
   const scoredJob = await scoreJobPublishedEvent(publishedJob);
 

--- a/template/lambda-sqs-worker/src/framework/validation.test.ts
+++ b/template/lambda-sqs-worker/src/framework/validation.test.ts
@@ -1,4 +1,8 @@
-import { IdDescription, chance, mockIdDescription } from 'src/testing/types';
+import {
+  chance,
+  filterIdDescription,
+  mockIdDescription,
+} from 'src/testing/types';
 
 import { validateJson } from './validation';
 
@@ -8,20 +12,24 @@ describe('validateJson', () => {
   it('permits valid input', () => {
     const input = JSON.stringify(idDescription);
 
-    expect(validateJson(input, IdDescription)).toStrictEqual(idDescription);
+    expect(validateJson(input, filterIdDescription)).toStrictEqual(
+      idDescription,
+    );
   });
 
   it('filters additional properties', () => {
     const input = JSON.stringify({ ...idDescription, hacker: chance.name() });
 
-    expect(validateJson(input, IdDescription)).toStrictEqual(idDescription);
+    expect(validateJson(input, filterIdDescription)).toStrictEqual(
+      idDescription,
+    );
   });
 
   it('blocks mistyped prop', () => {
     const input = JSON.stringify({ ...idDescription, id: null });
 
     expect(() =>
-      validateJson(input, IdDescription),
+      validateJson(input, filterIdDescription),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Expected string, but was null in id"`,
     );
@@ -31,7 +39,7 @@ describe('validateJson', () => {
     const input = '{}';
 
     expect(() =>
-      validateJson(input, IdDescription),
+      validateJson(input, filterIdDescription),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Expected string, but was undefined in id"`,
     );
@@ -41,7 +49,7 @@ describe('validateJson', () => {
     const input = '}';
 
     expect(() =>
-      validateJson(input, IdDescription),
+      validateJson(input, filterIdDescription),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Unexpected token } in JSON at position 0"`,
     );

--- a/template/lambda-sqs-worker/src/framework/validation.ts
+++ b/template/lambda-sqs-worker/src/framework/validation.ts
@@ -1,11 +1,2 @@
-import { Runtype } from 'runtypes';
-import { filter } from 'runtypes-filter';
-
-export const validate = <T>(input: unknown, schema: Runtype<T>) => {
-  const unfilteredValue = schema.check(input);
-
-  return filter(schema, unfilteredValue);
-};
-
-export const validateJson = <T>(input: string, schema: Runtype<T>) =>
-  validate(JSON.parse(input), schema);
+export const validateJson = <T>(input: string, filter: (input: unknown) => T) =>
+  filter(JSON.parse(input));

--- a/template/lambda-sqs-worker/src/services/jobScorer.ts
+++ b/template/lambda-sqs-worker/src/services/jobScorer.ts
@@ -2,7 +2,11 @@ import {
   jobPublishedEventToScorerInput,
   jobScorerOutputToScoredEvent,
 } from 'src/mapping/jobScorer';
-import { JobScorerInput, JobScorerOutput } from 'src/types/jobScorer';
+import {
+  JobScorerInput,
+  JobScorerOutput,
+  filterJobScorerOutput,
+} from 'src/types/jobScorer';
 import { JobPublishedEvent, JobScoredEvent } from 'src/types/pipelineEvents';
 
 /* istanbul ignore next: simulation of an external service */
@@ -30,7 +34,7 @@ const scoreJob = async ({
 }: JobScorerInput): Promise<JobScorerOutput> => {
   const score = await scoringService.request(details);
 
-  return JobScorerOutput.check({
+  return filterJobScorerOutput({
     id,
     score,
   });

--- a/template/lambda-sqs-worker/src/testing/types.ts
+++ b/template/lambda-sqs-worker/src/testing/types.ts
@@ -1,19 +1,19 @@
 /* eslint-disable new-cap */
 
 import { Chance } from 'chance';
-import { Record, Static, String } from 'runtypes';
-import { validate } from 'runtypes-filter';
+import * as t from 'runtypes';
+import checkFilter from 'runtypes-filter';
 
 import { JobPublishedEvent } from 'src/types/pipelineEvents';
 
-export type IdDescription = Static<typeof IdDescription>;
+export type IdDescription = t.Static<typeof IdDescription>;
 
-export const IdDescription = Record({
-  id: String,
-  description: String,
+const IdDescription = t.Record({
+  id: t.String,
+  description: t.String,
 });
 
-validate(IdDescription);
+export const filterIdDescription = checkFilter(IdDescription);
 
 export const chance = new Chance();
 

--- a/template/lambda-sqs-worker/src/types/jobScorer.ts
+++ b/template/lambda-sqs-worker/src/types/jobScorer.ts
@@ -1,21 +1,22 @@
 /* eslint-disable new-cap */
 
-import { Number, Record, Static, String } from 'runtypes';
-import { validate } from 'runtypes-filter';
+import * as t from 'runtypes';
+import checkFilter from 'runtypes-filter';
 
-export type JobScorerInput = Static<typeof JobScorerInput>;
+export type JobScorerInput = t.Static<typeof JobScorerInput>;
 
-export const JobScorerInput = Record({
-  id: String,
-  details: String,
+const JobScorerInput = t.Record({
+  id: t.String,
+  details: t.String,
 });
 
-export type JobScorerOutput = Static<typeof JobScorerOutput>;
+export const filterJobScorerInput = checkFilter(JobScorerInput);
 
-export const JobScorerOutput = Record({
-  id: String,
-  score: Number,
+export type JobScorerOutput = t.Static<typeof JobScorerOutput>;
+
+const JobScorerOutput = t.Record({
+  id: t.String,
+  score: t.Number,
 });
 
-validate(JobScorerInput);
-validate(JobScorerOutput);
+export const filterJobScorerOutput = checkFilter(JobScorerOutput);

--- a/template/lambda-sqs-worker/src/types/pipelineEvents.ts
+++ b/template/lambda-sqs-worker/src/types/pipelineEvents.ts
@@ -1,27 +1,28 @@
 /* eslint-disable new-cap */
 
-import { Literal, Number, Record, Static, String } from 'runtypes';
-import { validate } from 'runtypes-filter';
+import * as t from 'runtypes';
+import checkFilter from 'runtypes-filter';
 
-export type JobPublishedEvent = Static<typeof JobPublishedEvent>;
+export type JobPublishedEvent = t.Static<typeof JobPublishedEvent>;
 
-export const JobPublishedEvent = Record({
-  data: Record({
-    details: String,
+const JobPublishedEvent = t.Record({
+  data: t.Record({
+    details: t.String,
   }),
-  entityId: String,
-  eventType: Literal('JobPublished'),
+  entityId: t.String,
+  eventType: t.Literal('JobPublished'),
 });
 
-export type JobScoredEvent = Static<typeof JobScoredEvent>;
+export const filterJobPublishedEvent = checkFilter(JobPublishedEvent);
 
-export const JobScoredEvent = Record({
-  data: Record({
-    score: Number,
+export type JobScoredEvent = t.Static<typeof JobScoredEvent>;
+
+const JobScoredEvent = t.Record({
+  data: t.Record({
+    score: t.Number,
   }),
-  entityId: String,
-  eventType: Literal('JobScored'),
+  entityId: t.String,
+  eventType: t.Literal('JobScored'),
 });
 
-validate(JobPublishedEvent);
-validate(JobScoredEvent);
+export const filterJobScoredEvent = checkFilter(JobScoredEvent);


### PR DESCRIPTION
This removes Yup from the Koa template. Per #151, Yup is too generous in coercing inputs by default, and its strict mode does not support the `stripUnknown` feature that I actually like in Yup.

This also updates the Lambda template with the latest in Runtypes:

- Use the default `checkFilter` as it is easier to comprehend than the manual `filter` and `validate` functions
- Import using `import * as t` to avoid collisions with built-in types