### PR TITLE
Ensure workspaced `package.json` is private

### DIFF
--- a/.changeset/wet-books-live.md
+++ b/.changeset/wet-books-live.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**configure:** Ensure workspaced `package.json` is private

--- a/src/cli/configure/modules/package.test.ts
+++ b/src/cli/configure/modules/package.test.ts
@@ -216,4 +216,25 @@ describe('packageModule', () => {
       version: '0.0.0-semantically-released',
     });
   });
+
+  it('privatises a workspaced manifest', async () => {
+    const inputFiles = {
+      'package.json': JSON.stringify({
+        devDependencies: {},
+        scripts: {},
+        skuba: {},
+        workspaces: {},
+      }),
+    };
+
+    const outputFiles = await executeModule(
+      packageModule,
+      inputFiles,
+      defaultOpts,
+    );
+
+    const outputData = parsePackage(outputFiles['package.json']);
+
+    expect(outputData).toHaveProperty('private', true);
+  });
 });

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -57,6 +57,11 @@ export const packageModule = async ({
         outputData.license ??= 'UNLICENSED';
         outputData.scripts ??= {};
 
+        // Workspaces can only be enabled in private projects
+        if (outputData.workspaces && !outputData.private) {
+          outputData.private = true;
+        }
+
         delete outputData.scripts.commit;
         delete outputData.scripts['format:check'];
         delete outputData.scripts['lint:build'];


### PR DESCRIPTION
This avoids awkward crashes on `yarn install`:

```text
error Workspaces can only be enabled in private projects.
```

---

Closes #199