### PR TITLE
fix CDK worker template

### DIFF
--- a/.changeset/green-bats-admire.md
+++ b/.changeset/green-bats-admire.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker-cdk:** Trim CDK deployment output

--- a/.changeset/seven-hotels-attend.md
+++ b/.changeset/seven-hotels-attend.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker-cdk:** Fix npm token in Buildkite pipeline

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -9,16 +9,16 @@ prod-agent: &prod-agent
 plugins: &plugins #alias for shared plugins
   seek-oss/aws-sm#v2.3.1:
     env:
-      NPM_TOKEN: 'arn:aws:secretsmanager:ap-southeast-2:987872074697:secret:npm/npm-read-token'
+      NPM_READ_TOKEN: 'arn:aws:secretsmanager:ap-southeast-2:987872074697:secret:npm/npm-read-token'
   docker#v3.8.0:
     volumes:
       - /workdir/node_modules
       - /workdir/lib
     environment:
-      - NPM_TOKEN
+      - NPM_READ_TOKEN
   seek-oss/docker-ecr-cache#v1.9.0:
     build-args:
-      - NPM_TOKEN
+      - NPM_READ_TOKEN
     cache-on:
       - package.json
       - yarn.lock

--- a/template/lambda-sqs-worker-cdk/cdk.json
+++ b/template/lambda-sqs-worker-cdk/cdk.json
@@ -20,6 +20,7 @@
           "SOMETHING": "prod"
         }
       }
-    }
+    },
+    "progress": "events"
   }
 }


### PR DESCRIPTION
**What?**
1. Pass the correct npm token arg name to the build container
2. Limit update to events only to prevent output being flooded by single characters during cdk deploy