### PR TITLE
Tweak template test scripts

### DIFF
--- a/.changeset/cuddly-pillows-push.md
+++ b/.changeset/cuddly-pillows-push.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Check coverage on default `test` script

--- a/.changeset/giant-foxes-move.md
+++ b/.changeset/giant-foxes-move.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Include `test:watch` script

--- a/template/express-rest-api/package.json
+++ b/template/express-rest-api/package.json
@@ -23,6 +23,7 @@
     "lint": "skuba lint",
     "start": "ENVIRONMENT=local skuba start",
     "start:debug": "ENVIRONMENT=local skuba start --inspect-brk",
-    "test": "skuba test"
+    "test": "skuba test --coverage",
+    "test:watch": "skuba test --watch"
   }
 }

--- a/template/greeter/package.json
+++ b/template/greeter/package.json
@@ -17,6 +17,7 @@
     "lint": "skuba lint",
     "start": "ENVIRONMENT=local skuba start",
     "start:debug": "ENVIRONMENT=local skuba start --inspect-brk",
-    "test": "skuba test"
+    "test": "skuba test --coverage",
+    "test:watch": "skuba test --watch"
   }
 }

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -37,6 +37,7 @@
     "lint": "skuba lint",
     "start": "ENVIRONMENT=local skuba start",
     "start:debug": "ENVIRONMENT=local skuba start --inspect-brk",
-    "test": "skuba test"
+    "test": "skuba test --coverage",
+    "test:watch": "skuba test --watch"
   }
 }

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -26,6 +26,7 @@
     "deploy": "yarn build && serverless deploy --force --verbose",
     "format": "skuba format",
     "lint": "skuba lint",
-    "test": "skuba test"
+    "test": "skuba test --coverage",
+    "test:watch": "skuba test --watch"
   }
 }

--- a/template/oss-npm-package/_package.json
+++ b/template/oss-npm-package/_package.json
@@ -23,7 +23,8 @@
     "format": "skuba format",
     "lint": "skuba lint",
     "release": "yarn build && skuba release",
-    "test": "skuba test"
+    "test": "skuba test --coverage",
+    "test:watch": "skuba test --watch"
   },
   "sideEffects": false,
   "types": "./lib-types/index.d.ts",

--- a/template/private-npm-package/_package.json
+++ b/template/private-npm-package/_package.json
@@ -23,7 +23,8 @@
     "format": "skuba format",
     "lint": "skuba lint",
     "release": "yarn build && skuba release",
-    "test": "skuba test"
+    "test": "skuba test --coverage",
+    "test:watch": "skuba test --watch"
   },
   "sideEffects": false,
   "types": "./lib-types/index.d.ts",


### PR DESCRIPTION
I've been umming and ahhing on the right approach here, as I like a fairly unopinionated `test` script into which the user can pass their desired flags.

Practically speaking, we have some other tooling like our package publishing pipeline which presumes that the `test` script is suitable for exhaustive CI testing. `test:watch` should be a reasonable compromise for local testing, and already has some SEEK precedence with ~46 `package.json` results returned from a GitHub search.