### PR TITLE
Do not typecheck with `start`

### DIFF
--- a/.changeset/chilled-bats-argue.md
+++ b/.changeset/chilled-bats-argue.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**start:** Allow execution despite typechecking errors

--- a/src/cli/start/index.ts
+++ b/src/cli/start/index.ts
@@ -42,6 +42,7 @@ export const start = async () => {
   return exec(
     'ts-node-dev',
     '--respawn',
+    '--transpile-only',
     path.join(__dirname, 'http'),
     entryPoint,
     String(port),


### PR DESCRIPTION
This is the default with e.g. sku and I could've sworn that it was working this way in earlier versions of skuba. We could surface a separate command to run typechecking interactively, but that's probably not the responsibility of `start`.