### PR TITLE
Removing `sqs:SendMessage` permission to Dead Letter Queue for `lambda-sqs-worker`

### DIFF
--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -45,9 +45,6 @@ provider:
         - Action: sns:Publish
           Effect: Allow
           Resource: !Ref DestinationTopic
-        - Action: sqs:SendMessage*
-          Effect: Allow
-          Resource: !GetAtt DeadLetterQueue.Arn
   stackTags:
     # TODO: add data classification tags
     # https://rfc.skinfra.xyz/RFC019-AWS-Tagging-Standard.html#seekdataconsumers


### PR DESCRIPTION
### Description
- In the `lambda-sqs-worker` template,
- There is no longer a need to specifically grant `sqs:SendMessage*` for your lambda to your DeadLetterQueue
- This is now automatically done by AWS under the hood
- Therefore, we can remove this from the `provider.iam` yaml config
- As long as the `RedrivePolicy` is configured in the `SQS Message Queue`

### Validation

- The `apply-services` team has a new worker that has this removed.
- And DLQ messages are still being sent to the DLQ.
- Link to serverless: https://github.com/SEEK-Jobs/apply-pipeline-job-enricher/blob/629a1e338edef91bbbbab552285c21308b347503/serverless.yml#L25
- Another example of the `virus-scanner-service-submitter` worker also having this removed:
(https://github.com/SEEK-Jobs/virus-scanner-service/blob/379ba1fdbba4db3ddc6d8f72cd59d54014ac9c83/serverless.yml#L27)