### PR TITLE
Run processes serially on Buildkite

### DIFF
--- a/.changeset/purple-points-wash.md
+++ b/.changeset/purple-points-wash.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+**build-package, lint:** Run serially on Buildkite
+
+These commands now run their underlying processes serially when the `BUILDKITE` environment variable is set. This reduces the chance of resource exhaustion on smaller instance sizes but slows down builds.

--- a/docs/buildkite.md
+++ b/docs/buildkite.md
@@ -1,0 +1,63 @@
+# Buildkite
+
+## My agent exits with status -1
+
+**Scenario:**
+you're running some skuba commands like `skuba lint`,
+and observe the following error message on a Buildkite step:
+
+> Exited with status -1 (process killed or agent lost; see the timeline tab for more information)
+
+Navigating to the Timeline tab reveals this:
+
+> **Dispatcher Cancelled Job** (+Xm)
+>
+> |                          |                             |
+> | :----------------------- | :-------------------------- |
+> | **Last Agent Heartbeat** | Yesterday at 0:00:00.000 PM |
+> | **Command Exit Status**  | `-1 (Agent Lost)`           |
+
+**Explanation:**
+This implies that the step(s) exhausted the Buildkite agent's resources.
+The agent may be tied up running a particularly compute-intensive step.
+
+**Options:**
+
+1. Propagate the `BUILDKITE` environment variable to `skuba build-package` and `skuba lint` steps.
+   This will cause them to run their underlying processes serially,
+   reducing the chance of resource exhaustion.
+
+   With the [Docker Buildkite plugin],
+   you can achieve this in a couple ways:
+
+   ```yaml
+   steps:
+     - plugins:
+         - docker#v3.7.0:
+             # Option 1a: List environment variable explicitly
+             environment:
+               - BUILDKITE
+             # Option 1b: Propagate all pipeline variables
+             propagate-environment: true
+   ```
+
+   With Docker Compose,
+   you can add the variable to your [Compose file]:
+
+   ```yaml
+   services:
+     app:
+       environment:
+         - BUILDKITE
+   ```
+
+1. Reduce the number of agents that run on each instance.
+
+   At SEEK, this can be configured through Build Agency.
+
+1. Increase the instance size.
+
+   At SEEK, this can be configured through Build Agency.
+
+[compose file]: https://docs.docker.com/compose/compose-file
+[docker buildkite plugin]: https://github.com/buildkite-plugins/docker-buildkite-plugin

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -14,14 +14,14 @@ const externalLint = () =>
       prefixColor: 'magenta',
     },
     {
-      command: 'prettier --check .',
-      name: 'Prettier',
-      prefixColor: 'cyan',
-    },
-    {
       command: 'tsc --noEmit',
       name: 'tsc',
       prefixColor: 'blue',
+    },
+    {
+      command: 'prettier --check .',
+      name: 'Prettier',
+      prefixColor: 'cyan',
     },
   ]);
 

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -122,6 +122,10 @@ export const execConcurrently = async (commands: ExecConcurrentlyCommand[]) => {
         name: name.padEnd(maxNameLength),
         prefixColor,
       })),
+      {
+        // Run serially on Buildkite, where we often use puny agents.
+        maxProcesses: process.env.BUILDKITE ? 1 : 0,
+      },
     );
   } catch (err: unknown) {
     const result = ConcurrentlyErrors.validate(err);


### PR DESCRIPTION
This is sad but it's not uncommon to run into issues with typical instance sizing at SEEK. This should also alleviate contention on the shared publishing agents.

If we want to be clever in future we could inspect `BUILDKITE_AGENT_META_DATA_AWS_INSTANCE_TYPE`.