### PR TITLE
Include success message in smoke test body

### DIFF
--- a/.changeset/curly-deers-sort.md
+++ b/.changeset/curly-deers-sort.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template/koa-rest-api:** Include success message in smoke test body

--- a/template/koa-rest-api/src/api/smokeTest.ts
+++ b/template/koa-rest-api/src/api/smokeTest.ts
@@ -7,5 +7,5 @@ import { Middleware } from 'src/types/koa';
 export const smokeTestHandler: Middleware = async (ctx) => {
   await Promise.all([smokeTestJobStorage()]);
 
-  ctx.body = '';
+  ctx.body = 'Smoke test passed';
 };


### PR DESCRIPTION
When loading a smoke test URL in a browser (e.g. from a Datadog synthetics alert) it's impossible to tell a 2xx from a 5xx.

This includes a simple message to indicate the smoke test is happy.
