### PR TITLE
Fix doc deployment in CI

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,8 +8,7 @@ rm -rf dist-docs
 
 mkdir -p dist-docs
 
-cp CHANGELOG.md CONTRIBUTING.md index.md dist-docs/
-cp -R site/ dist-docs/
+cp CHANGELOG.md CONTRIBUTING.md index.md site/_config.yml dist-docs/
 cp -R docs/ dist-docs/docs/
 
 cd dist-docs


### PR DESCRIPTION
My `cp`ing was not evidently not portable enough, so we were losing all styling on merges to the default branch.