### PR TITLE
Improve concurrently error output

### DIFF
--- a/.changeset/lovely-owls-matter.md
+++ b/.changeset/lovely-owls-matter.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**build-package, lint:** Colour code subprocess output

--- a/.changeset/lucky-beds-shave.md
+++ b/.changeset/lucky-beds-shave.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-**lint:** Clean up error output
+**build-package, lint:** Clean up error output

--- a/.changeset/lucky-beds-shave.md
+++ b/.changeset/lucky-beds-shave.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**lint:** Clean up error output

--- a/src/cli/buildPackage.ts
+++ b/src/cli/buildPackage.ts
@@ -6,15 +6,18 @@ export const buildPackage = () =>
       command:
         'tsc --module CommonJS --outDir lib-commonjs --project tsconfig.build.json',
       name: 'commonjs',
+      prefixColor: 'green',
     },
     {
       command:
         'tsc --module ES2015 --outDir lib-es2015 --project tsconfig.build.json',
       name: 'es2015',
+      prefixColor: 'yellow',
     },
     {
       command:
         'tsc --allowJS false --declaration --emitDeclarationOnly --outDir lib-types --project tsconfig.build.json',
       name: 'types',
+      prefixColor: 'blue',
     },
   ]);

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -5,13 +5,16 @@ export const lint = () =>
     {
       command: 'eslint --ext=js,ts,tsx .',
       name: 'ESLint',
+      prefixColor: 'magenta',
     },
     {
       command: 'prettier --check .',
       name: 'Prettier',
+      prefixColor: 'cyan',
     },
     {
       command: 'tsc --noEmit',
       name: 'tsc',
+      prefixColor: 'blue',
     },
   ]);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,7 +1,23 @@
+/* eslint-disable new-cap */
+
 import { ExecaError } from 'execa';
+import * as t from 'runtypes';
 
 import { log } from './logging';
 import { hasNumberProp, hasProp } from './validation';
+
+export type ConcurrentlyErrors = t.Static<typeof ConcurrentlyErrors>;
+
+export const ConcurrentlyErrors = t.Array(
+  t.Record({
+    command: t.Record({
+      command: t.String,
+      name: t.String,
+    }),
+    index: t.Number,
+    exitCode: t.Number,
+  }),
+);
 
 const isExecaError = (err: unknown): err is ExecaError =>
   hasNumberProp(err, 'exitCode');

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -1,12 +1,13 @@
 import stream from 'stream';
 import util from 'util';
 
+import chalk from 'chalk';
 import concurrently from 'concurrently';
 import execa, { ExecaChildProcess } from 'execa';
 import npmRunPath from 'npm-run-path';
 import npmWhich from 'npm-which';
 
-import { isErrorWithCode } from './error';
+import { ConcurrentlyErrors, isErrorWithCode } from './error';
 import { log } from './logging';
 
 class YarnWarningFilter extends stream.Transform {
@@ -34,6 +35,7 @@ export type Exec = (
 interface ExecConcurrentlyCommand {
   command: string;
   name: string;
+  prefixColor?: string;
 }
 
 type ExecOptions = execa.Options & { streamStdio?: true | 'yarn' };
@@ -78,19 +80,49 @@ export const createExec = (opts: ExecOptions): Exec => (command, ...args) =>
 
 export const exec: Exec = (command, ...args) => runCommand(command, args);
 
-export const execConcurrently = (commands: ExecConcurrentlyCommand[]) => {
+export const execConcurrently = async (commands: ExecConcurrentlyCommand[]) => {
   const maxNameLength = commands.reduce(
     (length, command) => Math.max(length, command.name.length),
     0,
   );
 
-  return concurrently(
-    commands.map(({ command, name }) => ({
-      command,
-      env: envWithPath,
-      name: name.padEnd(maxNameLength),
-    })),
-  );
+  try {
+    await concurrently(
+      commands.map(({ command, name, prefixColor }) => ({
+        command,
+        env: envWithPath,
+        name: name.padEnd(maxNameLength),
+        prefixColor,
+      })),
+    );
+  } catch (err: unknown) {
+    const result = ConcurrentlyErrors.validate(err);
+
+    if (!result.success) {
+      throw err;
+    }
+
+    const messages = result.value
+      .filter(({ exitCode }) => exitCode !== 0)
+      .sort(({ index: indexA }, { index: indexB }) => indexA - indexB)
+      .map(
+        (a) =>
+          `[${a.command.name}] ${chalk.bold(
+            a.command.command,
+          )} exited with code ${chalk.bold(a.exitCode)}`,
+      );
+
+    log.newline();
+
+    messages.forEach((message) => log.err(message));
+    log.newline();
+
+    throw Error(
+      `${messages.length} subprocess${
+        messages.length === 1 ? '' : 'es'
+      } failed.`,
+    );
+  }
 };
 
 export const ensureCommands = async (...names: string[]) => {


### PR DESCRIPTION
This regressed at some point without us noticing.

---

Before:

```
[object Object],[object Object],[object Object]
```

After:

<img width="782" alt="Screen Shot 2020-08-26 at 8 34 34 pm" src="https://user-images.githubusercontent.com/25572311/91294004-366a9f00-e7dc-11ea-8fb8-b132eca4534f.png">

<img width="967" alt="Screen Shot 2020-08-26 at 8 35 53 pm" src="https://user-images.githubusercontent.com/25572311/91294016-39fe2600-e7dc-11ea-9444-dd231ef79f04.png">
