### PR TITLE
Remove redundant `ecr` plugin from Lambda template

### DIFF
--- a/.changeset/old-roses-carry.md
+++ b/.changeset/old-roses-carry.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Remove redundant `ecr` plugin

--- a/template/lambda-sqs-worker/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker/.buildkite/pipeline.yml
@@ -56,8 +56,6 @@ steps:
     plugins:
       - *aws-sm
       - *docker-ecr-cache
-      - ecr#v2.1.1:
-          login: true
       - docker-compose#v3.7.0:
           run: app
 


### PR DESCRIPTION
The preceding `docker-ecr-cache` plugin already logs in to ECR to cache the image.