### PR TITLE
Prime dev ECR cache in Lambda Buildkite pipelines

### DIFF
--- a/.changeset/chilled-vans-grow.md
+++ b/.changeset/chilled-vans-grow.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+**template/lambda-sqs-worker\*:** Prime dev ECR cache in Buildkite pipeline
+
+This should result in faster _Deploy Dev_ times as the ECR cache will already be warm.

--- a/.changeset/silent-pugs-fetch.md
+++ b/.changeset/silent-pugs-fetch.md
@@ -1,0 +1,7 @@
+---
+"skuba": patch
+---
+
+**template/lambda-sqs-worker-cdk:** Run _Test, Lint & Build_ step in prod
+
+This reduces our dependence on a dev environment to successfully deploy to prod.

--- a/.changeset/silent-pugs-fetch.md
+++ b/.changeset/silent-pugs-fetch.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 **template/lambda-sqs-worker-cdk:** Run _Test, Lint & Build_ step in prod

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -69,6 +69,15 @@ steps:
       - docker-compose#v3.8.0:
           run: app
 
+  - <<: *dev
+    branches: '!renovate/*'
+    label: 🧖‍♀️ Warm Dev
+    command: ':'
+    plugins:
+      - *aws-sm
+      - *private-npm
+      - *docker-ecr-cache
+
   - wait
   - block: 🙋🏻‍♀️ Deploy Dev
     branches: '!${BUILDKITE_PIPELINE_DEFAULT_BRANCH}'

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -52,7 +52,7 @@ configs:
           permit_on_passed: true
 
 steps:
-  - <<: *dev
+  - <<: *prod
     label: 🧪 Test, Lint & Build
     artifact_paths: lib/**/*
     commands:

--- a/template/lambda-sqs-worker/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker/.buildkite/pipeline.yml
@@ -72,6 +72,15 @@ steps:
       - docker-compose#v3.8.0:
           run: app
 
+  - <<: *dev
+    branches: '!renovate/*'
+    label: 🧖‍♀️ Warm Dev
+    command: ':'
+    plugins:
+      - *aws-sm
+      - *private-npm
+      - *docker-ecr-cache
+
   - wait
   - block: 🙋🏻‍♀️ Deploy Dev
     branches: '!${BUILDKITE_PIPELINE_DEFAULT_BRANCH}'


### PR DESCRIPTION
I'm pretty sure this was unintentionally omitted as we already do this on a bunch of repos internally. Caught by @samchungy.