### PR TITLE
Force `@jest/types` resolution in templates

### DIFF
--- a/.changeset/clean-needles-remember.md
+++ b/.changeset/clean-needles-remember.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** Force `@jest/types` resolution to fix clean installs

--- a/template/express-rest-api/package.json
+++ b/template/express-rest-api/package.json
@@ -17,6 +17,9 @@
   },
   "license": "UNLICENSED",
   "private": true,
+  "resolutions": {
+    "**/@jest/types/@types/node": "^15.0.0"
+  },
   "scripts": {
     "build": "skuba build",
     "format": "skuba format",

--- a/template/greeter/package.json
+++ b/template/greeter/package.json
@@ -11,6 +11,9 @@
   },
   "license": "UNLICENSED",
   "private": true,
+  "resolutions": {
+    "**/@jest/types/@types/node": "^15.0.0"
+  },
   "scripts": {
     "build": "skuba build",
     "format": "skuba format",

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -31,6 +31,9 @@
   },
   "license": "UNLICENSED",
   "private": true,
+  "resolutions": {
+    "**/@jest/types/@types/node": "^15.0.0"
+  },
   "scripts": {
     "build": "skuba build",
     "format": "skuba format",

--- a/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
+++ b/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
@@ -133,6 +133,17 @@ Object {
               },
               "Resource": "*",
             },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:GenerateDataKey",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "sns.amazonaws.com",
+              },
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },
@@ -540,6 +551,17 @@ Object {
                     "Arn",
                   ],
                 },
+              },
+              "Resource": "*",
+            },
+            Object {
+              "Action": Array [
+                "kms:Decrypt",
+                "kms:GenerateDataKey",
+              ],
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": "sns.amazonaws.com",
               },
               "Resource": "*",
             },

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -20,6 +20,9 @@
   },
   "license": "UNLICENSED",
   "private": true,
+  "resolutions": {
+    "**/@jest/types/@types/node": "^15.0.0"
+  },
   "scripts": {
     "build": "skuba build",
     "format": "skuba format",

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -23,6 +23,9 @@
   },
   "license": "UNLICENSED",
   "private": true,
+  "resolutions": {
+    "**/@jest/types/@types/node": "^15.0.0"
+  },
   "scripts": {
     "build": "skuba build",
     "deploy": "yarn build && serverless deploy --force --verbose",

--- a/template/oss-npm-package/_package.json
+++ b/template/oss-npm-package/_package.json
@@ -2,6 +2,7 @@
   "dependencies": {},
   "description": "<%- description %>",
   "devDependencies": {
+    "@types/node": "^15.0.0",
     "commitizen": "^4.2.3",
     "skuba": "*"
   },

--- a/template/oss-npm-package/_package.json
+++ b/template/oss-npm-package/_package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "git+https://github.com/<%- orgName %>/<%- repoName %>.git"
   },
+  "resolutions": {
+    "**/@jest/types/@types/node": "^15.0.0"
+  },
   "scripts": {
     "build": "skuba build-package",
     "commit": "cz",

--- a/template/private-npm-package/_package.json
+++ b/template/private-npm-package/_package.json
@@ -2,6 +2,7 @@
   "dependencies": {},
   "description": "<%- description %>",
   "devDependencies": {
+    "@types/node": "^15.0.0",
     "commitizen": "^4.2.3",
     "skuba": "*"
   },

--- a/template/private-npm-package/_package.json
+++ b/template/private-npm-package/_package.json
@@ -19,6 +19,9 @@
     "type": "git",
     "url": "git+https://github.com/<%- orgName %>/<%- repoName %>.git"
   },
+  "resolutions": {
+    "**/@jest/types/@types/node": "^15.0.0"
+  },
   "scripts": {
     "build": "skuba build-package",
     "commit": "cz",


### PR DESCRIPTION
A clean install of `@jest/types` is currently failing because it specifies a `@types/node` range of `*`, and the latest v16 release removes some globals that Jest depends on.

This is a hack to get CI healthy again, until `@jest/types` is properly patched: https://github.com/facebook/jest/pull/11645