### PR TITLE
Fix bad import in configure

### DIFF
--- a/.changeset/forty-students-exercise.md
+++ b/.changeset/forty-students-exercise.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Fix bad import

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 
 import { Select } from 'enquirer';
-import { hasProp } from 'utils/validation';
 
 import { createInclusionFilter } from '../../utils/copy';
 import { createExec, ensureCommands } from '../../utils/exec';
 import { log } from '../../utils/logging';
 import { showLogo } from '../../utils/logo';
 import { BASE_TEMPLATE_DIR } from '../../utils/template';
+import { hasProp } from '../../utils/validation';
 
 import { analyseConfiguration } from './analyseConfiguration';
 import { analyseDependencies } from './analyseDependencies';


### PR DESCRIPTION
This is causing errors on `skuba configure`.

```
Error: Cannot find module 'utils/validation'
```