### PR TITLE
Align greeter Dockerfile stages

### DIFF
--- a/.changeset/short-ladybugs-brush.md
+++ b/.changeset/short-ladybugs-brush.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/greeter:** Align Dockerfile stages

--- a/template/greeter/Dockerfile
+++ b/template/greeter/Dockerfile
@@ -14,11 +14,15 @@ RUN \
 
 ###
 
-FROM node:12-alpine AS build
+FROM node:12-alpine AS dev-deps
 
 WORKDIR /workdir
 
 COPY --from=unsafe-dev-deps /workdir .
+
+###
+
+FROM dev-deps AS build
 
 COPY . .
 


### PR DESCRIPTION
This aligns with the Lambda template and provides a generally useful `dev-deps` stage to target for e.g. ECR caching.