### PR TITLE
fix(lambda-sqs-worker): Remove region from subscription example snippet

### DIFF
--- a/.changeset/chilled-meals-hunt.md
+++ b/.changeset/chilled-meals-hunt.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Remove region from subscription example snippet

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -121,7 +121,6 @@ resources:
     #     Endpoint: !GetAtt MessageQueue.Arn
     #     Protocol: sqs
     #     RawMessageDelivery: true
-    #     Region: !Ref AWS::Region
     #     TopicArn: 'TODO: sourceSnsTopicArn'
 
     DestinationTopic:


### PR DESCRIPTION
From https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-region this field is only required for cross region subscriptions. The current value is the default implicit behavior. 