### PR TITLE
Sequence Validate action after Release

### DIFF
--- a/.changeset/old-baboons-rescue.md
+++ b/.changeset/old-baboons-rescue.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-Remove explicitly set env NPM_READ_TOKEN
+**template:** Remove explicitly set NPM_READ_TOKEN from Dockerfile commands

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,19 @@
 name: Validate
 
 on:
-  - pull_request
-  - push
+  pull_request:
+
+  push:
+    branches-ignore:
+      - master
+
+  workflow_run:
+    branches:
+      - master
+    types:
+      - completed
+    workflows:
+      - Release
 
 jobs:
   core:


### PR DESCRIPTION
This uses GitHub's new `workflow_run` event to sequence our Validate action to run after the Release action on the default branch. We would previously run into race conditions when we released a new version, as Validate would try to run against a version that was in the process of being released.

Resolves #110.