### PR TITLE
Skip pre-build in Docker Compose service

### DIFF
--- a/.changeset/two-trees-own.md
+++ b/.changeset/two-trees-own.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Skip pre-build in Docker Compose service

--- a/template/express-rest-api/docker-compose.yml
+++ b/template/express-rest-api/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         - NPM_READ_TOKEN
       context: .
-      target: build
+      target: dev-deps
     init: true
     volumes:
       - /workdir/node_modules

--- a/template/greeter/docker-compose.yml
+++ b/template/greeter/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         - NPM_READ_TOKEN
       context: .
-      target: build
+      target: dev-deps
     init: true
     volumes:
       - /workdir/node_modules

--- a/template/koa-rest-api/docker-compose.yml
+++ b/template/koa-rest-api/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         - NPM_READ_TOKEN
       context: .
-      target: build
+      target: dev-deps
     init: true
     volumes:
       - /workdir/node_modules

--- a/template/lambda-sqs-worker/docker-compose.yml
+++ b/template/lambda-sqs-worker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         - NPM_READ_TOKEN
       context: .
-      target: build
+      target: dev-deps
     environment:
       - BUILDKITE_COMMIT
       - ENVIRONMENT

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -24,7 +24,7 @@
   "private": true,
   "scripts": {
     "build": "skuba build",
-    "deploy": "serverless deploy --force --verbose",
+    "deploy": "yarn build && serverless deploy --force --verbose",
     "format": "skuba format",
     "lint": "skuba lint",
     "test": "skuba test"


### PR DESCRIPTION
This should be generally faster across the pipelines, especially for Gantry services that already have this covered with `gantry build`. A caveat is that the Lambda deploy step may take a bit longer, but it's probably good to have a safer npm `deploy` script and we know that we need to revisit the speed of that pipeline soon anyway.