### PR TITLE
Fix server listener and port in Express template

### DIFF
--- a/.changeset/proud-impalas-learn.md
+++ b/.changeset/proud-impalas-learn.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**start:** Support default export of Express listener

--- a/.changeset/shiny-cougars-greet.md
+++ b/.changeset/shiny-cougars-greet.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/express-rest-api:** Fix server listener and port

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ As does Express:
 ```typescript
 const app = express();
 
-export default app;
+export default Object.assign(app, { port });
 ```
 
 ### `skuba test`

--- a/README.md
+++ b/README.md
@@ -262,6 +262,14 @@ const app = new Koa();
 export default Object.assign(app, { port });
 ```
 
+As does Express:
+
+```typescript
+const app = express();
+
+export default app;
+```
+
 ### `skuba test`
 
 Run tests with Jest.

--- a/template/express-rest-api/Dockerfile
+++ b/template/express-rest-api/Dockerfile
@@ -60,8 +60,8 @@ COPY --from=deps /workdir/node_modules node_modules
 
 ENV NODE_ENV production
 
-ARG PORT=3000
+ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD node lib/app
+CMD node lib/listen

--- a/template/express-rest-api/package.json
+++ b/template/express-rest-api/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@seek/logger": "^4.4.5",
     "express": "^4.17.1",
     "skuba-dive": "^1.1.1"
   },
@@ -7,6 +8,7 @@
     "@types/express": "^4.17.8",
     "@types/node": "^14.14.0",
     "@types/supertest": "^2.0.10",
+    "pino-pretty": "^4.3.0",
     "skuba": "*",
     "supertest": "^6.0.0"
   },
@@ -19,7 +21,7 @@
     "build": "skuba build",
     "format": "skuba format",
     "lint": "skuba lint",
-    "start": "skuba start",
+    "start": "ENVIRONMENT=local skuba start",
     "start:debug": "ENVIRONMENT=local skuba start --inspect-brk",
     "test": "skuba test"
   }

--- a/template/express-rest-api/src/app.ts
+++ b/template/express-rest-api/src/app.ts
@@ -1,8 +1,15 @@
+import 'skuba-dive/register';
+
 import express, { Application, Request, Response } from 'express';
+
+import { config } from './config';
+import { rootLogger } from './framework/logging';
 
 const app: Application = express();
 
 app.get('/', (_req: Request, res: Response) => {
+  rootLogger.debug('greeting...');
+
   res.send('Hello World!');
 });
 
@@ -10,8 +17,6 @@ app.get('/health', (_req: Request, res: Response) => {
   res.send('');
 });
 
-if (process.env.ENVIRONMENT !== 'test') {
-  app.listen(3000);
-}
-
-export default app;
+export default Object.assign(app, {
+  port: config.port,
+});

--- a/template/express-rest-api/src/config.ts
+++ b/template/express-rest-api/src/config.ts
@@ -1,0 +1,62 @@
+import { Env } from 'skuba-dive';
+
+interface Config {
+  environment: Environment;
+
+  logLevel: string;
+  name: string;
+  region: string;
+  version: string;
+
+  metricsServer?: string;
+  port?: number;
+}
+
+type Environment = typeof environments[number];
+
+const dev = '<%- devGantryEnvironmentName %>';
+const prod = '<%- prodGantryEnvironmentName %>';
+
+const environments = ['local', 'test', dev, prod] as const;
+
+const environment = Env.oneOf(environments)('ENVIRONMENT');
+
+/* istanbul ignore next: config verification makes more sense in a smoke test */
+const configs: Record<Environment, () => Omit<Config, 'environment'>> = {
+  local: () => ({
+    logLevel: 'debug',
+    name: '<%- serviceName %>',
+    region: 'ap-southeast-2',
+    version: 'local',
+
+    port: Env.nonNegativeInteger('PORT', { default: undefined }),
+  }),
+
+  test: () => ({
+    ...configs.local(),
+
+    logLevel: Env.string('LOG_LEVEL', { default: 'silent' }),
+    version: 'test',
+  }),
+
+  [dev]: () => ({
+    ...configs[prod](),
+
+    logLevel: 'debug',
+  }),
+
+  [prod]: () => ({
+    logLevel: 'info',
+    name: Env.string('SERVICE'),
+    region: Env.string('REGION'),
+    version: Env.string('VERSION'),
+
+    metricsServer: 'localhost',
+    port: Env.nonNegativeInteger('PORT'),
+  }),
+};
+
+export const config: Config = {
+  ...configs[environment](),
+  environment,
+};

--- a/template/express-rest-api/src/framework/logging.ts
+++ b/template/express-rest-api/src/framework/logging.ts
@@ -1,0 +1,17 @@
+import createLogger from '@seek/logger';
+
+import { config } from 'src/config';
+
+export const rootLogger = createLogger({
+  base: {
+    environment: config.environment,
+    region: config.region,
+    version: config.version,
+  },
+
+  level: config.logLevel,
+
+  name: config.name,
+
+  prettyPrint: config.environment === 'local',
+});

--- a/template/express-rest-api/src/listen.ts
+++ b/template/express-rest-api/src/listen.ts
@@ -1,0 +1,13 @@
+import app from './app';
+import { rootLogger } from './framework/logging';
+
+// If your application is deployed with more than 1 vCPU you can delete this
+// file and use a clustering utility to run `lib/app`.
+
+const listener = app.listen(app.port, () => {
+  const address = listener.address();
+
+  if (typeof address === 'object' && address) {
+    rootLogger.debug(`listening on port ${address.port}`);
+  }
+});


### PR DESCRIPTION
The template wasn't respecting the PORT environment variable provided by a Gantry deployment, and wasn't compatible with `skuba start`.

This fixes those issues and introduces some boilerplate config and logging code that can be extended in future.