### PR TITLE
Include aws-sdk in Lambda bundle

### DIFF
--- a/.changeset/good-singers-provide.md
+++ b/.changeset/good-singers-provide.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Include `aws-sdk` in bundle

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "aws-sdk": "^2.702.0",
     "seek-datadog-custom-metrics": "^3.0.0",
     "skuba-dive": "^1.1.0",
     "pino": "^6.3.2",
@@ -11,7 +12,6 @@
     "@types/chance": "^1.1.0",
     "@types/node": "^14.0.13",
     "@types/pino": "^6.3.0",
-    "aws-sdk": "^2.702.0",
     "chance": "^1.1.6",
     "pino-pretty": "^4.0.0",
     "serverless": "^1.73.1",


### PR DESCRIPTION
The Lambda runtime includes its own version of the SDK, but this ensures a matching version and circumvents bundling issues like we're currently seeing with the latest SDK and Serverless.