### PR TITLE
Remove koa-cluster from template

### DIFF
--- a/.changeset/thick-seas-notice.md
+++ b/.changeset/thick-seas-notice.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+Remove koa-cluster from koa-rest-api template

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -64,4 +64,4 @@ ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD npx --no-install koa-cluster lib/app
+CMD node lib/listen

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -5,7 +5,6 @@
     "hot-shots": "^7.5.0",
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.3.0",
-    "koa-cluster": "^1.1.0",
     "koa-compose": "^4.1.0",
     "pino": "^6.3.2",
     "runtypes": "^5.0.1",

--- a/template/koa-rest-api/src/listen.ts
+++ b/template/koa-rest-api/src/listen.ts
@@ -1,9 +1,14 @@
 import app from './app';
 import { rootLogger } from './framework/logging';
 
-// This implements a minimal version of `koa-cluster`'s interface.
+// This implements a minimal version of `koa-cluster`'s interface
 // If your application is deployed with more than 1 vCPU you can delete this
 // file and use `koa-cluster` to run `lib/app`.
 
-rootLogger.debug(`listening on port ${app.port}`);
-app.listen(app.port);
+const listener = app.listen(app.port, () => {
+  const address = listener.address();
+
+  if (typeof address === 'object' && address) {
+    rootLogger.debug(`listening on port ${address.port}`);
+  }
+});

--- a/template/koa-rest-api/src/listen.ts
+++ b/template/koa-rest-api/src/listen.ts
@@ -1,0 +1,9 @@
+import app from './app';
+import { rootLogger } from './framework/logging';
+
+// This implements a minimal version of `koa-cluster`'s interface.
+// If your application is deployed with more than 1 vCPU you can delete this
+// file and use `koa-cluster` to run `lib/app`.
+
+rootLogger.debug(`listening on port ${app.port}`);
+app.listen(app.port);


### PR DESCRIPTION
The benefit of `koa-cluster` with less than 1 vCPU hadn't been properly established. On Fargate AWS will expose multiple hyperthreads but according to our TAM they'll be throttled to use less than 100% CPU usage in total.

Benchmarking across three high-volume Indirect services with a variety of workloads has confirmed this. Their response latency, CPU usage, etc. remain unaffected but their memory usage is reduced 20-40%. This should also improve the efficiency of any in-memory caches the services have.

This keeps the same basic layout as before but with a stub `listen.ts` taking the place of `koa-cluster`. This still allows easy use of `koa-cluster` and reduces forward/backwards compatibility issues with existing Skuba apps.