### PR TITLE
Keep AWS SDK connections alive in Koa template

### DIFF
--- a/.changeset/cyan-years-exercise.md
+++ b/.changeset/cyan-years-exercise.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/koa-rest-api:** Keep AWS SDK connections alive

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -9,9 +9,13 @@ image: '{{values "image"}}'
 region: '{{values "region"}}'
 
 env:
+  # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
+  AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
+
   ENVIRONMENT: '{{.Environment}}'
   REGION: '{{values "region"}}'
   SERVICE: '{{values "service"}}'
+
   {{range $key, $value := .Values.env}}
   {{$key}}: {{$value}}
   {{end}}

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -59,12 +59,15 @@ functions:
     reservedConcurrency: 20
     timeout: 30
     environment:
+      # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
-      DESTINATION_SNS_TOPIC_ARN: !Ref DestinationTopic
+
       ENVIRONMENT: ${env:ENVIRONMENT}
       REGION: ${self:provider.region}
       SERVICE: ${self:service}
       VERSION: ${env:VERSION, 'local'}
+
+      DESTINATION_SNS_TOPIC_ARN: !Ref DestinationTopic
     events:
       - sqs:
           arn: !GetAtt MessageQueue.Arn


### PR DESCRIPTION
I'm not sure why I only added this to the Lambda template.