### PR TITLE
Deploy docs to GitHub Pages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEEK_OSS_CI_NPM_TOKEN }}
+
+      - name: Deploy to GitHub Pages
+        run: yarn deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_GITHUB_PAGES: true

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn skuba build && scripts/postbuild.sh",
+    "deploy": "scripts/deploy.sh",
     "format": "yarn skuba format",
     "lint": "yarn skuba lint",
     "release": "yarn build && changeset publish",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+
+set -e
+
+echo '=> Packaging...'
+
+rm -rf dist-docs
+
+mkdir -p dist-docs
+
+cp README.md dist-docs/
+
+cp -R docs dist-docs/docs/
+
+exit 0
+
+cd dist-docs
+
+git init
+
+git add --all
+
+git \
+-c 'user.email=<>' \
+-c 'user.name=skuba' \
+commit \
+--author 'skuba <>' \
+--message 'Deploy to GitHub Pages' \
+--quiet
+
+echo '=> Deploying...'
+
+{
+  GIT_URL="git@github.com:seek-oss/skuba.git"
+
+  if [ "${IS_GITHUB_PAGES:-}" = 'true' ]; then
+    GIT_URL="https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/seek-oss/skuba.git"
+  fi
+
+  git push --force --quiet "${GIT_URL}" 'master:gh-pages'
+}
+
+cd ..
+rm -rf dist-docs
+
+echo "=> Deployed: https://seek-oss.github.io/skuba"


### PR DESCRIPTION
Our README is too long and you can easily get lost in it. I'm planning to pull it apart into multiple pages and include more user guide-like content which will tie in better to our Tech Onboarding initiatives.

A starting point is to deploy our existing Markdown documentation pages to GitHub Pages in CI/CD. I'm still undecided on whether it's worth us wrapping this up in a full-blown sku app for SEEK styling.