### PR TITLE
Exclude Jest `config.ts` files from coverage

### DIFF
--- a/.changeset/swift-ads-arrive.md
+++ b/.changeset/swift-ads-arrive.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**test:** Exclude Jest `config.ts` files from coverage

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -32,6 +32,7 @@ module.exports = {
     '!<rootDir>/dist*/**',
     '!<rootDir>/lib*/**',
     '!<rootDir>/tmp*/**',
+    '!<rootDir>/jest.*.ts',
   ],
   coverageDirectory: 'coverage',
   moduleNameMapper: {


### PR DESCRIPTION
These were getting picked up post-TypeScriptification.