### PR TITLE
Rework initial init prompt

### DIFF
--- a/.changeset/stupid-dolphins-tap.md
+++ b/.changeset/stupid-dolphins-tap.md
@@ -1,0 +1,7 @@
+---
+'skuba': minor
+---
+
+**init:** Redesign base prompt
+
+The base prompt no longer mandates a team name and supports copy+paste.

--- a/README.md
+++ b/README.md
@@ -194,8 +194,7 @@ skuba init << EOF
   "destinationDir": "tmp-greeter",
   "templateComplete": true,
   "templateData": {
-    "teamName": "my-team",
-    "orgName": "my-org",
+    "ownerName": "my-org/my-team",
     "prodBuildkiteQueueName": "my-team-prod:cicd",
     "repoName": "tmp-greeter"
   },

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -24,15 +24,13 @@ yarn skuba init << EOF
     "description": "description",
     "devBuildkiteQueueName": "my-account-dev:cicd",
     "devGantryEnvironmentName": "dev",
-    "teamName": "my-team",
     "moduleName": "first-module",
-    "orgName": "my-org",
+    "ownerName": "my-org/my-team",
     "prodAwsAccountId": "000000000000",
     "prodBuildkiteQueueName": "my-account-prod:cicd",
     "prodGantryEnvironmentName": "prod",
     "repoName": "${directory}",
-    "serviceName": "serviceName",
-    "teamName": "my-team"
+    "serviceName": "serviceName"
   },
   "templateName": "${template}"
 }

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -9,9 +9,8 @@ const INIT_CONFIG_INPUT_FIELDS = {
   templateComplete: t.Boolean,
   templateData: t
     .Record({
-      teamName: t.String,
+      ownerName: t.String,
       repoName: t.String,
-      orgName: t.String,
     })
     .And(t.Dictionary(t.String, 'string')),
   templateName: t.String,
@@ -23,8 +22,19 @@ export const InitConfigInput = t.Record(INIT_CONFIG_INPUT_FIELDS);
 
 export type InitConfig = t.Static<typeof InitConfig>;
 
-export const InitConfig = t.Record({
+const InitConfig = t.Record({
   ...INIT_CONFIG_INPUT_FIELDS,
+
+  templateData: t
+    .Record({
+      ownerName: t.String,
+      repoName: t.String,
+
+      // Derived from ownerName
+      orgName: t.String,
+      teamName: t.String,
+    })
+    .And(t.Dictionary(t.String, 'string')),
 
   entryPoint: t.String.Or(t.Undefined),
   type: ProjectType.Or(t.Undefined),

--- a/src/enquirer.d.ts
+++ b/src/enquirer.d.ts
@@ -17,7 +17,7 @@ declare module 'enquirer' {
     constructor(opts: {
       name: string;
       message: string;
-      choices: FormChoice[];
+      choices: ReadonlyArray<FormChoice>;
       result?: (values: Record<string, string>) => Record<string, string>;
       validate?: (
         values: Record<string, string>,
@@ -55,24 +55,5 @@ declare module 'enquirer' {
     });
 
     run(): Promise<T>;
-  }
-
-  export class Snippet<T> {
-    constructor(opts: {
-      name: string;
-      message: string;
-      fields: ReadonlyArray<{
-        name: string;
-        message?: string;
-        initial?: string;
-        validate?: (
-          values: Record<string, string>,
-        ) => boolean | string | Promise<boolean | string>;
-      }>;
-      required?: boolean;
-      template: string;
-    });
-
-    run(): Promise<{ result: string; values: T }>;
   }
 }

--- a/template/base/.github/CODEOWNERS
+++ b/template/base/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @<%- orgName %>/<%- teamName %>
+* @<%- ownerName %>
 
 # Configured by Renovate
 package.json


### PR DESCRIPTION
The Snippet prompt looked elegant, but was slightly confusing in practice and glitched out on copy+paste. Instead, use a more traditional form input.

- Team name is now optional; closes #149.
- Copy+paste now works; closes #229.