### PR TITLE
Support debug flag on format and lint

### DIFF
--- a/.changeset/nice-apricots-turn.md
+++ b/.changeset/nice-apricots-turn.md
@@ -1,0 +1,5 @@
+---
+'skuba': minor
+---
+
+**format, lint:** Support `--debug` flag

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ Apply automatic fixes to code quality and flag issues that require manual interv
 
 This script should be run locally before pushing code to a remote branch.
 
+| Option    | Description                 |
+| :-------- | :-------------------------- |
+| `--debug` | Enable debug console output |
+
 ### `skuba help`
 
 ```shell
@@ -220,6 +224,10 @@ see [`skuba configure`].
 Check for code quality issues.
 
 This script should be run in CI to verify that [`skuba format`] was applied and triaged locally.
+
+| Option    | Description                 |
+| :-------- | :-------------------------- |
+| `--debug` | Enable debug console output |
 
 ### `skuba node`
 

--- a/src/cli/format.test.ts
+++ b/src/cli/format.test.ts
@@ -1,0 +1,100 @@
+import execa from 'execa';
+
+import { hasStringProp } from '../utils/validation';
+
+import { format } from './format';
+
+jest.mock('execa');
+
+const execaCalls = () =>
+  ((execa as unknown) as jest.Mock<typeof execa>).mock.calls
+    .flat(2)
+    .map((val) =>
+      Array.isArray(val) || !hasStringProp(val, 'localDir')
+        ? val
+        : { ...val, localDir: 'REDACTED' },
+    );
+
+describe('format', () => {
+  const consoleLog = jest.spyOn(global.console, 'log').mockReturnValue();
+
+  const consoleLogCalls = () => consoleLog.mock.calls.flat(2);
+
+  afterEach(jest.clearAllMocks);
+
+  const oldProcessArgv = process.argv;
+  afterAll(() => (process.argv = oldProcessArgv));
+
+  it('handles no flags', async () => {
+    process.argv = [];
+
+    await expect(format()).resolves.toBeUndefined();
+
+    expect(execaCalls()).toMatchInlineSnapshot(`
+      Array [
+        "eslint",
+        "--ext=js,ts,tsx",
+        "--fix",
+        ".",
+        Object {
+          "localDir": "REDACTED",
+          "preferLocal": true,
+          "stdio": "inherit",
+        },
+        "prettier",
+        "--write",
+        ".",
+        Object {
+          "localDir": "REDACTED",
+          "preferLocal": true,
+          "stdio": "inherit",
+        },
+      ]
+    `);
+
+    expect(consoleLogCalls()).toMatchInlineSnapshot(`
+      Array [
+        "✔ ESLint",
+        "✔ Prettier",
+      ]
+    `);
+  });
+
+  it('handles debug flag', async () => {
+    process.argv = ['something', '--dEbUg', 'else'];
+
+    await expect(format()).resolves.toBeUndefined();
+
+    expect(execaCalls()).toMatchInlineSnapshot(`
+      Array [
+        "eslint",
+        "--debug",
+        "--ext=js,ts,tsx",
+        "--fix",
+        ".",
+        Object {
+          "localDir": "REDACTED",
+          "preferLocal": true,
+          "stdio": "inherit",
+        },
+        "prettier",
+        "--loglevel",
+        "debug",
+        "--write",
+        ".",
+        Object {
+          "localDir": "REDACTED",
+          "preferLocal": true,
+          "stdio": "inherit",
+        },
+      ]
+    `);
+
+    expect(consoleLogCalls()).toMatchInlineSnapshot(`
+      Array [
+        "✔ ESLint",
+        "✔ Prettier",
+      ]
+    `);
+  });
+});

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -1,10 +1,24 @@
+import { hasDebugFlag } from '../utils/args';
 import { exec } from '../utils/exec';
 import { log } from '../utils/logging';
 
 export const format = async () => {
-  await exec('eslint', '--ext=js,ts,tsx', '--fix', '.');
+  const debug = hasDebugFlag();
+
+  await exec(
+    'eslint',
+    ...(debug ? ['--debug'] : []),
+    '--ext=js,ts,tsx',
+    '--fix',
+    '.',
+  );
   log.ok('✔ ESLint');
 
-  await exec('prettier', '--write', '.');
+  await exec(
+    'prettier',
+    ...(debug ? ['--loglevel', 'debug'] : []),
+    '--write',
+    '.',
+  );
   log.ok('✔ Prettier');
 };

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -3,23 +3,30 @@ import path from 'path';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 
+import { hasDebugFlag } from '../utils/args';
 import { execConcurrently } from '../utils/exec';
 import { getConsumerManifest } from '../utils/manifest';
 
-const externalLint = () =>
+interface Options {
+  debug: boolean;
+}
+
+const externalLint = ({ debug }: Options) =>
   execConcurrently([
     {
-      command: 'eslint --ext=js,ts,tsx --report-unused-disable-directives .',
+      command: `eslint${
+        debug ? ' --debug' : ''
+      } --ext=js,ts,tsx --report-unused-disable-directives .`,
       name: 'ESLint',
       prefixColor: 'magenta',
     },
     {
-      command: 'tsc --noEmit',
+      command: `tsc${debug ? ' --extendedDiagnostics' : ''} --noEmit`,
       name: 'tsc',
       prefixColor: 'blue',
     },
     {
-      command: 'prettier --check .',
+      command: `prettier --check${debug ? ' --loglevel debug' : ''} .`,
       name: 'Prettier',
       prefixColor: 'cyan',
     },
@@ -51,7 +58,11 @@ export const internalLint = async () => {
 };
 
 export const lint = async () => {
-  await externalLint();
+  const opts: Options = {
+    debug: hasDebugFlag(),
+  };
+
+  await externalLint(opts);
 
   await internalLint();
 };

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -1,4 +1,19 @@
-import { parseProcessArgs, parseRunArgs } from './args';
+import { hasDebugFlag, parseProcessArgs, parseRunArgs } from './args';
+
+describe('hasDebugFlag', () => {
+  test.each`
+    description                    | args                                | expected
+    ${'no args'}                   | ${[]}                               | ${false}
+    ${'unrelated args'}            | ${['something', 'else']}            | ${false}
+    ${'single dash'}               | ${['-debug']}                       | ${false}
+    ${'matching lowercase arg'}    | ${['--debug']}                      | ${true}
+    ${'matching uppercase arg'}    | ${['--DEBUG']}                      | ${true}
+    ${'matching spongebob arg'}    | ${['--dEBuG']}                      | ${true}
+    ${'matching arg among others'} | ${['something', '--debug', 'else']} | ${true}
+  `('$description => $expected', ({ args, expected }) =>
+    expect(hasDebugFlag(args)).toBe(expected),
+  );
+});
 
 describe('parseProcessArgs', () => {
   it('parses a macOS command with args', () => {

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -2,6 +2,9 @@ import assert from 'assert';
 
 import { COMMAND_ALIASES } from './command';
 
+export const hasDebugFlag = (args = process.argv) =>
+  args.some((arg) => arg.toLocaleLowerCase() === '--debug');
+
 /**
  * Parse process arguments.
  *


### PR DESCRIPTION
This can clue you in on which files ESLint and Prettier are formatting and linting, which can in turn inform your `.eslintignore` and `.prettierignore` files.