### PR TITLE
Use @types/node@14

### DIFF
--- a/.changeset/nasty-zebras-share.md
+++ b/.changeset/nasty-zebras-share.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+**template:** @types/node ^14.17.19

--- a/template/express-rest-api/package.json
+++ b/template/express-rest-api/package.json
@@ -1,16 +1,16 @@
 {
   "dependencies": {
-    "@seek/logger": "^4.4.5",
+    "@seek/logger": "^4.4.7",
     "express": "^4.17.1",
-    "skuba-dive": "^1.1.2"
+    "skuba-dive": "^1.2.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.11",
-    "@types/node": "^15.0.0",
-    "@types/supertest": "^2.0.10",
-    "pino-pretty": "^5.0.0",
+    "@types/express": "^4.17.13",
+    "@types/node": "^14.17.9",
+    "@types/supertest": "^2.0.11",
+    "pino-pretty": "^5.1.3",
     "skuba": "*",
-    "supertest": "^6.1.3"
+    "supertest": "^6.1.4"
   },
   "engines": {
     "node": ">=14"
@@ -18,7 +18,7 @@
   "license": "UNLICENSED",
   "private": true,
   "resolutions": {
-    "**/@jest/types/@types/node": "^15.0.0"
+    "**/@jest/types/@types/node": "^14.17.9"
   },
   "scripts": {
     "build": "skuba build",

--- a/template/greeter/package.json
+++ b/template/greeter/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "skuba-dive": "^1.1.2"
+    "skuba-dive": "^1.2.0"
   },
   "devDependencies": {
-    "@types/node": "^15.0.0",
+    "@types/node": "^14.17.9",
     "skuba": "*"
   },
   "engines": {
@@ -12,7 +12,7 @@
   "license": "UNLICENSED",
   "private": true,
   "resolutions": {
-    "**/@jest/types/@types/node": "^15.0.0"
+    "**/@jest/types/@types/node": "^14.17.9"
   },
   "scripts": {
     "build": "skuba build",

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -18,7 +18,7 @@
     "@types/koa": "^2.13.4",
     "@types/koa-bodyparser": "^5.0.2",
     "@types/koa__router": "^8.0.7",
-    "@types/node": "^15.14.7",
+    "@types/node": "^14.17.9",
     "@types/supertest": "^2.0.11",
     "@types/uuid": "^8.3.1",
     "chance": "^1.1.7",
@@ -32,7 +32,7 @@
   "license": "UNLICENSED",
   "private": true,
   "resolutions": {
-    "**/@jest/types/@types/node": "^15.14.7"
+    "**/@jest/types/@types/node": "^14.17.9"
   },
   "scripts": {
     "build": "skuba build",

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -1,27 +1,27 @@
 {
   "dependencies": {
     "@seek/logger": "^4.4.7",
-    "runtypes": "^6.0.0"
+    "runtypes": "^6.3.2"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.95.1",
-    "@aws-cdk/aws-iam": "^1.95.1",
-    "@aws-cdk/aws-kms": "^1.95.1",
-    "@aws-cdk/aws-lambda": "^1.95.1",
-    "@aws-cdk/aws-lambda-event-sources": "^1.95.1",
-    "@aws-cdk/aws-sns": "^1.95.1",
-    "@aws-cdk/aws-sns-subscriptions": "^1.95.1",
-    "@aws-cdk/aws-sqs": "^1.95.1",
-    "@aws-cdk/core": "^1.95.1",
-    "@types/aws-lambda": "^8.10.73",
-    "@types/node": "^15.0.0",
-    "aws-cdk": "^1.18.0",
+    "@aws-cdk/assert": "^1.118.0",
+    "@aws-cdk/aws-iam": "^1.118.0",
+    "@aws-cdk/aws-kms": "^1.118.0",
+    "@aws-cdk/aws-lambda": "^1.118.0",
+    "@aws-cdk/aws-lambda-event-sources": "^1.118.0",
+    "@aws-cdk/aws-sns": "^1.118.0",
+    "@aws-cdk/aws-sns-subscriptions": "^1.118.0",
+    "@aws-cdk/aws-sqs": "^1.118.0",
+    "@aws-cdk/core": "^1.118.0",
+    "@types/aws-lambda": "^8.10.82",
+    "@types/node": "^14.17.9",
+    "aws-cdk": "^1.118.0",
     "skuba": "*"
   },
   "license": "UNLICENSED",
   "private": true,
   "resolutions": {
-    "**/@jest/types/@types/node": "^15.0.0"
+    "**/@jest/types/@types/node": "^14.17.9"
   },
   "scripts": {
     "build": "skuba build",

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -1,21 +1,21 @@
 {
   "dependencies": {
-    "@seek/logger": "^4.4.5",
-    "aws-sdk": "^2.831.0",
+    "@seek/logger": "^4.4.7",
+    "aws-sdk": "^2.965.0",
     "seek-datadog-custom-metrics": "^4.0.0",
-    "skuba-dive": "^1.1.2",
-    "runtypes": "^6.0.0",
+    "skuba-dive": "^1.2.0",
+    "runtypes": "^6.3.2",
     "runtypes-filter": "^0.6.0"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.71",
-    "@types/chance": "^1.1.1",
-    "@types/node": "^15.0.0",
+    "@types/aws-lambda": "^8.10.82",
+    "@types/chance": "^1.1.3",
+    "@types/node": "^14.17.9",
     "chance": "^1.1.7",
-    "pino-pretty": "^5.0.0",
-    "serverless": "^2.25.1",
+    "pino-pretty": "^5.1.3",
+    "serverless": "^2.53.1",
     "serverless-plugin-canary-deployments": "^0.6.0",
-    "serverless-prune-plugin": "^1.4.3",
+    "serverless-prune-plugin": "^1.5.1",
     "skuba": "*"
   },
   "engines": {
@@ -24,7 +24,7 @@
   "license": "UNLICENSED",
   "private": true,
   "resolutions": {
-    "**/@jest/types/@types/node": "^15.0.0"
+    "**/@jest/types/@types/node": "^14.17.9"
   },
   "scripts": {
     "build": "skuba build",

--- a/template/oss-npm-package/_package.json
+++ b/template/oss-npm-package/_package.json
@@ -2,8 +2,8 @@
   "dependencies": {},
   "description": "<%- description %>",
   "devDependencies": {
-    "@types/node": "^15.0.0",
-    "commitizen": "^4.2.3",
+    "@types/node": "^14.17.9",
+    "commitizen": "^4.2.4",
     "skuba": "*"
   },
   "files": [
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/<%- orgName %>/<%- repoName %>.git"
   },
   "resolutions": {
-    "**/@jest/types/@types/node": "^15.0.0"
+    "**/@jest/types/@types/node": "^14.17.9"
   },
   "scripts": {
     "build": "skuba build-package",

--- a/template/private-npm-package/_package.json
+++ b/template/private-npm-package/_package.json
@@ -2,8 +2,8 @@
   "dependencies": {},
   "description": "<%- description %>",
   "devDependencies": {
-    "@types/node": "^15.0.0",
-    "commitizen": "^4.2.3",
+    "@types/node": "^14.17.9",
+    "commitizen": "^4.2.4",
     "skuba": "*"
   },
   "files": [
@@ -21,7 +21,7 @@
     "url": "git+https://github.com/<%- orgName %>/<%- repoName %>.git"
   },
   "resolutions": {
-    "**/@jest/types/@types/node": "^15.0.0"
+    "**/@jest/types/@types/node": "^14.17.9"
   },
   "scripts": {
     "build": "skuba build-package",


### PR DESCRIPTION
It makes more sense for us to track the LTS version.

I've also updated the carets ranges because why not.