### PR TITLE
Implement node wrapper

### DIFF
--- a/.changeset/late-carrots-speak.md
+++ b/.changeset/late-carrots-speak.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+**start:** Improve support for non-HTTP server entry points
+
+You can now run arbitrary TypeScript files without them exiting on a `You must export callback or requestListener` error.

--- a/.changeset/light-files-nail.md
+++ b/.changeset/light-files-nail.md
@@ -1,0 +1,33 @@
+---
+'skuba': minor
+---
+
+**node:** Add command
+
+`skuba node` lets you run a TypeScript source file, or open a REPL if none is provided:
+
+- `skuba node src/some-cli-script.ts`
+- `skuba node`
+
+This automatically registers a `src` module alias for ease of local development. For example, you can run a prospective `src/someLocalCliScript.ts` without having to register a module alias resolver:
+
+```typescript
+// This `src` module alias just works under `skuba node` and `skuba start`
+import { rootLogger } from 'src/framework/logging';
+```
+
+```bash
+yarn skuba node src/someLocalCliScript
+```
+
+If you use this alias in your production code,
+your production entry point(s) will need to import a runtime module alias resolver like [`skuba-dive/register`](https://github.com/seek-oss/skuba-dive#register).
+For example, your `src/app.ts` may look like:
+
+```typescript
+// This must be imported directly within the `src` directory
+import 'skuba-dive/register';
+
+// You can use the `src` module alias after registration
+import { rootLogger } 'src/framework/logging';
+```

--- a/.changeset/strange-candles-count.md
+++ b/.changeset/strange-candles-count.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**start:** Support `src` module alias

--- a/.changeset/thick-moons-float.md
+++ b/.changeset/thick-moons-float.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**start:** Support source maps

--- a/README.md
+++ b/README.md
@@ -212,6 +212,48 @@ Check for code quality issues.
 
 This script should be run in CI to verify that [`skuba format`] was applied and triaged locally.
 
+### `skuba node`
+
+Run a TypeScript source file, or open a REPL if none is provided:
+
+- `skuba node src/some-cli-script.ts`
+- `skuba node`
+
+This automatically registers a `src` module alias for ease of local development.
+If you use this alias in your production code,
+your production entry point(s) will need to import a runtime module alias resolver like [`skuba-dive/register`].
+For example, your `src/app.ts` may look like:
+
+```typescript
+// This must be imported directly within the `src` directory
+import 'skuba-dive/register';
+
+// You can use the `src` module alias after registration
+import { rootLogger } 'src/framework/logging';
+```
+
+[`skuba-dive/register`]: https://github.com/seek-oss/skuba-dive#register
+[experimental babel toolchain]: ./docs/babel.md
+
+> **Note:** if you're using the [experimental Babel toolchain].
+> you'll be limited to the fairly primitive `babel-node` REPL.
+> While it can import TypeScript modules,
+> it does not support interactive TypeScript nor modern JavaScript syntax:
+>
+> ```typescript
+> import { someExport } from 'src/someModule';
+> // Thrown: [...] Modules aren't supported in the REPL
+>
+> const { someExport } = require('src/someModule');
+> // Thrown: [...] Only `var` variables are supported in the REPL
+>
+> var { someExport } = require('src/someModule');
+> // undefined
+>
+> var v: undefined;
+> // Thrown: [...] Unexpected token
+> ```
+
 ### `skuba start`
 
 Start a live-reloading server for local development.
@@ -227,6 +269,19 @@ For example, in Visual Studio Code:
 
 1. Run `skuba start --inspect-brk`
 1. Run the built-in `Node.js: Attach` launch configuration
+
+This automatically registers a `src` module alias for ease of local development.
+If you use this alias in your production code,
+your production entry point(s) will need to import a runtime module alias resolver like [`skuba-dive/register`].
+For example, your `src/app.ts` may look like:
+
+```typescript
+// This must be imported directly within the `src` directory
+import 'skuba-dive/register';
+
+// You can use the `src` module alias after registration
+import { rootLogger } 'src/framework/logging';
+```
 
 [node.js options]: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options
 

--- a/README.md
+++ b/README.md
@@ -232,10 +232,7 @@ import 'skuba-dive/register';
 import { rootLogger } 'src/framework/logging';
 ```
 
-[`skuba-dive/register`]: https://github.com/seek-oss/skuba-dive#register
-[experimental babel toolchain]: ./docs/babel.md
-
-> **Note:** if you're using the [experimental Babel toolchain].
+> **Note:** if you're using the [experimental Babel toolchain],
 > you'll be limited to the fairly primitive `babel-node` REPL.
 > While it can import TypeScript modules,
 > it does not support interactive TypeScript nor modern JavaScript syntax:
@@ -253,6 +250,9 @@ import { rootLogger } 'src/framework/logging';
 > var v: undefined;
 > // Thrown: [...] Unexpected token
 > ```
+
+[`skuba-dive/register`]: https://github.com/seek-oss/skuba-dive#register
+[experimental babel toolchain]: ./docs/babel.md
 
 ### `skuba start`
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/ejs": "3.0.5",
     "@types/fs-extra": "9.0.5",
     "@types/lodash.mergewith": "4.6.6",
+    "@types/module-alias": "2.0.0",
     "@types/npm-which": "3.0.0",
     "type-fest": "0.20.2"
   },
@@ -65,6 +66,7 @@
     "jest": "^26.6.0",
     "latest-version": "^5.1.0",
     "lodash.mergewith": "^4.6.2",
+    "module-alias": "^2.2.2",
     "nodemon": "^2.0.6",
     "normalize-package-data": "^3.0.0",
     "npm-run-path": "^4.0.1",
@@ -73,6 +75,7 @@
     "read-pkg-up": "^7.0.1",
     "runtypes": "^5.0.1",
     "semantic-release": "^17.2.3",
+    "source-map-support": "^0.5.19",
     "ts-jest": "^26.4.1",
     "ts-node": "^9.0.0",
     "ts-node-dev": "1.1.1",

--- a/src/cli/node.ts
+++ b/src/cli/node.ts
@@ -1,0 +1,66 @@
+import path from 'path';
+
+import getPort from 'get-port';
+import parse from 'yargs-parser';
+
+import { unsafeMapYargs } from '../utils/args';
+import { createExec } from '../utils/exec';
+import { isBabelFromManifest } from '../utils/manifest';
+
+const parseArgs = () => {
+  const {
+    _: [entryPointArg],
+    ...yargs
+  } = parse(process.argv.slice(2));
+
+  const entryPoint = typeof entryPointArg === 'string' ? entryPointArg : null;
+
+  const inspect = unsafeMapYargs({
+    inspect: yargs.inspect as unknown,
+    'inspect-brk': yargs['inspect-brk'] as unknown,
+  });
+
+  return {
+    entryPoint,
+    inspect,
+  };
+};
+
+export const node = async () => {
+  const args = parseArgs();
+
+  const [port, isBabel] = await Promise.all([getPort(), isBabelFromManifest()]);
+
+  const exec = createExec({
+    env: isBabel ? undefined : { __SKUBA_REGISTER_MODULE_ALIASES: '1' },
+  });
+
+  if (isBabel) {
+    return exec(
+      'babel-node',
+      ...args.inspect,
+      '--extensions',
+      ['.js', '.json', '.ts'].join(','),
+      '--require',
+      path.join('skuba', 'lib', 'register'),
+      ...(args.entryPoint === null
+        ? []
+        : [
+            path.join(__dirname, '..', 'wrapper.js'),
+            args.entryPoint,
+            String(port),
+          ]),
+    );
+  }
+
+  return exec(
+    'ts-node',
+    ...args.inspect,
+    '--require',
+    path.join('skuba', 'lib', 'register'),
+    '--transpile-only',
+    ...(args.entryPoint === null
+      ? []
+      : [path.join(__dirname, '..', 'wrapper'), args.entryPoint, String(port)]),
+  );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,14 @@
+/**
+ * Entry point for the Node.js development API.
+ *
+ * This is where skuba imports point to:
+ *
+ * ```typescript
+ * import { Net } from 'skuba';
+ *
+ * const { Net } = require('skuba');
+ * ```
+ */
+
 export * as Jest from './api/jest';
 export * as Net from './api/net';

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,0 +1,53 @@
+/**
+ * Local hook for module alias and source map support.
+ *
+ * This is only intended for use with `skuba node` and `skuba start`,
+ * where it is loaded before the entry point provided by the user:
+ *
+ * ```bash
+ * ts-node --require skuba/lib/register src/userProvidedEntryPoint
+ * ```
+ *
+ * These commands make use of development tooling like `ts-node`,
+ * which may not exactly match the runtime characteristics of `node`.
+ * Production code should be compiled down to JavaScript and run with Node.js.
+ *
+ * For equivalent module alias and source map support in production,
+ * import the `skuba-dive/register` hook.
+ *
+ * {@link https://github.com/seek-oss/skuba-dive#register}
+ */
+
+import 'source-map-support/register';
+
+import path from 'path';
+
+import { addAlias } from 'module-alias';
+import readPkgUp from 'read-pkg-up';
+
+import { log } from './utils/logging';
+
+const registerModuleAliases = () => {
+  if (!process.env.__SKUBA_REGISTER_MODULE_ALIASES) {
+    return;
+  }
+
+  // This may pick the wrong `package.json` if we are in a nested directory.
+  // Consider revisiting this when we decide how to better support monorepos.
+  const result = readPkgUp.sync();
+
+  if (typeof result === 'undefined') {
+    log.warn(log.bold('src'), '→', 'not found');
+
+    return;
+  }
+
+  const root = path.dirname(result.path);
+  const src = path.join(root, 'src');
+
+  log.subtle(log.bold('src'), '→', src);
+
+  addAlias('src', src);
+};
+
+registerModuleAliases();

--- a/src/skuba.ts
+++ b/src/skuba.ts
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
 
+/**
+ * Entry point for the CLI.
+ *
+ * This is where you end up when you run:
+ *
+ * ```bash
+ * [yarn] skuba help
+ * ```
+ */
+
 import path from 'path';
 
 import { parseArgs } from './utils/args';

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -19,6 +19,7 @@ export const COMMAND_LIST = [
   'help',
   'init',
   'lint',
+  'node',
   'release',
   'start',
   'test',

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,9 +1,18 @@
+/**
+ * Wrapper around an entry point provided to `skuba node` or `skuba start`.
+ *
+ * Beyond simply loading the entry point, it supports the following features:
+ *
+ * - If you `export =` or `export default` an Express or Koa application,
+ *   it will spin up a local HTTP server.
+ */
+
 import http from 'http';
 import { AddressInfo } from 'net';
 import path from 'path';
 
-import { handleCliError } from '../../utils/error';
-import { log } from '../../utils/logging';
+import { handleCliError } from './utils/error';
+import { log } from './utils/logging';
 
 type Config = FunctionConfig | ObjectConfig;
 
@@ -25,7 +34,7 @@ interface ObjectConfig {
 const isConfig = (data: unknown): data is Config =>
   (typeof data === 'object' && data !== null) || typeof data === 'function';
 
-const start = () => {
+const main = () => {
   if (process.argv.length < 4) {
     log.err('Missing arguments:', log.bold('entry-point'), log.bold('port'));
     process.exit(1);
@@ -65,13 +74,7 @@ const start = () => {
       : config.requestListener ?? config.callback?.();
 
   if (typeof requestListener === 'undefined') {
-    log.err(
-      'You must export',
-      log.bold('callback'),
-      'or',
-      log.bold('requestListener'),
-    );
-    process.exit(1);
+    return Promise.resolve();
   }
 
   const server = http.createServer(requestListener);
@@ -89,4 +92,4 @@ const start = () => {
   );
 };
 
-start().catch(handleCliError);
+main().catch(handleCliError);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,6 +1708,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
+"@types/module-alias@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/module-alias/-/module-alias-2.0.0.tgz#882668f8b8cdbda44812c3b592c590909e18849e"
+  integrity sha512-e3sW4oEH0qS1QxSfX7PT6xIi5qk/YSMsrB9Lq8EtkhQBZB+bKyfkP+jpLJRySanvBhAQPSv2PEBe81M8Iy/7yg==
+
 "@types/node@*", "@types/node@>= 8":
   version "14.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"
@@ -6711,6 +6716,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+module-alias@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
+  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8760,7 +8770,7 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.12, source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6:
+source-map-support@^0.5.12, source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==


### PR DESCRIPTION
See changesets and README for full details. Closes #84.

---

`skuba node` runs a TypeScript file; it's like a one-off `skuba start`. Unlike start, it gives you a REPL when you omit the command line entry point rather than falling back to the entry point in `package.json`.

This PR also adds some secret sauce to automatically register the `src` module alias when you're running under `skuba node` or `skuba start`. This means that you only need a runtime module alias resolver like `import skuba-dive/register` at the top of production entry points; local scripts can be run with little fanfare using the skuba commands.

---

Notes:

- I considered calling the command `skuba exec`, but that sounds a bit awkward when it supports opening a REPL.

- You may be wondering why don't we just use `tsconfig-paths`.

  This is tempting but I'm not convinced that we should depend on reading configuration out of `tsconfig.json` at runtime. This can be confusing given TypeScript is generally considered a compile-time concern, and our own templates only keep `lib` and `node_modules` in the runtime Docker image.

- Diving into this has uncovered that the `@babel/node` REPL is pretty unusable with modern JavaScript/TypeScript. See the README for more.