### PR TITLE
Use explicit deregistrationDelay in Gantry

### DIFF
--- a/.changeset/fresh-ladybugs-sip.md
+++ b/.changeset/fresh-ladybugs-sip.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+Use explicit deregistrationDelay in Gantry

--- a/.changeset/fresh-ladybugs-sip.md
+++ b/.changeset/fresh-ladybugs-sip.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
-Use explicit deregistrationDelay in Gantry
+**template:** Use explicit `deregistrationDelay` in Gantry

--- a/template/express-rest-api/gantry.apply.yml
+++ b/template/express-rest-api/gantry.apply.yml
@@ -48,6 +48,8 @@ deployment:
     path: /health
     useExternalDns: true
 
+deregistrationDelay: 10
+
 tags:
   {{range $key, $value := .Values.tags}}
   {{$key}}: '{{$value}}'

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -49,6 +49,8 @@ deployment:
     path: /smoke
     useExternalDns: true
 
+deregistrationDelay: 10
+
 tags:
   {{range $key, $value := .Values.tags}}
   {{$key}}: '{{$value}}'


### PR DESCRIPTION
The default of 120 seconds seems to be excessive for most workloads, so provide a more sensible default explicitly.

This will hopefully also prompt users to tweak the value as they see fit.

A typical Gantry deploy seems to take about 5 minutes, so this should reduce typical time to deploy by about a third.