### PR TITLE
Add changelog frontmatter during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,4 @@
----
-nav_order: 98
-title: Changelog
----
-
 # skuba
-
----
 
 ## 3.14.4
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -8,7 +8,25 @@ rm -rf dist-docs
 
 mkdir -p dist-docs
 
-cp CHANGELOG.md CONTRIBUTING.md index.md site/_config.yml dist-docs/
+changelog="$(cat CHANGELOG.md)"
+
+old_header='# skuba'
+
+new_header="$(cat << EOF
+---
+nav_order: 98
+title: Changelog
+---
+
+# skuba
+
+---
+EOF
+)"
+
+echo "${changelog/#"${old_header}"/"${new_header}"}" > dist-docs/CHANGELOG.md
+
+cp CONTRIBUTING.md index.md site/_config.yml dist-docs/
 cp -R docs/ dist-docs/docs/
 
 cd dist-docs


### PR DESCRIPTION
Changesets doesn't like us mangling with the source CHANGELOG.md. See this brokenness: https://github.com/seek-oss/skuba/pull/496/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed

---

I went this route because I'm not seeing an obvious way to configure how Changesets actually inserts into CHANGELOG.md, only formatting the individual entries beforehand: https://github.com/atlassian/changesets/blob/main/docs/modifying-changelog-format.md