### PR TITLE
Banish `typeof undefined` syntax

### DIFF
--- a/.changeset/loud-feet-pump.md
+++ b/.changeset/loud-feet-pump.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Banish `typeof undefined` syntax

--- a/src/cli/configure/analyseConfiguration.ts
+++ b/src/cli/configure/analyseConfiguration.ts
@@ -42,9 +42,7 @@ export const analyseConfiguration = async (
 
     await Promise.all(
       Object.entries(files).map(([filename, { data }]) =>
-        typeof data === 'undefined'
-          ? fs.remove(filename)
-          : fs.writeFile(filename, data),
+        data === undefined ? fs.remove(filename) : fs.writeFile(filename, data),
       ),
     );
   };

--- a/src/cli/configure/analysis/diff.ts
+++ b/src/cli/configure/analysis/diff.ts
@@ -4,9 +4,9 @@ export const determineOperation = (
   oldData?: string,
   newData?: string,
 ): string => {
-  if (typeof oldData === 'undefined') {
+  if (oldData === undefined) {
     return chalk.green('A');
   }
 
-  return typeof newData === 'undefined' ? chalk.red('D') : chalk.yellow('M');
+  return newData === undefined ? chalk.red('D') : chalk.yellow('M');
 };

--- a/src/cli/configure/analysis/package.ts
+++ b/src/cli/configure/analysis/package.ts
@@ -14,7 +14,7 @@ export const getDestinationManifest = async (
 ) => {
   const result = await readPkgUp(props);
 
-  if (typeof result === 'undefined') {
+  if (result === undefined) {
     log.err(
       'Could not find a',
       log.bold('package.json'),
@@ -27,7 +27,7 @@ export const getDestinationManifest = async (
 };
 
 const joinVersions = (a: string | undefined, b: string | undefined) =>
-  [a, b].filter((v) => typeof v !== 'undefined').join(' -> ');
+  [a, b].filter((v) => v !== undefined).join(' -> ');
 
 interface DiffDependenciesProps {
   old: Record<string, string | undefined>;
@@ -39,7 +39,7 @@ export const diffDependencies = (
 ): DependencyDiff => {
   const deletionsAndModifications = Object.fromEntries(
     Object.entries(props.old).flatMap(([name, oldVersion]) => {
-      if (oldVersion === props.new[name] || typeof oldVersion === 'undefined') {
+      if (oldVersion === props.new[name] || oldVersion === undefined) {
         return [];
       }
 
@@ -54,7 +54,7 @@ export const diffDependencies = (
 
   const additions = Object.fromEntries(
     Object.entries(props.new).flatMap(([name, version]) => {
-      if (name in props.old || typeof version === 'undefined') {
+      if (name in props.old || version === undefined) {
         return [];
       }
 

--- a/src/cli/configure/getEntryPoint.ts
+++ b/src/cli/configure/getEntryPoint.ts
@@ -27,7 +27,7 @@ export const getEntryPoint = ({
     return manifest.packageJson.skuba.entryPoint;
   }
 
-  if (typeof templateConfig.entryPoint !== 'undefined') {
+  if (templateConfig.entryPoint !== undefined) {
     return templateConfig.entryPoint;
   }
 

--- a/src/cli/configure/getProjectType.ts
+++ b/src/cli/configure/getProjectType.ts
@@ -22,7 +22,7 @@ export const getProjectType = async ({
     return manifest.packageJson.skuba.type;
   }
 
-  if (typeof templateConfig.type !== 'undefined') {
+  if (templateConfig.type !== undefined) {
     return templateConfig.type;
   }
 

--- a/src/cli/configure/modules/jest.ts
+++ b/src/cli/configure/modules/jest.ts
@@ -48,11 +48,9 @@ export const jestModule = async (): Promise<Module> => {
       const inputFile = tsFile ?? jsFile;
 
       const props =
-        typeof inputFile === 'undefined'
-          ? undefined
-          : readModuleExports(inputFile);
+        inputFile === undefined ? undefined : readModuleExports(inputFile);
 
-      if (typeof props === 'undefined') {
+      if (props === undefined) {
         return configFile;
       }
 

--- a/src/cli/configure/modules/skubaDive.ts
+++ b/src/cli/configure/modules/skubaDive.ts
@@ -24,7 +24,7 @@ export const skubaDiveModule = ({ entryPoint, type }: Options): Module => {
 
       if (
         !packageJson?.dependencies?.['skuba-dive'] ||
-        typeof inputFile === 'undefined' ||
+        inputFile === undefined ||
         inputFile.includes('skuba-dive/register') ||
         registerFile?.includes('skuba-dive/register')
       ) {

--- a/src/cli/configure/modules/tsconfig.ts
+++ b/src/cli/configure/modules/tsconfig.ts
@@ -52,7 +52,7 @@ export const tsconfigModule = async ({
       }
 
       // optimistically rewire Dockerfile for new output directory
-      if (typeof outDir !== 'undefined' && outDir !== 'lib') {
+      if (outDir !== undefined && outDir !== 'lib') {
         files.Dockerfile = files.Dockerfile?.split(outDir).join('lib');
       }
 

--- a/src/cli/configure/processing/ignoreFile.ts
+++ b/src/cli/configure/processing/ignoreFile.ts
@@ -50,7 +50,7 @@ export const mergeWithIgnoreFile = (rawTemplateFile: string) => {
   ]);
 
   return (rawInputFile?: string) => {
-    if (typeof rawInputFile === 'undefined') {
+    if (rawInputFile === undefined) {
       return `${templateFile}\n`;
     }
 

--- a/src/cli/configure/processing/javascript.ts
+++ b/src/cli/configure/processing/javascript.ts
@@ -1,6 +1,6 @@
 export const prependImport = (name: string, file?: string) =>
   [`import '${name}';\n`, file]
-    .filter((value) => typeof value !== 'undefined')
+    .filter((value) => value !== undefined)
     .join('\n');
 
 export const stripImports = (names: readonly string[], inputFile: string) => {

--- a/src/cli/configure/processing/json.ts
+++ b/src/cli/configure/processing/json.ts
@@ -16,14 +16,14 @@ export const formatObject = (
 
   return formatPrettier(
     output,
-    typeof filepath === 'undefined' ? { parser: 'json' } : { filepath },
+    filepath === undefined ? { parser: 'json' } : { filepath },
   );
 };
 
 export const parseObject = (
   input: string | undefined,
 ): Record<PropertyKey, unknown> | undefined => {
-  if (typeof input === 'undefined') {
+  if (input === undefined) {
     return;
   }
 

--- a/src/cli/configure/processing/package.ts
+++ b/src/cli/configure/processing/package.ts
@@ -43,7 +43,7 @@ export const parsePackage = (
 ): PackageJson | undefined => {
   const data = parseObject(input);
 
-  if (typeof data === 'undefined') {
+  if (data === undefined) {
     return;
   }
 

--- a/src/cli/configure/processing/record.ts
+++ b/src/cli/configure/processing/record.ts
@@ -8,7 +8,7 @@ export const getFirstDefined = <T>(
 ): T | undefined => {
   for (const key of keys) {
     const value = record[key];
-    if (typeof value !== 'undefined') {
+    if (value !== undefined) {
       return value;
     }
   }

--- a/src/cli/configure/processing/typescript.ts
+++ b/src/cli/configure/processing/typescript.ts
@@ -39,7 +39,7 @@ const createExportDefaultObjectLiteralExpression = (
     undefined,
     undefined,
     undefined,
-    typeof callExpression === 'undefined'
+    callExpression === undefined
       ? factory.createObjectLiteralExpression(props, true)
       : factory.createCallExpression(callExpression, undefined, [
           factory.createObjectLiteralExpression(props, true),

--- a/src/cli/init/prompts.ts
+++ b/src/cli/init/prompts.ts
@@ -22,9 +22,7 @@ const BASE_CHOICES = [
       }
 
       return (
-        typeof team === 'undefined' ||
-        isGitHubTeam(team) ||
-        'fails GitHub validation'
+        team === undefined || isGitHubTeam(team) || 'fails GitHub validation'
       );
     },
   },

--- a/src/cli/lint.test.ts
+++ b/src/cli/lint.test.ts
@@ -8,8 +8,8 @@ const concurrentlyCalls = () =>
   ((concurrently as unknown) as jest.Mock<typeof concurrently>).mock.calls
     .flat(2)
     .map(({ env, maxProcesses, ...rest }) => ({
-      ...(typeof env !== 'undefined' && { env: 'REDACTED' }),
-      ...(typeof maxProcesses !== 'undefined' && { maxProcesses: 'REDACTED' }),
+      ...(env !== undefined && { env: 'REDACTED' }),
+      ...(maxProcesses !== undefined && { maxProcesses: 'REDACTED' }),
       ...rest,
     }));
 

--- a/src/cli/test.ts
+++ b/src/cli/test.ts
@@ -2,7 +2,7 @@ import { run } from 'jest';
 
 export const test = () => {
   // This is usually set in `jest-cli`'s binary wrapper
-  if (typeof process.env.NODE_ENV === 'undefined') {
+  if (process.env.NODE_ENV === undefined) {
     process.env.NODE_ENV = 'test';
   }
 

--- a/src/register.ts
+++ b/src/register.ts
@@ -36,7 +36,7 @@ const registerModuleAliases = () => {
   // Consider revisiting this when we decide how to better support monorepos.
   const result = readPkgUp.sync();
 
-  if (typeof result === 'undefined') {
+  if (result === undefined) {
     log.warn(log.bold('src'), '→', 'not found');
 
     return;

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -19,13 +19,13 @@ const DEFAULT_ENTRY_POINT = 'src/app.ts';
 let skubaManifest: NormalizedPackageJson | undefined;
 
 export const getSkubaManifest = async (): Promise<NormalizedPackageJson> => {
-  if (typeof skubaManifest !== 'undefined') {
+  if (skubaManifest !== undefined) {
     return skubaManifest;
   }
 
   const result = await readPkgUp({ cwd: __dirname });
 
-  if (typeof result === 'undefined') {
+  if (result === undefined) {
     throw Error('skuba could not find its own manifest');
   }
 
@@ -37,7 +37,7 @@ export const getConsumerManifest = () => readPkgUp();
 export const getEntryPointFromManifest = async () => {
   const result = await getConsumerManifest();
 
-  return typeof result !== 'undefined' &&
+  return result !== undefined &&
     hasStringProp(result.packageJson.skuba, 'entryPoint')
     ? result.packageJson.skuba.entryPoint
     : DEFAULT_ENTRY_POINT;
@@ -47,7 +47,7 @@ export const isBabelFromManifest = async () => {
   const result = await getConsumerManifest();
 
   return (
-    typeof result !== 'undefined' &&
+    result !== undefined &&
     hasProp(result.packageJson.skuba, 'babel') &&
     Boolean(result.packageJson.skuba.babel)
   );

--- a/template/koa-rest-api/src/framework/server.ts
+++ b/template/koa-rest-api/src/framework/server.ts
@@ -19,7 +19,7 @@ const metrics = MetricsMiddleware.create(
 );
 
 const requestLogging = RequestLogging.createMiddleware((ctx, fields, err) => {
-  if (typeof err === 'undefined') {
+  if (err === undefined) {
     // Depend on sidecar logging for happy path requests
     return;
   }

--- a/template/lambda-sqs-worker/src/services/pipelineEventSender.ts
+++ b/template/lambda-sqs-worker/src/services/pipelineEventSender.ts
@@ -23,7 +23,7 @@ export const sendPipelineEvent = async (
     })
     .promise();
 
-  if (typeof snsResponse.MessageId === 'undefined') {
+  if (snsResponse.MessageId === undefined) {
     throw Error('SNS did not return a message ID');
   }
 


### PR DESCRIPTION
Neither skuba nor the affected templates here would be run in an ES3 environment.