### PR TITLE
Set memory for Lambda smoke test hook to 128 MiB

### DIFF
--- a/.changeset/gentle-ads-attend.md
+++ b/.changeset/gentle-ads-attend.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker:** Set `memorySize` for smoke test hook to 128 MiB

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -94,6 +94,7 @@ functions:
   WorkerPreHook:
     name: ${self:functions.Worker.name}-pre-hook
     handler: lib/hooks.pre
+    memorySize: 128
     # This is generous because a timeout will hang the deployment
     timeout: 300
     environment:


### PR DESCRIPTION
This was defaulting to 1024 MiB, which is overkill.