### PR TITLE
Add smoke testing to Lambda template

### DIFF
--- a/.changeset/eight-mails-pay.md
+++ b/.changeset/eight-mails-pay.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Add smoke test
+
+This brings back versioned functions along with `serverless-prune-plugin` to control Lambda storage consumption. By default we configure `serverless-plugin-canary-deployments` for an instantaneous switch once the smoke test has passed, but this can be customised as necessary.

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -14,6 +14,8 @@
     "chance": "^1.1.7",
     "pino-pretty": "^4.3.0",
     "serverless": "^2.8.0",
+    "serverless-plugin-canary-deployments": "^0.4.8",
+    "serverless-prune-plugin": "^1.4.3",
     "skuba": "*"
   },
   "engines": {
@@ -26,7 +28,9 @@
     "deploy": "yarn build && serverless deploy --force --verbose",
     "format": "skuba format",
     "lint": "skuba lint",
+    "smoke": "serverless invoke --data '{}' --function Worker",
     "start": "ENVIRONMENT=local skuba start",
+    "start:debug": "ENVIRONMENT=local skuba start --inspect-brk",
     "test": "skuba test --coverage",
     "test:watch": "skuba test --watch"
   }

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -8,6 +8,13 @@ custom:
       isProduction: 'false'
     prod:
       isProduction: 'true'
+  prune:
+    automatic: true
+    number: 3
+
+plugins:
+  - serverless-plugin-canary-deployments
+  - serverless-prune-plugin
 
 provider:
   logRetentionInDays: 30
@@ -17,15 +24,25 @@ provider:
   stackName: ${self:service}
   stage: ${env:ENVIRONMENT}
   variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}"
-  versionFunctions: false
+  versionFunctions: true
   # deploymentBucket:
   #   name: 'TODO: deploymentBucketName'
   iamRoleStatements:
+    - Action: codedeploy:PutLifecycleEventHookExecutionStatus
+      Effect: Allow
+      Resource: !Join
+        - ''
+        - - !Sub arn:aws:codedeploy:${AWS::Region}:${AWS::AccountId}:deploymentgroup
+          - ':*/'
+          - !Ref WorkerLambdaFunctionDeploymentGroup
     - Action:
         - kms:Decrypt
         - kms:GenerateDataKey*
       Effect: Allow
       Resource: !GetAtt EncryptionKey.Arn
+    - Action: lambda:InvokeFunction
+      Effect: Allow
+      Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${self:functions.Worker.name}
     - Action: sns:Publish
       Effect: Allow
       Resource: !Ref DestinationTopic
@@ -52,13 +69,17 @@ package:
     - lib/**
 
 functions:
-  Proxy:
+  Worker:
     name: ${self:service}
     handler: lib/app.handler
     description: ${self:custom.description}
     memorySize: 128
     reservedConcurrency: 20
     timeout: 30
+    deploymentSettings:
+      type: AllAtOnce
+      alias: Live
+      preTrafficHook: WorkerPreHook
     environment:
       # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
@@ -73,6 +94,16 @@ functions:
       - sqs:
           arn: !GetAtt MessageQueue.Arn
           batchSize: 1
+  WorkerPreHook:
+    name: ${self:functions.Worker.name}-pre-hook
+    handler: lib/hooks.pre
+    # This is generous because a timeout will hang the deployment
+    timeout: 300
+    environment:
+      # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
+      AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
+
+      FUNCTION_NAME_TO_INVOKE: ${self:functions.Worker.name}
 
 resources:
   # This becomes the Lambda application's description

--- a/template/lambda-sqs-worker/src/hooks.ts
+++ b/template/lambda-sqs-worker/src/hooks.ts
@@ -1,0 +1,103 @@
+/* eslint-disable no-console */
+/* istanbul ignore file */
+
+// Use minimal dependencies to reduce the chance of crashes on module load.
+import { CodeDeploy, Lambda } from 'aws-sdk';
+
+/**
+ * Common AWS options to avoid hanging the deployment on a transient error.
+ *
+ * AWS uses exponential backoff, so we wait for ~15 seconds total per request.
+ */
+const awsRetryOptions = {
+  maxRetries: 5,
+  retryDelayOptions: {
+    base: 500,
+  },
+};
+
+const codeDeploy = new CodeDeploy({
+  ...awsRetryOptions,
+  apiVersion: '2014-10-06',
+});
+
+const lambda = new Lambda({
+  ...awsRetryOptions,
+  apiVersion: '2015-03-31',
+});
+
+type Status = 'Succeeded' | 'Failed';
+
+/**
+ * Synchronously invokes a Lambda function with a smoke test event.
+ *
+ * Any non-error response is treated as a success.
+ */
+const smokeTestLambdaFunction = async (): Promise<Status> => {
+  const functionName = process.env.FUNCTION_NAME_TO_INVOKE;
+
+  if (!functionName) {
+    console.error('Missing process.env.FUNCTION_NAME_TO_INVOKE');
+    return 'Failed';
+  }
+
+  console.info('Function:', functionName);
+
+  const response = await lambda
+    .invoke({
+      FunctionName: functionName,
+      InvocationType: 'RequestResponse',
+      // Treat an empty object as our smoke test event.
+      Payload: '{}',
+      // $LATEST is updated by the time a pre hook runs.
+      Qualifier: '$LATEST',
+    })
+    .promise();
+
+  console.info('Version:', response.ExecutedVersion ?? '?');
+  console.info('Status', response.StatusCode ?? '?');
+
+  if (response.FunctionError) {
+    console.error('Error:', response.FunctionError);
+    console.error(response.Payload);
+    return 'Failed';
+  }
+
+  return response.StatusCode === 200 ? 'Succeeded' : 'Failed';
+};
+
+/**
+ * The event supplied to a CodeDeploy lifecycle hook Lambda function.
+ *
+ * {@link https://docs.aws.amazon.com/codedeploy/latest/userguide/tutorial-ecs-with-hooks-create-hooks.html}
+ */
+interface CodeDeployLifecycleHookEvent {
+  DeploymentId: string;
+  LifecycleEventHookExecutionId: string;
+}
+
+/**
+ * A handler to smoke test a new Lambda function version before it goes live.
+ *
+ * This tries to be exception safe so that a status reaches CodeDeploy. If we
+ * crash or otherwise fail to report back, the deployment will hang for an hour.
+ */
+export const pre = async (
+  event: CodeDeployLifecycleHookEvent,
+): Promise<void> => {
+  let status: Status;
+  try {
+    status = await smokeTestLambdaFunction();
+  } catch (err) {
+    console.error('Exception:', err);
+    status = 'Failed';
+  }
+
+  await codeDeploy
+    .putLifecycleEventHookExecutionStatus({
+      deploymentId: event.DeploymentId,
+      lifecycleEventHookExecutionId: event.LifecycleEventHookExecutionId,
+      status,
+    })
+    .promise();
+};

--- a/template/lambda-sqs-worker/src/services/jobScorer.ts
+++ b/template/lambda-sqs-worker/src/services/jobScorer.ts
@@ -12,19 +12,24 @@ import { JobPublishedEvent, JobScoredEvent } from 'src/types/pipelineEvents';
 /* istanbul ignore next: simulation of an external service */
 export const scoringService = {
   request: (details: string): Promise<unknown> => {
-    // networking woes
+    // Networking woes
     if (Math.random() < 0.05) {
       const err = Error('could not reach scoring service');
 
       return Promise.reject(err);
     }
 
-    // unexpected behaviour on certain inputs
+    // Unexpected behaviour on certain inputs
     if (details.length % 100 === 0) {
       return Promise.resolve(null);
     }
 
     return Promise.resolve(Math.random());
+  },
+
+  smokeTest: async (): Promise<void> => {
+    // A connectivity test
+    await Promise.resolve();
   },
 };
 

--- a/template/lambda-sqs-worker/src/services/pipelineEventSender.ts
+++ b/template/lambda-sqs-worker/src/services/pipelineEventSender.ts
@@ -2,10 +2,23 @@ import { config } from 'src/config';
 
 import { sns } from './aws';
 
-export const sendPipelineEvent = async (event: unknown): Promise<string> => {
+export const sendPipelineEvent = async (
+  event: unknown,
+  smokeTest: boolean = false,
+): Promise<string> => {
   const snsResponse = await sns
     .publish({
       Message: JSON.stringify(event),
+      ...(smokeTest && {
+        MessageAttributes: {
+          // Used for connectivity tests.
+          // Subscribers should filter out messages containing this attribute.
+          SmokeTest: {
+            DataType: 'String',
+            StringValue: 'true',
+          },
+        },
+      }),
       TopicArn: config.destinationSnsTopicArn,
     })
     .promise();


### PR DESCRIPTION
This is missing a bit of documentation; I have a follow-up PR to uplift the API and worker READMEs. We've tested this pattern with an internal service and I've also ensured that the template is deployable from scratch.

---

Relates to #116, which can be closed once we add appropriate documentation to the API templates.