### PR TITLE
Parameterise region in Gantry templates

### DIFF
--- a/.changeset/short-geese-yawn.md
+++ b/.changeset/short-geese-yawn.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+Parameterise AWS region

--- a/.changeset/short-geese-yawn.md
+++ b/.changeset/short-geese-yawn.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-Parameterise AWS region
+**template/\*-rest-api:** Parameterise AWS region

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "engines": {
     "node": ">=12"
   },
-  "version": "3.14.3",
+  "version": "9.99.99",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "engines": {
     "node": ">=12"
   },
-  "version": "9.99.99",
+  "version": "3.14.3",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "files": [

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -31,7 +31,7 @@ yarn skuba init << EOF
     "prodGantryEnvironmentName": "prod",
     "repoName": "${directory}",
     "serviceName": "serviceName",
-    "region: "ap-southeast-1"
+    "region": "ap-southeast-2"
   },
   "templateName": "${template}"
 }

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -30,7 +30,8 @@ yarn skuba init << EOF
     "prodBuildkiteQueueName": "my-account-prod:cicd",
     "prodGantryEnvironmentName": "prod",
     "repoName": "${directory}",
-    "serviceName": "serviceName"
+    "serviceName": "serviceName",
+    "region: "ap-southeast-1"
   },
   "templateName": "${template}"
 }

--- a/template/express-rest-api/.buildkite/pipeline.yml
+++ b/template/express-rest-api/.buildkite/pipeline.yml
@@ -70,7 +70,7 @@ steps:
       - seek-jobs/gantry#v1.4.0:
           command: build
           file: gantry.build.yml
-          region: ap-southeast-2
+          region: <%- region %>
           values: .gantry/common.yml
 
   - wait
@@ -87,7 +87,7 @@ steps:
           command: apply
           environment: <%- devGantryEnvironmentName %>
           file: gantry.apply.yml
-          region: ap-southeast-2
+          region: <%- region %>
           values:
             - .gantry/common.yml
             - .gantry/dev.yml
@@ -103,7 +103,7 @@ steps:
           command: apply
           environment: <%- prodGantryEnvironmentName %>
           file: gantry.apply.yml
-          region: ap-southeast-2
+          region: <%- region %>
           values:
             - .gantry/common.yml
             - .gantry/prod.yml

--- a/template/express-rest-api/.gantry/common.yml
+++ b/template/express-rest-api/.gantry/common.yml
@@ -5,7 +5,7 @@ service: '<%- serviceName %>'
 
 # TODO: enable Datadog agent
 # https://gantry.ssod.skinfra.xyz/docs/v1/resources/service.html#datadogSecretId
-# datadogSecretId: arn:aws:secretsmanager:ap-southeast-2:<aws-account-id>:secret:<secret-name>
+# datadogSecretId: arn:aws:secretsmanager:<%- region %>:<aws-account-id>:secret:<secret-name>
 
 tags:
   # TODO: add data classification tags

--- a/template/express-rest-api/.gantry/common.yml
+++ b/template/express-rest-api/.gantry/common.yml
@@ -1,6 +1,6 @@
 prodAccountId: '<%- prodAwsAccountId %>'
 
-image: '{{values "prodAccountId"}}.dkr.ecr.ap-southeast-2.amazonaws.com/{{values "service"}}:{{.BuildID}}'
+image: '{{values "prodAccountId"}}.dkr.ecr.<%- region %>.amazonaws.com/{{values "service"}}:{{.BuildID}}'
 service: '<%- serviceName %>'
 
 # TODO: enable Datadog agent

--- a/template/express-rest-api/skuba.template.js
+++ b/template/express-rest-api/skuba.template.js
@@ -41,7 +41,7 @@ module.exports = {
     {
       name: 'region',
       message: 'AWS region',
-      initial: 'ap-southeast-2',
+      initial: 'my-region-0',
       validate: (value) => /^[a-z]{2}-[a-z]+-\d+$/.test(value),
     },
   ],

--- a/template/express-rest-api/skuba.template.js
+++ b/template/express-rest-api/skuba.template.js
@@ -38,6 +38,12 @@ module.exports = {
       initial: '123456789012',
       validate: (value) => /^\d{12}$/.test(value),
     },
+    {
+      name: 'region',
+      message: 'AWS region',
+      initial: 'ap-southeast-2',
+      validate: (value) => /^[a-z]{2}-[a-z]+-\d+$/.test(value),
+    },
   ],
   type: 'application',
 };

--- a/template/koa-rest-api/.buildkite/pipeline.yml
+++ b/template/koa-rest-api/.buildkite/pipeline.yml
@@ -70,7 +70,7 @@ steps:
       - seek-jobs/gantry#v1.4.0:
           command: build
           file: gantry.build.yml
-          region: ap-southeast-2
+          region: <%- region %>
           values: .gantry/common.yml
 
   - wait
@@ -87,7 +87,7 @@ steps:
           command: apply
           environment: <%- devGantryEnvironmentName %>
           file: gantry.apply.yml
-          region: ap-southeast-2
+          region: <%- region %>
           values:
             - .gantry/common.yml
             - .gantry/dev.yml
@@ -103,7 +103,7 @@ steps:
           command: apply
           environment: <%- prodGantryEnvironmentName %>
           file: gantry.apply.yml
-          region: ap-southeast-2
+          region: <%- region %>
           values:
             - .gantry/common.yml
             - .gantry/prod.yml

--- a/template/koa-rest-api/.gantry/common.yml
+++ b/template/koa-rest-api/.gantry/common.yml
@@ -1,7 +1,8 @@
 prodAccountId: '<%- prodAwsAccountId %>'
 
-image: '{{values "prodAccountId"}}.dkr.ecr.ap-southeast-2.amazonaws.com/{{values "service"}}:{{.BuildID}}'
+image: '{{values "prodAccountId"}}.dkr.ecr.{{values "region"}}.amazonaws.com/{{values "service"}}:{{.BuildID}}'
 service: '<%- serviceName %>'
+region: '<%- prodAwsAccountId %>'
 
 # TODO: enable Datadog agent
 # https://gantry.ssod.skinfra.xyz/docs/v1/resources/service.html#datadogSecretId

--- a/template/koa-rest-api/.gantry/common.yml
+++ b/template/koa-rest-api/.gantry/common.yml
@@ -6,7 +6,7 @@ region: '<%- prodAwsAccountId %>'
 
 # TODO: enable Datadog agent
 # https://gantry.ssod.skinfra.xyz/docs/v1/resources/service.html#datadogSecretId
-# datadogSecretId: arn:aws:secretsmanager:ap-southeast-2:<aws-account-id>:secret:<secret-name>
+# datadogSecretId: arn:aws:secretsmanager:<%- region %>:<aws-account-id>:secret:<secret-name>
 
 tags:
   # TODO: add data classification tags

--- a/template/koa-rest-api/.gantry/common.yml
+++ b/template/koa-rest-api/.gantry/common.yml
@@ -1,8 +1,7 @@
 prodAccountId: '<%- prodAwsAccountId %>'
 
-image: '{{values "prodAccountId"}}.dkr.ecr.{{values "region"}}.amazonaws.com/{{values "service"}}:{{.BuildID}}'
+image: '{{values "prodAccountId"}}.dkr.ecr.<%- region %>.amazonaws.com/{{values "service"}}:{{.BuildID}}'
 service: '<%- serviceName %>'
-region: '<%- prodAwsAccountId %>'
 
 # TODO: enable Datadog agent
 # https://gantry.ssod.skinfra.xyz/docs/v1/resources/service.html#datadogSecretId

--- a/template/koa-rest-api/skuba.template.js
+++ b/template/koa-rest-api/skuba.template.js
@@ -38,6 +38,11 @@ module.exports = {
       initial: '123456789012',
       validate: (value) => /^\d{12}$/.test(value),
     },
+    {
+      name: 'region',
+      message: 'AWS region',
+      initial: 'ap-southeast-2',
+    },
   ],
   type: 'application',
 };

--- a/template/koa-rest-api/skuba.template.js
+++ b/template/koa-rest-api/skuba.template.js
@@ -41,7 +41,8 @@ module.exports = {
     {
       name: 'region',
       message: 'AWS region',
-      initial: 'ap-southeast-2',
+      initial: 'my-region-0',
+      validate: (value) => /^[a-z]{2}-[a-z]+-\d+$/.test(value),
     },
   ],
   type: 'application',


### PR DESCRIPTION
The region values for Gantry are currently hardcoded to ap-southeast-2, but I'd like to encourage all APAC teams to use skuba so parameterising the region would be nice. 

I guessed this is a patch change based on https://github.com/seek-oss/skuba/commit/985ff9a73cf079882efe7f81e45679e8e0a1f7d1