### PR TITLE
Qualify `awsRequestId` log field

### DIFF
--- a/.changeset/seven-rules-brake.md
+++ b/.changeset/seven-rules-brake.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Qualify `awsRequestId` log field

--- a/template/lambda-sqs-worker/src/framework/logging.ts
+++ b/template/lambda-sqs-worker/src/framework/logging.ts
@@ -39,5 +39,5 @@ export const rootLogger = pino({
 });
 
 /* istanbul ignore next: pino interface */
-export const contextLogger = (ctx: Context) =>
-  rootLogger.child({ requestId: ctx.awsRequestId });
+export const contextLogger = ({ awsRequestId }: Context) =>
+  rootLogger.child({ awsRequestId });


### PR DESCRIPTION
Plain `requestId` was a bit ambiguous as we also have concepts like an `X-Request-Id` header.