### PR TITLE
Use Distroless runtime images

### DIFF
--- a/.changeset/wise-fans-join.md
+++ b/.changeset/wise-fans-join.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/\*-rest-api:** Use Distroless runtime images

--- a/template/express-rest-api/Dockerfile
+++ b/template/express-rest-api/Dockerfile
@@ -50,7 +50,7 @@ RUN yarn build
 
 ###
 
-FROM node:12-alpine AS runtime
+FROM gcr.io/distroless/nodejs:12 AS runtime
 
 WORKDIR /workdir
 
@@ -64,4 +64,4 @@ ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD node lib/listen
+CMD ["lib/listen.js"]

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -50,7 +50,7 @@ RUN yarn build
 
 ###
 
-FROM node:12-alpine AS runtime
+FROM gcr.io/distroless/nodejs:12 AS runtime
 
 WORKDIR /workdir
 
@@ -64,4 +64,4 @@ ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD node lib/listen
+CMD ["lib/listen.js"]


### PR DESCRIPTION
Distroless images present a smaller attack surface as they ship without a package manager, shell and the like. These have been promoted out of experimental status since I last checked.

https://github.com/GoogleContainerTools/distroless/tree/master/nodejs