### PR TITLE
feat: Simplify supertest-koa bootstrap

### DIFF
--- a/.changeset/new-lions-shout.md
+++ b/.changeset/new-lions-shout.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/koa-rest-api:** Simplify supertest-koa bootstrap

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -6,6 +6,9 @@ template="${1}"
 
 directory="tmp-${template}"
 
+echo '--- cleanup'
+rm -rf "${directory}" "../${directory}"
+
 echo '--- yarn install'
 yarn install --frozen-lockfile --ignore-optional --non-interactive
 

--- a/template/koa-rest-api/src/api/jobs/getJobs.test.ts
+++ b/template/koa-rest-api/src/api/jobs/getJobs.test.ts
@@ -5,10 +5,6 @@ import { jobRouter } from '.';
 
 const agent = agentFromRouter(jobRouter);
 
-beforeAll(agent.setup);
-
-afterAll(agent.teardown);
-
 describe('getJobsHandler', () => {
   it('provides no results on first load', () => {
     const jobInput = mockJobInput();

--- a/template/koa-rest-api/src/api/jobs/getJobs.test.ts
+++ b/template/koa-rest-api/src/api/jobs/getJobs.test.ts
@@ -9,6 +9,6 @@ describe('getJobsHandler', () => {
   it('provides no results on first load', () => {
     const jobInput = mockJobInput();
 
-    return agent().get('/').send(jobInput).expect(200, []);
+    return agent.get('/').send(jobInput).expect(200, []);
   });
 });

--- a/template/koa-rest-api/src/api/jobs/postJob.test.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.test.ts
@@ -5,10 +5,6 @@ import { jobRouter } from '.';
 
 const agent = agentFromRouter(jobRouter);
 
-beforeAll(agent.setup);
-
-afterAll(agent.teardown);
-
 describe('postJobHandler', () => {
   it('200s and allocates an ID on valid input', () => {
     const jobInput = mockJobInput();

--- a/template/koa-rest-api/src/api/jobs/postJob.test.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.test.ts
@@ -9,7 +9,7 @@ describe('postJobHandler', () => {
   it('200s and allocates an ID on valid input', () => {
     const jobInput = mockJobInput();
 
-    return agent()
+    return agent
       .post('/')
       .send(jobInput)
       .expect(200)
@@ -21,7 +21,7 @@ describe('postJobHandler', () => {
   it('422s on invalid input', () => {
     const jobInput = {};
 
-    return agent()
+    return agent
       .post('/')
       .send(jobInput)
       .expect(422, 'Expected { id: string; }, but was undefined in hirer');

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -13,14 +13,10 @@ describe('app', () => {
   it('has a happy health check', () => agent.get('/health').expect(200, ''));
 
   it('has a reachable smoke test', () =>
-    agent
-      .get('/smoke')
-      .expect(({ status }) => status !== 404));
+    agent.get('/smoke').expect(({ status }) => status !== 404));
 
   it('has a reachable nested route', () =>
-    agent
-      .get('/jobs')
-      .expect(({ status }) => status !== 404));
+    agent.get('/jobs').expect(({ status }) => status !== 404));
 
   it('has OPTIONS for a nested route', () =>
     agent.options('/jobs').expect(200).expect('allow', /HEAD/));

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -4,10 +4,6 @@ import app from './app';
 
 const agent = agentFromApp(app);
 
-beforeAll(agent.setup);
-
-afterAll(agent.teardown);
-
 describe('app', () => {
   it('exports props for skuba start', () => {
     expect(app).toHaveProperty('callback');

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -10,18 +10,18 @@ describe('app', () => {
     expect(app).toHaveProperty('port');
   });
 
-  it('has a happy health check', () => agent().get('/health').expect(200, ''));
+  it('has a happy health check', () => agent.get('/health').expect(200, ''));
 
   it('has a reachable smoke test', () =>
-    agent()
+    agent
       .get('/smoke')
       .expect(({ status }) => status !== 404));
 
   it('has a reachable nested route', () =>
-    agent()
+    agent
       .get('/jobs')
       .expect(({ status }) => status !== 404));
 
   it('has OPTIONS for a nested route', () =>
-    agent().options('/jobs').expect(200).expect('allow', /HEAD/));
+    agent.options('/jobs').expect(200).expect('allow', /HEAD/));
 });

--- a/template/koa-rest-api/src/framework/server.test.ts
+++ b/template/koa-rest-api/src/framework/server.test.ts
@@ -14,10 +14,6 @@ const router = new Router()
 
 const agent = agentFromRouter(router);
 
-beforeAll(agent.setup);
-
-afterAll(agent.teardown);
-
 describe('createApp', () => {
   beforeAll(rootLogger.spy);
 

--- a/template/koa-rest-api/src/framework/server.test.ts
+++ b/template/koa-rest-api/src/framework/server.test.ts
@@ -23,7 +23,7 @@ describe('createApp', () => {
   it('handles root route', async () => {
     middleware.mockImplementation((ctx) => (ctx.body = ''));
 
-    await agent()
+    await agent
       .get('/')
       .expect(200, '')
       .expect('server', /.+/)
@@ -51,7 +51,7 @@ describe('createApp', () => {
   it('handles nested route', async () => {
     middleware.mockImplementation((ctx) => (ctx.body = ''));
 
-    await agent()
+    await agent
       .put('/nested/123')
       .expect(200, '')
       .expect('server', /.+/)
@@ -78,7 +78,7 @@ describe('createApp', () => {
   it('handles unknown route', async () => {
     middleware.mockImplementation((ctx) => (ctx.body = ''));
 
-    await agent()
+    await agent
       .get('/unknown')
       .expect(404, 'Not Found')
       .expect('server', /.+/)
@@ -107,7 +107,7 @@ describe('createApp', () => {
 
     middleware.mockImplementation((ctx) => ctx.throw(400, message));
 
-    await agent()
+    await agent
       .get('/')
       .expect(400, message)
       .expect('server', /.+/)
@@ -136,7 +136,7 @@ describe('createApp', () => {
 
     middleware.mockImplementation((ctx) => ctx.throw(500, message));
 
-    await agent()
+    await agent
       .get('/')
       .expect(500, '')
       .expect('server', /.+/)
@@ -167,7 +167,7 @@ describe('createApp', () => {
       throw err;
     });
 
-    await agent()
+    await agent
       .get('/')
       .expect(500, '')
       .expect('server', /.+/)
@@ -197,7 +197,7 @@ describe('createApp', () => {
       throw null;
     });
 
-    await agent()
+    await agent
       .get('/')
       .expect(500, '')
       .expect('server', /.+/)
@@ -229,7 +229,7 @@ describe('createApp', () => {
       throw err;
     });
 
-    await agent()
+    await agent
       .get('/')
       .expect(500, '')
       .expect('server', /.+/)

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -8,7 +8,7 @@ import {
 import { jsonBodyParser } from './middleware';
 import { validate } from './validation';
 
-const agent agentFromMiddleware(jsonBodyParser, (ctx) => {
+const agent = agentFromMiddleware(jsonBodyParser, (ctx) => {
   const result = validate({
     ctx,
     input: ctx.request.body,

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -18,10 +18,6 @@ const agent = agentFromMiddleware(jsonBodyParser, (ctx) => {
   ctx.body = result;
 });
 
-beforeAll(agent.setup);
-
-afterAll(agent.teardown);
-
 describe('validate', () => {
   it('permits valid input', () => {
     const idDescription = mockIdDescription();

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -8,7 +8,7 @@ import {
 import { jsonBodyParser } from './middleware';
 import { validate } from './validation';
 
-const agent = agentFromMiddleware(jsonBodyParser, (ctx) => {
+const agent agentFromMiddleware(jsonBodyParser, (ctx) => {
   const result = validate({
     ctx,
     input: ctx.request.body,
@@ -22,13 +22,13 @@ describe('validate', () => {
   it('permits valid input', () => {
     const idDescription = mockIdDescription();
 
-    return agent().post('/').send(idDescription).expect(200, idDescription);
+    return agent.post('/').send(idDescription).expect(200, idDescription);
   });
 
   it('filters additional properties', () => {
     const idDescription = mockIdDescription();
 
-    return agent()
+    return agent
       .post('/')
       .send({ ...idDescription, hacker: chance.name() })
       .expect(200, idDescription);
@@ -37,14 +37,14 @@ describe('validate', () => {
   it('blocks mistyped prop', () => {
     const idDescription = mockIdDescription();
 
-    return agent()
+    return agent
       .post('/')
       .send({ ...idDescription, id: null })
       .expect(422, 'Expected string, but was null in id');
   });
 
   it('blocks missing props', () =>
-    agent()
+    agent
       .post('/')
       .send({})
       .expect(422, 'Expected string, but was undefined in id'));

--- a/template/koa-rest-api/src/testing/server.ts
+++ b/template/koa-rest-api/src/testing/server.ts
@@ -1,5 +1,3 @@
-import { Server } from 'http';
-
 import Router from '@koa/router';
 import Koa, { Middleware } from 'koa';
 import request from 'supertest';
@@ -10,8 +8,7 @@ import { createApp } from 'src/framework/server';
  * Create a new SuperTest agent from a Koa application.
  */
 export const agentFromApp = <State, Context>(app: Koa<State, Context>) => {
-  const agent: request.SuperTest<request.Test> = request.agent(app.callback());
-  return () => agent;
+  return request.agent(app.callback());
 };
 
 /**

--- a/template/koa-rest-api/src/testing/server.ts
+++ b/template/koa-rest-api/src/testing/server.ts
@@ -10,19 +10,8 @@ import { createApp } from 'src/framework/server';
  * Create a new SuperTest agent from a Koa application.
  */
 export const agentFromApp = <State, Context>(app: Koa<State, Context>) => {
-  let server: Server;
-  let agent: request.SuperTest<request.Test>;
-
-  const getAgent = () => agent;
-
-  const setup = async () => {
-    await new Promise((resolve) => (server = app.listen(undefined, resolve)));
-    agent = request.agent(server);
-  };
-
-  const teardown = () => new Promise((resolve) => server.close(resolve));
-
-  return Object.assign(getAgent, { setup, teardown });
+  const agent: request.SuperTest<request.Test> = request.agent(app.callback());
+  return () => agent;
 };
 
 /**

--- a/template/koa-rest-api/src/testing/server.ts
+++ b/template/koa-rest-api/src/testing/server.ts
@@ -7,9 +7,8 @@ import { createApp } from 'src/framework/server';
 /**
  * Create a new SuperTest agent from a Koa application.
  */
-export const agentFromApp = <State, Context>(app: Koa<State, Context>) => {
-  return request.agent(app.callback());
-};
+export const agentFromApp = <State, Context>(app: Koa<State, Context>) =>
+  request.agent(app.callback());
 
 /**
  * Create a new SuperTest agent from a set of Koa middleware.


### PR DESCRIPTION
Don't start the server and avoid the need to stop it.


> app.callback()
> Return a callback function suitable for the http.createServer() method to handle a request. You may also use this callback function to mount your Koa app in a Connect/Express app.