### PR TITLE
Retain package comments on first configure

### DIFF
--- a/.changeset/plenty-tables-impress.md
+++ b/.changeset/plenty-tables-impress.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Retain package comments on first run

--- a/src/cli/configure/analyseConfiguration.ts
+++ b/src/cli/configure/analyseConfiguration.ts
@@ -10,6 +10,7 @@ import { diffFiles } from './analysis/project';
 interface Props {
   destinationRoot: string;
   entryPoint: string;
+  firstRun: boolean;
   type: ProjectType;
 }
 

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { Select } from 'enquirer';
+import { hasProp } from 'utils/validation';
 
 import { createInclusionFilter } from '../../utils/copy';
 import { createExec, ensureCommands } from '../../utils/exec';
@@ -82,9 +83,12 @@ export const configure = async () => {
     }
   }
 
+  const firstRun = hasProp(manifest.packageJson, 'skuba');
+
   const fixConfiguration = await analyseConfiguration({
     destinationRoot,
     entryPoint,
+    firstRun,
     type,
   });
 

--- a/src/cli/configure/modules/tsconfig.test.ts
+++ b/src/cli/configure/modules/tsconfig.test.ts
@@ -33,7 +33,7 @@ describe('tsconfigModule', () => {
     expect(outputData.compilerOptions!.paths).toEqual({ src: ['src'] });
   });
 
-  it('disables module aliasing for packages', async () => {
+  it('disables module aliasing and retains comments for packages', async () => {
     const inputFiles = {};
 
     const outputFiles = await executeModule(
@@ -54,6 +54,26 @@ describe('tsconfigModule', () => {
     assertDefined(outputData);
     expect(outputData.compilerOptions!.baseUrl).toBeUndefined();
     expect(outputData.compilerOptions!.paths).toBeUndefined();
+    expect(outputData.compilerOptions!.removeComments).toBe(false);
+  });
+
+  it('respects explicit comment removal for packages', async () => {
+    const inputFiles = {
+      'tsconfig.json': '{"compilerOptions": {"removeComments": true}}',
+    };
+
+    const outputFiles = await executeModule(
+      tsconfigModule,
+      inputFiles,
+      defaultPackageOpts,
+    );
+
+    const outputData = parseObject(
+      outputFiles['tsconfig.json'],
+    ) as TsConfigJson;
+
+    assertDefined(outputData);
+    expect(outputData.compilerOptions!.removeComments).toBe(true);
   });
 
   it('augments existing config', async () => {

--- a/src/cli/configure/modules/tsconfig.ts
+++ b/src/cli/configure/modules/tsconfig.ts
@@ -5,7 +5,10 @@ import { loadFiles } from '../processing/loadFiles';
 import { merge } from '../processing/record';
 import { Module, Options } from '../types';
 
-export const tsconfigModule = async ({ type }: Options): Promise<Module> => {
+export const tsconfigModule = async ({
+  firstRun,
+  type,
+}: Options): Promise<Module> => {
   const [buildFile, baseFile] = await Promise.all([
     readBaseTemplateFile('tsconfig.build.json'),
     readBaseTemplateFile('tsconfig.json'),
@@ -72,6 +75,16 @@ export const tsconfigModule = async ({ type }: Options): Promise<Module> => {
         !initialFiles['tsconfig.json']?.includes('skuba/config/tsconfig.json')
       ) {
         delete outputData.include;
+      }
+
+      // Retain comments for package documentation
+      if (
+        firstRun &&
+        type === 'package' &&
+        isObject(outputData.compilerOptions) &&
+        !outputData.compilerOptions.removeComments
+      ) {
+        outputData.compilerOptions.removeComments = false;
       }
 
       return formatObject(outputData);

--- a/src/cli/configure/testing/module.ts
+++ b/src/cli/configure/testing/module.ts
@@ -7,12 +7,14 @@ export function assertDefined<T>(value?: T): asserts value is T {
 export const defaultOpts: Options = {
   destinationRoot: '/tmp',
   entryPoint: 'src/app.ts',
+  firstRun: true,
   type: 'application',
 };
 
 export const defaultPackageOpts: Options = {
   destinationRoot: '/tmp',
   entryPoint: 'src/index.ts',
+  firstRun: true,
   type: 'package',
 };
 

--- a/src/cli/configure/types.ts
+++ b/src/cli/configure/types.ts
@@ -31,5 +31,6 @@ export type Module = Record<string, FileProcessor>;
 export interface Options {
   destinationRoot: string;
   entryPoint: string;
+  firstRun: boolean;
   type: ProjectType;
 }


### PR DESCRIPTION
A number of our older packages don't seem to retain comments in the compiled TypeScript. This makes the first configure (i.e. when migrating from another toolkit) default to retaining comments.