### PR TITLE
Include JSON files in package bundles

### DIFF
--- a/.changeset/heavy-starfishes-build.md
+++ b/.changeset/heavy-starfishes-build.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure, template/\*-npm-package:** Pack JSON files

--- a/docs/migrating-from-seek-module-toolkit.md
+++ b/docs/migrating-from-seek-module-toolkit.md
@@ -67,7 +67,12 @@ Expect something like this:
 
 ```jsonc
 {
-  "files": ["lib*/**/*.d.ts", "lib*/**/*.js", "lib*/**/*.js.map"],
+  "files": [
+    "lib*/**/*.d.ts",
+    "lib*/**/*.js",
+    "lib*/**/*.js.map",
+    "lib*/**/*.json"
+  ],
   "main": "./lib-commonjs/index.js",
   "main": "./lib-es2015/index.js",
   "types": "./lib-types/index.d.ts"

--- a/src/cli/configure/modules/package.test.ts
+++ b/src/cli/configure/modules/package.test.ts
@@ -51,7 +51,12 @@ describe('packageModule', () => {
     const outputData = parsePackage(outputFiles['package.json']);
 
     expect(outputData).toMatchObject({
-      files: ['lib*/**/*.d.ts', 'lib*/**/*.js', 'lib*/**/*.js.map'],
+      files: [
+        'lib*/**/*.d.ts',
+        'lib*/**/*.js',
+        'lib*/**/*.js.map',
+        'lib*/**/*.json',
+      ],
       license: 'UNLICENSED',
       main: './lib-commonjs/index.js',
       module: './lib-es2015/index.js',
@@ -186,6 +191,7 @@ describe('packageModule', () => {
         'lib*/**/*.d.ts',
         'lib*/**/*.js',
         'lib*/**/*.js.map',
+        'lib*/**/*.json',
         'something-else',
       ],
       license: 'UNLICENSED',

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -9,6 +9,7 @@ const DEFAULT_PACKAGE_FILES = [
   'lib*/**/*.d.ts',
   'lib*/**/*.js',
   'lib*/**/*.js.map',
+  'lib*/**/*.json',
 ];
 
 export const packageModule = async ({

--- a/template/oss-npm-package/_package.json
+++ b/template/oss-npm-package/_package.json
@@ -4,7 +4,12 @@
   "devDependencies": {
     "skuba": "*"
   },
-  "files": ["lib*/**/*.d.ts", "lib*/**/*.js", "lib*/**/*.js.map"],
+  "files": [
+    "lib*/**/*.d.ts",
+    "lib*/**/*.js",
+    "lib*/**/*.js.map",
+    "lib*/**/*.json"
+  ],
   "license": "MIT",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-es2015/index.js",

--- a/template/private-npm-package/_package.json
+++ b/template/private-npm-package/_package.json
@@ -4,7 +4,12 @@
   "devDependencies": {
     "skuba": "*"
   },
-  "files": ["lib*/**/*.d.ts", "lib*/**/*.js", "lib*/**/*.js.map"],
+  "files": [
+    "lib*/**/*.d.ts",
+    "lib*/**/*.js",
+    "lib*/**/*.js.map",
+    "lib*/**/*.json"
+  ],
   "license": "UNLICENSED",
   "main": "./lib-commonjs/index.js",
   "module": "./lib-es2015/index.js",


### PR DESCRIPTION
This is something that should be expected to _just work_ and it didn't. JSON deserves to be a special case as it doesn't require packaging hacks as described in our migration documentation; it can be properly resolved and bundled by TypeScript's built-in `resolveJsonModules`.

https://github.com/seek-oss/skuba/blob/master/docs/migrating-from-seek-module-toolkit.md#building