### PR TITLE
feat(rest api): Add default CPU and memory settings

### DIFF
--- a/rich-books-confess.md
+++ b/rich-books-confess.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/*-rest-api:** Reduce default CPU and memory

--- a/rich-books-confess.md
+++ b/rich-books-confess.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-**template/*-rest-api:** Reduce default CPU and memory
+**template/\*-rest-api:** Reduce default CPU and memory

--- a/template/express-rest-api/gantry.apply.yml
+++ b/template/express-rest-api/gantry.apply.yml
@@ -33,6 +33,9 @@ authentication:
     - /health
     - /
 
+cpu: 256
+memory: 512
+
 autoScaling:
   cpuThreshold: 50
   maxCount: {{values "maxInstanceCount"}}

--- a/template/express-rest-api/gantry.apply.yml
+++ b/template/express-rest-api/gantry.apply.yml
@@ -33,13 +33,13 @@ authentication:
     - /health
     - /
 
-cpu: 256
-memory: 512
-
 autoScaling:
   cpuThreshold: 50
   maxCount: {{values "maxInstanceCount"}}
   minCount: {{values "minInstanceCount"}}
+
+cpu: 256
+memory: 512
 
 deployment:
   # Ignore alarms otherwise we can't deploy to a failed environment (SEEK-Jobs/gantry#488)

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -39,6 +39,9 @@ autoScaling:
   maxCount: {{values "maxInstanceCount"}}
   minCount: {{values "minInstanceCount"}}
 
+cpu: 256
+memory: 512
+
 deployment:
   # Ignore alarms otherwise we can't deploy to a failed environment (SEEK-Jobs/gantry#488)
   ignoreAlarms: true


### PR DESCRIPTION
Adds lower default memory and CPU values for Koa apps.

As @etaoins mentioned elsewhere, the higher Gantry defaults make sense without knowing what the image/runtime will be, e.g a JVM app that may need more memory just to start up.

For skuba where we know the runtime is Node, the lowest available Fargate options seem like a sane default.