### PR TITLE
Build lambda-sqs-worker-cdk before deploy

### DIFF
--- a/.changeset/lucky-pants-peel.md
+++ b/.changeset/lucky-pants-peel.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker-cdk:** Always build before deploy
+
+This prevents stale compiled code from being cached and deployed from ECR.

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -35,19 +35,21 @@ steps:
       - echo "--- Running yarn test :jest:"
       - yarn test
 
-  - label: 'CDK Deploy Staging  :shipit:'
+  - label: 'Build & CDK Deploy Staging  :shipit:'
     <<: *dev-agent
     plugins:
       <<: *plugins
     depends_on:
       - test
     command:
+      - echo "--- Building code"
+      - yarn build
       - echo "--- Running CDK deploy to staging"
       - yarn deploy:dev
     concurrency: 1
     concurrency_group: '<%- repoName %>/deploy/dev'
 
-  - label: 'CDK Deploy Production  :shipit:'
+  - label: 'Build & CDK Deploy Production  :shipit:'
     branches: 'master'
     <<: *prod-agent
     plugins:
@@ -55,6 +57,8 @@ steps:
     depends_on:
       - test
     command:
+      - echo "--- Building code"
+      - yarn build
       - echo "--- Running CDK deploy to production"
       - yarn deploy:prod
     concurrency: 1

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -15,16 +15,8 @@ RUN \
 
 ###
 
-FROM node:14-alpine AS dev-deps
+FROM node:14-alpine AS build
 
 WORKDIR /workdir
 
 COPY --from=unsafe-dev-deps /workdir .
-
-###
-
-FROM dev-deps AS build
-
-COPY . .
-
-RUN yarn build

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -15,7 +15,7 @@ RUN \
 
 ###
 
-FROM node:14-alpine AS build
+FROM node:14-alpine AS dev-deps
 
 WORKDIR /workdir
 


### PR DESCRIPTION
**Why?**
Prior to this change, the built code was packaged with the docker image. Since the image is ECR cached on `package.json` and `yarn.lock`, stale code will be deployed if there are no changes to either file.

**What?**
This change adds a build command before CDK deploy to ensure the latest built code gets picked up and deployed. It also removes the unnecessary code build in the image.