### PR TITLE
Set NODE_ENV to `test` in Jest

### DIFF
--- a/.changeset/thick-bees-ring.md
+++ b/.changeset/thick-bees-ring.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+Set `NODE_ENV` to `test` in Jest
+
+This is something that Jest itself does in its `bin/jest`

--- a/.changeset/thick-bees-ring.md
+++ b/.changeset/thick-bees-ring.md
@@ -2,6 +2,6 @@
 'skuba': patch
 ---
 
-Set `NODE_ENV` to `test` in Jest
+**test:** Set `NODE_ENV=test`
 
-This is something that Jest itself does in its `bin/jest`
+This is something that Jest itself does in its `bin/jest`.

--- a/src/cli/test.ts
+++ b/src/cli/test.ts
@@ -1,6 +1,11 @@
 import { run } from 'jest';
 
 export const test = () => {
+  // This is usually set in `jest-cli`'s binary wrapper
+  if (typeof process.env.NODE_ENV === 'undefined') {
+    process.env.NODE_ENV = 'test';
+  }
+
   const argv = process.argv.slice(2);
 
   return run(argv);


### PR DESCRIPTION
This is something that Jest itself does in its `bin/jest`:
https://github.com/facebook/jest/blob/master/packages/jest-cli/bin/jest.js

Typically this doesn't do anything interesting but some libraries look at `NODE_ENV` to tweak their behaviour under Jest.

An example (and the motivation for this) is `new ApolloServer`. Normally it attaches an event listener to `process.exit` to clean up various internal handles. However, if this happens too many times it causes Node to spew warnings:

> MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added to [process]. Use emitter.setMaxListeners() to increase limit

To work around this Apollo won't attach an event listener if `NODE_ENV` === `test`. Unfortunately because Skuba isn't using the Jest wrapper this is unset.
