### PR TITLE
Avoid TSDoc linting errors on package init

### DIFF
--- a/.changeset/wet-zebras-enjoy.md
+++ b/.changeset/wet-zebras-enjoy.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/\*-npm-package:** Avoid TSDoc linting errors on init

--- a/template/oss-npm-package/README.md
+++ b/template/oss-npm-package/README.md
@@ -18,7 +18,7 @@ Please read [SEEK's Open Source RFC] before proceeding.
 
 ### `log`
 
-Writes "<%- moduleName %>" to stdout.
+Writes the module name to stdout.
 Thrilling stuff.
 
 ```typescript

--- a/template/oss-npm-package/src/index.ts
+++ b/template/oss-npm-package/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Writes "<%- moduleName %>" to stdout.
+ * Writes the module name to stdout.
  * Thrilling stuff.
  */
 export const log = () =>

--- a/template/private-npm-package/README.md
+++ b/template/private-npm-package/README.md
@@ -16,7 +16,7 @@ run `skuba init` and select the `oss-npm-package` template.
 
 ### `log`
 
-Writes "<%- moduleName %>" to stdout.
+Writes the module name to stdout.
 Thrilling stuff.
 
 ```typescript

--- a/template/private-npm-package/src/index.ts
+++ b/template/private-npm-package/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Writes "<%- moduleName %>" to stdout.
+ * Writes the module name to stdout.
  * Thrilling stuff.
  */
 export const log = () =>


### PR DESCRIPTION
Scoped module names were triggering `tsdoc-at-sign-in-word`.