### PR TITLE
Retire REGION in favour of AWS_REGION

### DIFF
--- a/.changeset/silly-knives-prove.md
+++ b/.changeset/silly-knives-prove.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+**template/lambda-sqs-worker:** Use `AWS_REGION` environment variable

--- a/.changeset/silly-knives-prove.md
+++ b/.changeset/silly-knives-prove.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 **template/lambda-sqs-worker:** Use `AWS_REGION` environment variable

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -82,7 +82,6 @@ functions:
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
 
       ENVIRONMENT: ${env:ENVIRONMENT}
-      REGION: ${self:provider.region}
       SERVICE: ${self:service}
       VERSION: ${env:VERSION, 'local'}
 

--- a/template/lambda-sqs-worker/src/config.ts
+++ b/template/lambda-sqs-worker/src/config.ts
@@ -44,7 +44,7 @@ const configs: Record<Environment, () => Omit<Config, 'environment'>> = {
   prod: () => ({
     logLevel: 'info',
     name: Env.string('SERVICE'),
-    region: Env.string('REGION'),
+    region: Env.string('AWS_REGION'),
     version: Env.string('VERSION'),
 
     destinationSnsTopicArn: Env.string('DESTINATION_SNS_TOPIC_ARN'),


### PR DESCRIPTION
Why:
1. `AWS_REGION` is the reserved runtime environment variable in AWS lambda.
2. AWS_SDK looks for AWS_REGION by default
3. one less environment configuration in serverless.yml

References:
https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html#setting-region-environment-variable
https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html