### PR TITLE
Remove ESM from bundle

### DIFF
--- a/.changeset/stale-keys-sell.md
+++ b/.changeset/stale-keys-sell.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+**pkg:** Remove ESM from skuba's bundle
+
+This simplifies our bundle; Node.js and skuba's CLI have always defaulted to CommonJS anyway.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ you can use [npm link] to register your local copy as a global shell command:
 # do this once upfront
 npm link
 
-# npm link points to the compiled JavaScript in ./lib-commonjs/index.js, so
+# npm link points to the compiled JavaScript in ./lib/index.js, so
 # you'll need to rebuild skuba on every code change
 yarn build
 

--- a/package.json
+++ b/package.json
@@ -2,15 +2,14 @@
   "name": "skuba",
   "description": "Toolkit for backend TypeScript development",
   "bin": {
-    "skuba": "lib-commonjs/skuba.js"
+    "skuba": "lib/skuba.js"
   },
   "engines": {
     "node": ">=12"
   },
   "version": "3.11.0",
-  "main": "lib-commonjs",
-  "module": "lib-es2015",
-  "typings": "lib-types/index.d.ts",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "files": [
     "config/**/*",
     "lib*/**/*.d.ts",
@@ -22,7 +21,7 @@
   "sideEffects": false,
   "license": "MIT",
   "scripts": {
-    "build": "yarn skuba build-package && scripts/postbuild.sh",
+    "build": "yarn skuba build && scripts/postbuild.sh",
     "format": "yarn skuba format",
     "lint": "yarn skuba lint",
     "release": "yarn build && changeset publish",
@@ -39,7 +38,7 @@
     "@changesets/cli": "2.12.0",
     "@types/concurrently": "5.2.1",
     "@types/ejs": "3.0.5",
-    "@types/fs-extra": "9.0.4",
+    "@types/fs-extra": "9.0.5",
     "@types/lodash.mergewith": "4.6.6",
     "@types/npm-which": "3.0.0",
     "type-fest": "0.20.2"

--- a/scripts/postbuild.sh
+++ b/scripts/postbuild.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-chmod +x 'lib-commonjs/skuba.js'
+chmod +x 'lib/skuba.js'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "compilerOptions": {
     "baseUrl": "src",
+    "declaration": true,
     // TODO: set in /config/tsconfig.json
     "isolatedModules": true,
+    "outDir": "lib",
     "removeComments": false
   },
   "exclude": ["lib*/**/*", "template/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,10 +1640,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
   integrity sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==
 
-"@types/fs-extra@9.0.4":
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.4.tgz#12553138cf0438db9a31cdc8b0a3aa9332eb67aa"
-  integrity sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==
+"@types/fs-extra@9.0.5":
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.5.tgz#2afb76a43a4bef80a363b94b314d0ca1694fc4f8"
+  integrity sha512-wr3t7wIW1c0A2BIJtdVp4EflriVaVVAsCAIHVzzh8B+GiFv9X1xeJjCs4upRXtzp7kQ6lP5xvskjoD4awJ1ZeA==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
See changeset. Currently we'd only compile to ESM for browser usage, which isn't relevant to skuba.

If it's feasible to drop CommonJS on the Node.js side in future, we can switch across to ESM in one fell swoop rather than bundling both module resolutions.