### PR TITLE
Switch default branch to `main`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,6 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master",
+  "baseBranch": "main",
   "updateInternalDependencies": "patch"
 }

--- a/.changeset/lucky-dragons-warn.md
+++ b/.changeset/lucky-dragons-warn.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Default branch to `main` for new repos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - beta
-      - master
+      - main
 
 jobs:
   release:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,11 +5,11 @@ on:
 
   push:
     branches-ignore:
-      - master
+      - main
 
   workflow_run:
     branches:
-      - master
+      - main
     types:
       - completed
     workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,7 +169,7 @@
 
   `seek-module-toolkit` users can now install `skuba` and run `skuba configure` to migrate their configuration.
 
-  Care should be taken around the [change in build directories](https://github.com/seek-oss/skuba/blob/master/docs/migrating-from-seek-module-toolkit.md#building).
+  Care should be taken around the [change in build directories](https://github.com/seek-oss/skuba/blob/main/docs/migrating-from-seek-module-toolkit.md#building).
 
 - f2f3925: **eslint:** skuba is now usable as a shareable config
 
@@ -186,7 +186,7 @@
 
   You can now build your project with Babel instead of tsc. Experimentally.
 
-  See [docs/babel.md](https://github.com/seek-oss/skuba/tree/master/docs/babel.md) for details.
+  See [docs/babel.md](https://github.com/seek-oss/skuba/tree/main/docs/babel.md) for details.
 
 - b23bd23: **jest:** skuba is now usable as a preset
 
@@ -324,7 +324,7 @@
 
 - 0d3f0ad: **build-package:** Add opinionated command to replace `smt build`
 
-  See the [migration documentation](https://github.com/seek-oss/skuba/blob/master/docs/migrating-from-seek-module-toolkit.md) for more information.
+  See the [migration documentation](https://github.com/seek-oss/skuba/blob/main/docs/migrating-from-seek-module-toolkit.md) for more information.
 
 ### Patch Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,11 @@ yarn install
 
 We use [GitHub flow](https://guides.github.com/introduction/flow/).
 
-Create a new branch off of the latest commit on master:
+Create a new branch off of the latest commit on main:
 
 ```shell
 git fetch origin
-git switch --create your-branch-name origin/master
+git switch --create your-branch-name origin/main
 ```
 
 Develop, [test](#testing) and commit your changes on this branch.
@@ -96,7 +96,7 @@ git push --set-upstream fork your-branch-name
 ```
 
 A maintainer will get to your pull request and review the changes.
-If all is well, they will merge your pull request into master.
+If all is well, they will merge your pull request into main.
 
 ### Testing
 
@@ -234,10 +234,10 @@ We currently have limited support for prereleases on the `beta` [dist-tag].
 This can only be performed by a maintainer.
 
 ```shell
-# revert beta branch to match master
+# revert beta branch to match main
 git fetch origin
 git switch beta
-git reset --hard origin/master
+git reset --hard origin/main
 
 # stage a beta release
 yarn changeset pre enter beta
@@ -261,7 +261,7 @@ git push --set-upstream origin beta
 ```
 
 [#typescriptification]: https://seekchat.slack.com/channels/typescriptification
-[changelog]: https://github.com/seek-oss/skuba/blob/master/CHANGELOG.md
+[changelog]: https://github.com/seek-oss/skuba/blob/main/CHANGELOG.md
 [changesets]: https://github.com/atlassian/changesets
 [create a pull request]: https://github.com/seek-oss/skuba/compare
 [dist-tag]: https://docs.npmjs.com/cli/dist-tag

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 ╰───╰─┴─╰───╯───╯── ╰
 ```
 
-[![GitHub Release](https://github.com/seek-oss/skuba/workflows/Release/badge.svg?branch=master)](https://github.com/seek-oss/skuba/actions?query=workflow%3ARelease)
-[![GitHub Validate](https://github.com/seek-oss/skuba/workflows/Validate/badge.svg?branch=master)](https://github.com/seek-oss/skuba/actions?query=workflow%3AValidate)
+[![GitHub Release](https://github.com/seek-oss/skuba/workflows/Release/badge.svg?branch=main)](https://github.com/seek-oss/skuba/actions?query=workflow%3ARelease)
+[![GitHub Validate](https://github.com/seek-oss/skuba/workflows/Validate/badge.svg?branch=main)](https://github.com/seek-oss/skuba/actions?query=workflow%3AValidate)
 [![Node.js version](https://img.shields.io/badge/node-%3E%3D%2012-brightgreen)](https://nodejs.org/en/)
 [![npm package](https://img.shields.io/npm/v/skuba)](https://www.npmjs.com/package/skuba)
 
@@ -34,7 +34,7 @@ Related reading:
 - [Development API reference](#development-api-reference)
 - [Runtime API reference](#runtime-api-reference)
 - [Design](#design)
-- [Contributing](https://github.com/seek-oss/skuba/tree/master/CONTRIBUTING.md)
+- [Contributing](https://github.com/seek-oss/skuba/tree/main/CONTRIBUTING.md)
 
 ## Getting started
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/fs-extra": "9.0.1",
     "@types/lodash.mergewith": "4.6.6",
     "@types/npm-which": "3.0.0",
+    "@types/semantic-release": "17.1.0",
     "type-fest": "0.16.0"
   },
   "dependencies": {

--- a/src/cli/configure/analysis/package.ts
+++ b/src/cli/configure/analysis/package.ts
@@ -92,7 +92,7 @@ export const generateNotices = ({
       log.warn(
         'Read more:',
         log.bold(
-          'https://github.com/seek-oss/skuba/blob/master/docs/migrating-from-seek-module-toolkit.md#building',
+          'https://github.com/seek-oss/skuba/blob/main/docs/migrating-from-seek-module-toolkit.md#building',
         ),
       );
     };

--- a/src/cli/init/git.ts
+++ b/src/cli/init/git.ts
@@ -16,7 +16,7 @@ export const initialiseRepo = async (
 ) => {
   await exec('git', 'init');
 
-  await exec(
+  const result = await exec(
     'git',
     '-c',
     'user.email=<>',
@@ -28,8 +28,13 @@ export const initialiseRepo = async (
     'skuba <>',
     '--message',
     'Initial commit',
-    '--quiet',
   );
+
+  // For compatibility, otherwise we could use Git 2.28's init.defaultBranch
+  if (result.stdout.includes('master')) {
+    await exec('git', 'checkout', '-b', 'main');
+    await exec('git', 'branch', '-D', 'master');
+  }
 
   await exec(
     'git',

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -96,5 +96,5 @@ export const init = async () => {
 
   log.newline();
   log.ok(log.bold('cd', destinationDir));
-  log.ok(log.bold('git push --set-upstream origin master'));
+  log.ok(log.bold('git push --set-upstream origin main'));
 };

--- a/src/cli/release.ts
+++ b/src/cli/release.ts
@@ -1,5 +1,40 @@
-import { exec } from '../utils/exec';
+import semanticRelease from 'semantic-release';
+
+import { log } from '../utils/logging';
+
+const DEFAULT_BRANCH =
+  process.env.DEFAULT_BRANCH_NAME ||
+  process.env.BUILDKITE_PIPELINE_DEFAULT_BRANCH ||
+  'master';
+
+/**
+ * {@link https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches}
+ */
+const BRANCHES = [
+  '+([0-9])?(.{+([0-9]),x}).x',
+  DEFAULT_BRANCH,
+  'next',
+  'next-major',
+  {
+    name: 'beta',
+    prerelease: true,
+  },
+  {
+    name: 'alpha',
+    prerelease: true,
+  },
+];
 
 export const release = async () => {
-  await exec('semantic-release', '--success', 'false');
+  const result = await semanticRelease({
+    branches: BRANCHES,
+  });
+
+  if (!result) {
+    return log.plain('Release skipped.');
+  }
+
+  const { type, version } = result.nextRelease;
+
+  log.ok('Released', type, 'version', log.bold(version));
 };

--- a/template/express-rest-api/.buildkite/pipeline.yml
+++ b/template/express-rest-api/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
 
   - wait
   - block: 🙋🏻‍♀️ Deploy Dev
-    branches: '!master'
+    branches: '!${BUILDKITE_PIPELINE_DEFAULT_BRANCH}'
 
   - <<: *dev
     label: 🤞 Deploy Dev
@@ -57,7 +57,7 @@ steps:
 
   - <<: *prod
     label: 🚀 Deploy Prod
-    branches: master
+    branches: ${BUILDKITE_PIPELINE_DEFAULT_BRANCH}
     concurrency: 1
     concurrency_group: <%- teamName %>/deploy/gantry/<%- prodGantryEnvironmentName %>
     plugins:

--- a/template/koa-rest-api/.buildkite/pipeline.yml
+++ b/template/koa-rest-api/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
 
   - wait
   - block: 🙋🏻‍♀️ Deploy Dev
-    branches: '!master'
+    branches: '!${BUILDKITE_PIPELINE_DEFAULT_BRANCH}'
 
   - <<: *dev
     label: 🤞 Deploy Dev
@@ -57,7 +57,7 @@ steps:
 
   - <<: *prod
     label: 🚀 Deploy Prod
-    branches: master
+    branches: ${BUILDKITE_PIPELINE_DEFAULT_BRANCH}
     concurrency: 1
     concurrency_group: <%- teamName %>/deploy/gantry/<%- prodGantryEnvironmentName %>
     plugins:

--- a/template/lambda-sqs-worker/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker/.buildkite/pipeline.yml
@@ -63,7 +63,7 @@ steps:
 
   - wait
   - block: 🙋🏻‍♀️ Deploy Dev
-    branches: '!master'
+    branches: '!${BUILDKITE_PIPELINE_DEFAULT_BRANCH}'
 
   - <<: *dev
     <<: *deploy
@@ -75,7 +75,7 @@ steps:
 
   - <<: *prod
     <<: *deploy
-    branches: master
+    branches: ${BUILDKITE_PIPELINE_DEFAULT_BRANCH}
     command: yarn deploy
     concurrency_group: <%- repoName %>/deploy/prod
     label: 🚀 Deploy Prod

--- a/template/oss-npm-package/.github/workflows/release.yml
+++ b/template/oss-npm-package/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - beta
-      - master
+      - main
 
 jobs:
   release:

--- a/template/oss-npm-package/README.md
+++ b/template/oss-npm-package/README.md
@@ -76,7 +76,7 @@ on:
     branches:
       # add others as necessary
       - beta
-      - master
+      - main
       # - alpha
 ```
 
@@ -86,7 +86,7 @@ To set up this repo for publishing, follow the instructions in our [OSS npm pack
 
 ### Releasing latest
 
-Commits to the `master` branch will be released with the `latest` tag,
+Commits to the `main` branch will be released with the `latest` tag,
 which is the default used when running `npm install` or `yarn install`.
 
 ### Releasing other dist-tags
@@ -99,7 +99,7 @@ Here are some branches that **semantic-release** supports by default:
 
 | Git branch | npm dist-tag |
 | :--------- | :----------- |
-| master     | latest       |
+| main       | latest       |
 | alpha      | alpha        |
 | beta       | beta         |
 | next       | next         |

--- a/template/private-npm-package/README.md
+++ b/template/private-npm-package/README.md
@@ -72,7 +72,7 @@ To set up this repo for publishing, follow the instructions in Gutenberg's [inst
 
 ### Releasing latest
 
-Commits to the `master` branch will be released with the `latest` tag,
+Commits to the `main` branch will be released with the `latest` tag,
 which is the default used when running `npm install` or `yarn install`.
 
 ### Releasing other dist-tags
@@ -85,7 +85,7 @@ Here are some branches that **semantic-release** supports by default:
 
 | Git branch | npm dist-tag |
 | :--------- | :----------- |
-| master     | latest       |
+| main       | latest       |
 | alpha      | alpha        |
 | beta       | beta         |
 | next       | next         |

--- a/yarn.lock
+++ b/yarn.lock
@@ -1771,6 +1771,13 @@
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/semantic-release@17.1.0":
+  version "17.1.0"
+  resolved "https://registry.yarnpkg.com/@types/semantic-release/-/semantic-release-17.1.0.tgz#6c5f198c604fe938367aa6ef9c1a7f5253bbe901"
+  integrity sha512-p8g5EWp6kQ601GPSi1Xb4+z2YB4J1muGkB7Xy5eRX/fZfbKRfW33j5D8JHb9D4C8jx5w14eLvQufZ5IfZZsoEA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/semver@^6.0.0":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.1.tgz#a236185670a7860f1597cf73bea2e16d001461ba"


### PR DESCRIPTION
Our last September deadline is GitHub's new default branch. Existing repos are unaffected, so this is concerned with initialising new repos with `main`.