### PR TITLE
fix(koa-rest-api): Use per Gantry environment concurrency group in dev

### DIFF
--- a/.changeset/cuddly-mayflies-perform.md
+++ b/.changeset/cuddly-mayflies-perform.md
@@ -1,4 +1,5 @@
 ---
 'skuba': patch
 ---
-**template/koa-rest-api:** Use per Gantry environment concurrency group in dev
+
+**template/koa-rest-api:** Use per-Gantry environment concurrency group in dev

--- a/.changeset/cuddly-mayflies-perform.md
+++ b/.changeset/cuddly-mayflies-perform.md
@@ -1,0 +1,4 @@
+---
+'skuba': patch
+---
+**template/koa-rest-api:** Use per Gantry environment concurrency group in dev

--- a/template/koa-rest-api/.buildkite/pipeline.yml
+++ b/template/koa-rest-api/.buildkite/pipeline.yml
@@ -43,7 +43,7 @@ steps:
   - <<: *dev
     label: 🤞 Deploy Dev
     concurrency: 1
-    concurrency_group: <%- repoName %>/deploy/dev
+    concurrency_group: <%- teamName %>/deploy/gantry/<%- devGantryEnvironmentName %>
     plugins:
       - seek-jobs/gantry#v1.2.3:
           command: apply


### PR DESCRIPTION
Matches the production concurrency group configuration.