### PR TITLE
Expose testTimeout in jest preset options

### DIFF
--- a/.changeset/perfect-eyes-approve.md
+++ b/.changeset/perfect-eyes-approve.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+Expose testTimeout in jest preset options

--- a/.changeset/perfect-eyes-approve.md
+++ b/.changeset/perfect-eyes-approve.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 Expose testTimeout in jest preset options

--- a/.changeset/short-baboons-mix.md
+++ b/.changeset/short-baboons-mix.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**Jest:** Expose `testTimeout` in `Jest.mergePreset` options

--- a/src/api/jest/index.ts
+++ b/src/api/jest/index.ts
@@ -16,6 +16,7 @@ type Props = Pick<
   | 'setupFiles'
   | 'setupFilesAfterEnv'
   | 'testPathIgnorePatterns'
+  | 'testTimeout'
 >;
 
 /**


### PR DESCRIPTION
Makes it easier to set without having to merge with a separate object, e.g https://github.com/SEEK-Jobs/indie-awsk-redux/pull/23 

~I'm not sure if there is a way to set this if it isn't configurable via the skuba preset.~