### PR TITLE
ci: remove yarn cache for worker dev deps image

### DIFF
--- a/.changeset/wet-penguins-switch.md
+++ b/.changeset/wet-penguins-switch.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+**template:** Remove Yarn cache from worker Docker images
+
+This shrinks the cached Docker images that our worker templates generate.

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -9,4 +9,5 @@ COPY package.json yarn.lock ./
 RUN \
   --mount=type=secret,id=npm,dst=/workdir/.npmrc \
   yarn install --frozen-lockfile --ignore-optional --non-interactive && \
-  yarn package
+  yarn package && \
+  yarn cache clean

--- a/template/lambda-sqs-worker/Dockerfile
+++ b/template/lambda-sqs-worker/Dockerfile
@@ -8,4 +8,5 @@ COPY package.json yarn.lock ./
 
 RUN \
   --mount=type=secret,id=npm,dst=/workdir/.npmrc \
-  yarn install --frozen-lockfile --ignore-optional --non-interactive
+  yarn install --frozen-lockfile --ignore-optional --non-interactive && \
+  yarn cache clean


### PR DESCRIPTION
The workers don't need to run `yarn install` after this step so we might as well remove the yarn cache associated with it.

In my testing -> this reduced the size of images by half