### PR TITLE
Fix template range strategy

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -44,6 +44,7 @@
       paths: ['template/**'],
 
       branchPrefix: 'renovate-template/',
+      rangeStrategy: 'replace',
       semanticCommitType: 'template',
     },
   ],


### PR DESCRIPTION
This should be intentionally set to `range` to avoid pinning as seen in #439 and #441. Our templates are fully careted so that newly initialised repos get the latest semver minor and patch versions.