### PR TITLE
Add dodgy lint test cases

### DIFF
--- a/src/cli/lint.test.ts
+++ b/src/cli/lint.test.ts
@@ -1,0 +1,73 @@
+/**
+ * This test file only exists to ensure compatibility between our lint command
+ * and new syntax features.
+ */
+
+/* eslint-disable jest/no-commented-out-tests, jest/no-disabled-tests */
+
+import './lint';
+
+describe('TypeScript', () => {
+  describe('4.0', () => {
+    test('Variadic Tuple Types', () => {
+      type Strings = [string, string];
+      type Numbers = [number, number];
+      type StrStrNumNumBool = [...Strings, ...Numbers, boolean];
+
+      const strStrNumNumBool: StrStrNumNumBool = ['', '', 0, 0, true];
+
+      expect(strStrNumNumBool).toBeDefined();
+    });
+
+    test('Labeled Tuple Elements', () => {
+      type Foo = [first: number, second?: string, ...rest: unknown[]];
+
+      const foo: Foo = [1, , null, {}];
+
+      expect(foo).toBeDefined();
+    });
+
+    test('Short-Circuiting Assignment Operators', () => {
+      let a = 1;
+      const b = 1;
+
+      a += b;
+      a -= b;
+      a *= b;
+      a /= b;
+      a **= b;
+      a <<= b;
+
+      expect(a).toBeDefined();
+    });
+
+    test('unknown on catch Clause Bindings', () => {
+      try {
+      } catch (err: unknown) {}
+    });
+  });
+
+  describe.skip('4.1', () => {
+    // test('Template Literal Types', () => {
+    //   type Color = 'red' | 'blue';
+    //   type Quantity = 'one' | 'two';
+    //   type SeussFish = `${Quantity | Color} fish`;
+    //   const seussFish: SeussFish = 'red blue fish';
+    //   expect(seussFish).toBeDefined();
+    // });
+    // test('Key Remapping in Mapped Types', () => {
+    //   type RemoveKindField<T> = {
+    //     [K in keyof T as Exclude<K, "kind">]: T[K];
+    //   };
+    //   interface Circle {
+    //     kind: 'circle';
+    //     radius: number;
+    //   }
+    //   type KindlessCircle = RemoveKindField<Circle>;
+    //   const kindlessCircle: KindlessCircle = {
+    //     radius: 0,
+    //   };
+    //   expect(kindlessCircle).toBeDefined();
+    // });
+  });
+});


### PR DESCRIPTION
This test file serves to validate TypeScript syntax support in our ESLint and Prettier linting dependencies. It's dodgy because it's really only marked up as a Jest file for ease of test case structuring and to exclude it from the bundle.