### PR TITLE
Fix Babel `--out-dir requires filenames` error

### DIFF
--- a/.changeset/kind-wombats-care.md
+++ b/.changeset/kind-wombats-care.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**build:** Fix `--out-dir requires filenames` error on experimental Babel builds

--- a/src/cli/build/babel.ts
+++ b/src/cli/build/babel.ts
@@ -11,5 +11,6 @@ export const babel = () =>
     '--out-dir',
     'lib',
     '--source-maps',
+    'true',
     'src',
   );


### PR DESCRIPTION
It looks like this no longer works without an explicit argument.

https://babeljs.io/docs/en/options#sourcemaps