### PR TITLE
Fix `process.argv` propagation

### DIFF
--- a/.changeset/modern-grapes-crash.md
+++ b/.changeset/modern-grapes-crash.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**node, start:** Propagate `process.argv`

--- a/.changeset/modern-grapes-crash.md
+++ b/.changeset/modern-grapes-crash.md
@@ -3,3 +3,9 @@
 ---
 
 **node, start:** Propagate `process.argv`
+
+Passing command-line arguments into a script now works as expected:
+
+```bash
+yarn skuba node src/script.ts arg1 arg2 arg3
+```

--- a/.changeset/nasty-carpets-rescue.md
+++ b/.changeset/nasty-carpets-rescue.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**node:** Support Node.js inspector options when running a script

--- a/.changeset/nasty-carpets-rescue.md
+++ b/.changeset/nasty-carpets-rescue.md
@@ -3,3 +3,9 @@
 ---
 
 **node:** Support Node.js inspector options when running a script
+
+Passing an [inspector option](https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options) for script debugging now works as expected:
+
+```bash
+yarn skuba node --inspect-brk src/script.ts
+```

--- a/package.json
+++ b/package.json
@@ -89,8 +89,7 @@
     "ts-node": "^9.1.1",
     "ts-node-dev": "1.1.1",
     "tsconfig-seek": "1.0.2",
-    "typescript": "4.1.3",
-    "yargs-parser": "^20.2.4"
+    "typescript": "4.1.3"
   },
   "peerDependencies": {
     "@types/jest": ">= 25 < 27",

--- a/src/cli/node.ts
+++ b/src/cli/node.ts
@@ -46,7 +46,7 @@ export const node = async () => {
       path.posix.join('skuba', 'lib', 'register'),
       '--require',
       path.posix.join('ts-node', 'register', 'transpile-only'),
-      ...[path.join(__dirname, '..', 'wrapper')],
+      path.join(__dirname, '..', 'wrapper'),
       ...args.script,
     );
   }
@@ -58,7 +58,6 @@ export const node = async () => {
     '--require',
     path.posix.join('skuba', 'lib', 'register'),
     '--transpile-only',
-    ...(args.entryPoint ? [path.join(__dirname, '..', 'wrapper')] : []),
     ...args.script,
   );
 };

--- a/src/skuba.ts
+++ b/src/skuba.ts
@@ -12,7 +12,7 @@
 
 import path from 'path';
 
-import { parseArgs } from './utils/args';
+import { parseProcessArgs } from './utils/args';
 import { COMMAND_DIR, COMMAND_SET, commandToModule } from './utils/command';
 import { handleCliError } from './utils/error';
 import { showHelp } from './utils/help';
@@ -21,7 +21,7 @@ import { showLogoAndVersionInfo } from './utils/logo';
 import { hasProp } from './utils/validation';
 
 const skuba = async () => {
-  const { commandName } = parseArgs(process.argv);
+  const { commandName } = parseProcessArgs(process.argv);
 
   if (COMMAND_SET.has(commandName)) {
     const moduleName = commandToModule(commandName);

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -67,30 +67,30 @@ describe('parseRunArgs', () => {
   }
 
   test.each`
-    input                                                | entryPoint     | port         | node                         | script
-    ${''}                                                | ${undefined}   | ${undefined} | ${[]}                        | ${[]}
-    ${'--inspect'}                                       | ${undefined}   | ${undefined} | ${['--inspect']}             | ${[]}
-    ${'--inspect=1234'}                                  | ${undefined}   | ${undefined} | ${['--inspect=1234']}        | ${[]}
-    ${'--inspect 1234'}                                  | ${undefined}   | ${undefined} | ${['--inspect', '1234']}     | ${[]}
-    ${'--inspect 1234 listen.ts'}                        | ${'listen.ts'} | ${undefined} | ${['--inspect', '1234']}     | ${[]}
-    ${'--inspect 1234 listen.ts --inspect 1234'}         | ${'listen.ts'} | ${undefined} | ${['--inspect', '1234']}     | ${['--inspect', '1234']}
-    ${'--inspect listen.ts'}                             | ${'listen.ts'} | ${undefined} | ${['--inspect']}             | ${[]}
-    ${'--inspect-brk'}                                   | ${undefined}   | ${undefined} | ${['--inspect-brk']}         | ${[]}
-    ${'--inspect-brk=1234'}                              | ${undefined}   | ${undefined} | ${['--inspect-brk=1234']}    | ${[]}
-    ${'--inspect-brk 1234'}                              | ${undefined}   | ${undefined} | ${['--inspect-brk', '1234']} | ${[]}
-    ${'--inspect-brk 1234 listen.ts'}                    | ${'listen.ts'} | ${undefined} | ${['--inspect-brk', '1234']} | ${[]}
-    ${'--inspect-brk 1234 listen.ts --inspect-brk 1234'} | ${'listen.ts'} | ${undefined} | ${['--inspect-brk', '1234']} | ${['--inspect-brk', '1234']}
-    ${'--inspect-brk listen.ts'}                         | ${'listen.ts'} | ${undefined} | ${['--inspect-brk']}         | ${[]}
-    ${'--port'}                                          | ${undefined}   | ${undefined} | ${[]}                        | ${[]}
-    ${'--port=1234'}                                     | ${undefined}   | ${1234}      | ${[]}                        | ${[]}
-    ${'--port 1234'}                                     | ${undefined}   | ${1234}      | ${[]}                        | ${[]}
-    ${'--port 1234 listen.ts'}                           | ${'listen.ts'} | ${1234}      | ${[]}                        | ${[]}
-    ${'--port 1234 listen.ts --port 5678'}               | ${'listen.ts'} | ${1234}      | ${[]}                        | ${['--port', '5678']}
-    ${'--port listen.ts'}                                | ${'listen.ts'} | ${undefined} | ${[]}                        | ${[]}
-    ${'listen.ts'}                                       | ${'listen.ts'} | ${undefined} | ${[]}                        | ${[]}
-    ${'listen.ts --inspect'}                             | ${'listen.ts'} | ${undefined} | ${[]}                        | ${['--inspect']}
-    ${'listen.ts --inspect-brk'}                         | ${'listen.ts'} | ${undefined} | ${[]}                        | ${['--inspect-brk']}
-    ${'listen.ts --port 1234'}                           | ${'listen.ts'} | ${undefined} | ${[]}                        | ${['--port', '1234']}
+    input                                                | entryPoint     | port         | node                      | script
+    ${''}                                                | ${undefined}   | ${undefined} | ${[]}                     | ${[]}
+    ${'--inspect'}                                       | ${undefined}   | ${undefined} | ${['--inspect']}          | ${[]}
+    ${'--inspect=1234'}                                  | ${undefined}   | ${undefined} | ${['--inspect=1234']}     | ${[]}
+    ${'--inspect 1234'}                                  | ${undefined}   | ${undefined} | ${['--inspect=1234']}     | ${[]}
+    ${'--inspect 1234 listen.ts'}                        | ${'listen.ts'} | ${undefined} | ${['--inspect=1234']}     | ${[]}
+    ${'--inspect 1234 listen.ts --inspect 1234'}         | ${'listen.ts'} | ${undefined} | ${['--inspect=1234']}     | ${['--inspect', '1234']}
+    ${'--inspect listen.ts'}                             | ${'listen.ts'} | ${undefined} | ${['--inspect']}          | ${[]}
+    ${'--inspect-brk'}                                   | ${undefined}   | ${undefined} | ${['--inspect-brk']}      | ${[]}
+    ${'--inspect-brk=1234'}                              | ${undefined}   | ${undefined} | ${['--inspect-brk=1234']} | ${[]}
+    ${'--inspect-brk 1234'}                              | ${undefined}   | ${undefined} | ${['--inspect-brk=1234']} | ${[]}
+    ${'--inspect-brk 1234 listen.ts'}                    | ${'listen.ts'} | ${undefined} | ${['--inspect-brk=1234']} | ${[]}
+    ${'--inspect-brk 1234 listen.ts --inspect-brk 1234'} | ${'listen.ts'} | ${undefined} | ${['--inspect-brk=1234']} | ${['--inspect-brk', '1234']}
+    ${'--inspect-brk listen.ts'}                         | ${'listen.ts'} | ${undefined} | ${['--inspect-brk']}      | ${[]}
+    ${'--port'}                                          | ${undefined}   | ${undefined} | ${[]}                     | ${[]}
+    ${'--port=1234'}                                     | ${undefined}   | ${1234}      | ${[]}                     | ${[]}
+    ${'--port 1234'}                                     | ${undefined}   | ${1234}      | ${[]}                     | ${[]}
+    ${'--port 1234 listen.ts'}                           | ${'listen.ts'} | ${1234}      | ${[]}                     | ${[]}
+    ${'--port 1234 listen.ts --port 5678'}               | ${'listen.ts'} | ${1234}      | ${[]}                     | ${['--port', '5678']}
+    ${'--port listen.ts'}                                | ${'listen.ts'} | ${undefined} | ${[]}                     | ${[]}
+    ${'listen.ts'}                                       | ${'listen.ts'} | ${undefined} | ${[]}                     | ${[]}
+    ${'listen.ts --inspect'}                             | ${'listen.ts'} | ${undefined} | ${[]}                     | ${['--inspect']}
+    ${'listen.ts --inspect-brk'}                         | ${'listen.ts'} | ${undefined} | ${[]}                     | ${['--inspect-brk']}
+    ${'listen.ts --port 1234'}                           | ${'listen.ts'} | ${undefined} | ${[]}                     | ${['--port', '1234']}
   `('$input', ({ input, ...expected }: TestCase) =>
     expect(parseRunArgs(input.split(' '))).toEqual(expected),
   );

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -1,6 +1,6 @@
-import { parseArgs, unsafeMapYargs } from './args';
+import { parseProcessArgs, parseRunArgs } from './args';
 
-describe('parseArgs', () => {
+describe('parseProcessArgs', () => {
   it('parses a macOS command with args', () => {
     const argv = [
       '/usr/local/bin/node',
@@ -9,7 +9,7 @@ describe('parseArgs', () => {
       '--xyz',
     ];
 
-    expect(parseArgs(argv)).toStrictEqual({
+    expect(parseProcessArgs(argv)).toStrictEqual({
       commandName: 'start',
       args: ['--xyz'],
     });
@@ -22,7 +22,7 @@ describe('parseArgs', () => {
       'start',
     ];
 
-    expect(parseArgs(argv)).toStrictEqual({
+    expect(parseProcessArgs(argv)).toStrictEqual({
       commandName: 'start',
       args: [],
     });
@@ -36,7 +36,7 @@ describe('parseArgs', () => {
       '--xyz',
     ];
 
-    expect(parseArgs(argv)).toStrictEqual({
+    expect(parseProcessArgs(argv)).toStrictEqual({
       commandName: 'start',
       args: ['--xyz'],
     });
@@ -49,25 +49,49 @@ describe('parseArgs', () => {
       'start',
     ];
 
-    expect(parseArgs(argv)).toStrictEqual({
+    expect(parseProcessArgs(argv)).toStrictEqual({
       commandName: 'start',
       args: [],
     });
   });
 });
 
-describe('unsafeMapYargs', () => {
-  it('maps an assortment of yargs', () =>
-    expect(
-      unsafeMapYargs({
-        a: 1,
-        b: '2',
-        c: true,
-        d: [3, '4'],
-        e: [],
-        f: false,
-        g: undefined,
-        h: null,
-      }),
-    ).toEqual(['--a=1', '--b=2', '--c', '--d=3']));
+describe('parseRunArgs', () => {
+  interface TestCase {
+    input: string;
+
+    entryPoint: string | undefined;
+    port: number | undefined;
+    node: string[];
+    script: string[];
+  }
+
+  test.each`
+    input                                                | entryPoint     | port         | node                         | script
+    ${''}                                                | ${undefined}   | ${undefined} | ${[]}                        | ${[]}
+    ${'--inspect'}                                       | ${undefined}   | ${undefined} | ${['--inspect']}             | ${[]}
+    ${'--inspect=1234'}                                  | ${undefined}   | ${undefined} | ${['--inspect=1234']}        | ${[]}
+    ${'--inspect 1234'}                                  | ${undefined}   | ${undefined} | ${['--inspect', '1234']}     | ${[]}
+    ${'--inspect 1234 listen.ts'}                        | ${'listen.ts'} | ${undefined} | ${['--inspect', '1234']}     | ${[]}
+    ${'--inspect 1234 listen.ts --inspect 1234'}         | ${'listen.ts'} | ${undefined} | ${['--inspect', '1234']}     | ${['--inspect', '1234']}
+    ${'--inspect listen.ts'}                             | ${'listen.ts'} | ${undefined} | ${['--inspect']}             | ${[]}
+    ${'--inspect-brk'}                                   | ${undefined}   | ${undefined} | ${['--inspect-brk']}         | ${[]}
+    ${'--inspect-brk=1234'}                              | ${undefined}   | ${undefined} | ${['--inspect-brk=1234']}    | ${[]}
+    ${'--inspect-brk 1234'}                              | ${undefined}   | ${undefined} | ${['--inspect-brk', '1234']} | ${[]}
+    ${'--inspect-brk 1234 listen.ts'}                    | ${'listen.ts'} | ${undefined} | ${['--inspect-brk', '1234']} | ${[]}
+    ${'--inspect-brk 1234 listen.ts --inspect-brk 1234'} | ${'listen.ts'} | ${undefined} | ${['--inspect-brk', '1234']} | ${['--inspect-brk', '1234']}
+    ${'--inspect-brk listen.ts'}                         | ${'listen.ts'} | ${undefined} | ${['--inspect-brk']}         | ${[]}
+    ${'--port'}                                          | ${undefined}   | ${undefined} | ${[]}                        | ${[]}
+    ${'--port=1234'}                                     | ${undefined}   | ${1234}      | ${[]}                        | ${[]}
+    ${'--port 1234'}                                     | ${undefined}   | ${1234}      | ${[]}                        | ${[]}
+    ${'--port 1234 listen.ts'}                           | ${'listen.ts'} | ${1234}      | ${[]}                        | ${[]}
+    ${'--port 1234 listen.ts --port 5678'}               | ${'listen.ts'} | ${1234}      | ${[]}                        | ${['--port', '5678']}
+    ${'--port listen.ts'}                                | ${'listen.ts'} | ${undefined} | ${[]}                        | ${[]}
+    ${'listen.ts'}                                       | ${'listen.ts'} | ${undefined} | ${[]}                        | ${[]}
+    ${'listen.ts --inspect'}                             | ${'listen.ts'} | ${undefined} | ${[]}                        | ${['--inspect']}
+    ${'listen.ts --inspect-brk'}                         | ${'listen.ts'} | ${undefined} | ${[]}                        | ${['--inspect-brk']}
+    ${'listen.ts --port 1234'}                           | ${'listen.ts'} | ${undefined} | ${[]}                        | ${['--port', '1234']}
+  `('$input', ({ input, ...expected }: TestCase) =>
+    expect(parseRunArgs(input.split(' '))).toEqual(expected),
+  );
 });

--- a/src/wrapper/index.ts
+++ b/src/wrapper/index.ts
@@ -15,14 +15,17 @@ import { log } from '../utils/logging';
 
 import { main } from './main';
 
-const args = process.argv.slice(2);
+const ENTRY_POINT_VAR = '__SKUBA_ENTRY_POINT';
+const PORT_VAR = '__SKUBA_PORT';
 
-if (args.length < 2) {
-  throw new Error(
-    `Missing arguments: ${log.bold('entry-point')} ${log.bold('port')}`,
-  );
+const rawEntryPoint = process.env[ENTRY_POINT_VAR];
+if (!rawEntryPoint) {
+  throw new Error(`Missing environment variable: ${log.bold(ENTRY_POINT_VAR)}`);
 }
 
-const [rawEntryPoint, rawPort] = args;
+const rawPort = process.env[PORT_VAR];
+if (!rawPort) {
+  throw new Error(`Missing environment variable: ${log.bold(PORT_VAR)}`);
+}
 
 main(rawEntryPoint, rawPort).catch(handleCliError);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10740,7 +10740,7 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3, yargs-parser@^20.2.4:
+yargs-parser@20.x, yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==


### PR DESCRIPTION
`skuba node` and `skuba start` weren't even making an attempt to propagate command-line arguments to `process.argv` in the underlying entry point script. This is a dealbreaker for the former command as it's fairly common to want to run arbitrary scripts that take arguments, e.g. `skuba node cli/dropAllTables.ts --force`.

To maintain compatibility some tricky parsing is required, because we currently route arguments to a bunch of different places. The wrapper interplay is somewhat simplified by moving some arguments to environment variables.

I also uncovered that `ts-node` doesn't like Node.js inspector options, so we now run scripts using plain `node`. What could go wrong with all these layers upon layers?