### PR TITLE
Make it easier to add changesets

### DIFF
--- a/.changeset/.prettierrc.js
+++ b/.changeset/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  ...require("../config/prettier"),
+
+  // Changesets are generated with double quotes by default.
+  singleQuote: false,
+};

--- a/.changeset/blue-suits-tie.md
+++ b/.changeset/blue-suits-tie.md
@@ -1,5 +1,5 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**template:** pino-pretty ^7.0.0
+template: pino-pretty ^7.0.0

--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -5,7 +5,7 @@
 const {
   getInfo,
   getInfoFromPullRequest,
-} = require('@changesets/get-github-info');
+} = require("@changesets/get-github-info");
 
 /** @type import('@changesets/types').ChangelogFunctions */
 const changelogFunctions = {
@@ -19,7 +19,7 @@ const changelogFunctions = {
         'Please provide a repo to this changelog generator like this:\n"changelog": ["./changelog.js", { "repo": "org/repo" }]',
       );
     }
-    if (dependenciesUpdated.length === 0) return '';
+    if (dependenciesUpdated.length === 0) return "";
 
     const changesetLink = `- Updated dependencies [${(
       await Promise.all(
@@ -35,13 +35,13 @@ const changelogFunctions = {
       )
     )
       .filter((_) => _)
-      .join(', ')}]:`;
+      .join(", ")}]:`;
 
     const updatedDependenciesList = dependenciesUpdated.map(
       (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
     );
 
-    return [changesetLink, ...updatedDependenciesList].join('\n');
+    return [changesetLink, ...updatedDependenciesList].join("\n");
   },
   getReleaseLine: async (changeset, _type, options) => {
     if (!options || !options.repo) {
@@ -59,20 +59,20 @@ const changelogFunctions = {
       .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
         let num = Number(pr);
         if (!isNaN(num)) prFromSummary = num;
-        return '';
+        return "";
       })
       .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
         commitFromSummary = commit;
-        return '';
+        return "";
       })
       .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
         usersFromSummary.push(user);
-        return '';
+        return "";
       })
       .trim();
 
     const [firstLine, ...futureLines] = replacedChangelog
-      .split('\n')
+      .split("\n")
       .map((l) => l.trimRight());
 
     const links = await (async () => {
@@ -104,11 +104,14 @@ const changelogFunctions = {
       };
     })();
 
+    // Bold the scope.
+    const formattedFirstLine = firstLine.replace(/^([^:]+): /, "**$1:** ");
+
     const suffix = links.pull ?? links.commit;
 
-    return `\n\n- ${firstLine}${suffix ? ` (${suffix})` : ''}\n${futureLines
-      .map((l) => `  ${l}`)
-      .join('\n')}`;
+    return `\n\n- ${formattedFirstLine}${
+      suffix ? ` (${suffix})` : ""
+    }\n${futureLines.map((l) => `  ${l}`).join("\n")}`;
   },
 };
 

--- a/.changeset/chilled-dots-melt.md
+++ b/.changeset/chilled-dots-melt.md
@@ -1,5 +1,5 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**template:** serverless-plugin-canary-deployments ^0.7.0
+template: serverless-plugin-canary-deployments ^0.7.0

--- a/.changeset/chilled-vans-grow.md
+++ b/.changeset/chilled-vans-grow.md
@@ -1,7 +1,7 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
 **template/lambda-sqs-worker\*:** Prime dev ECR cache in Buildkite pipeline
 
-This should result in faster _Deploy Dev_ times as the ECR cache will already be warm.
+This should result in faster "Deploy Dev" times as the ECR cache will already be warm.

--- a/.changeset/giant-sloths-cross.md
+++ b/.changeset/giant-sloths-cross.md
@@ -1,5 +1,5 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**template:** seek-jobs/gantry v1.4.1
+template: seek-jobs/gantry v1.4.1

--- a/.changeset/good-lizards-appear.md
+++ b/.changeset/good-lizards-appear.md
@@ -1,5 +1,5 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**cli:** Drop `fs-extra` in favour of vanilla `fs`
+cli: Drop `fs-extra` in favour of vanilla `fs`

--- a/.changeset/light-islands-begin.md
+++ b/.changeset/light-islands-begin.md
@@ -1,7 +1,7 @@
 ---
-'skuba': minor
+"skuba": minor
 ---
 
-**node:** Run REPL in process
+node: Run REPL in process
 
 This avoids creating a separate Node.js process just to run the REPL.

--- a/.changeset/nine-fishes-swim.md
+++ b/.changeset/nine-fishes-swim.md
@@ -1,7 +1,7 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**template:** Remove `@types/node` resolution override
+template: Remove `@types/node` resolution override
 
 Jest 27.1 is compatible with newer versions of `@types/node`.

--- a/.changeset/quick-plants-peel.md
+++ b/.changeset/quick-plants-peel.md
@@ -1,7 +1,7 @@
 ---
-'skuba': minor
+"skuba": minor
 ---
 
-**format:** Execute ESLint with `--report-unused-disable-directives`
+format: Execute ESLint with `--report-unused-disable-directives`
 
 `skuba format` will now flag unused disable directives, and will [automatically remove](https://eslint.org/blog/2021/06/whats-coming-in-eslint-8.0.0#unused-disable-directives-are-now-fixable) them once ESLint v8 is released.

--- a/.changeset/short-baboons-leave.md
+++ b/.changeset/short-baboons-leave.md
@@ -1,7 +1,7 @@
 ---
-'skuba': minor
+"skuba": minor
 ---
 
-**deps:** Prettier 2.4
+deps: Prettier 2.4
 
 This includes TypeScript 4.4 support. See the [release notes](https://prettier.io/blog/2021/09/09/2.4.0.html) for more information.

--- a/.changeset/silent-pugs-fetch.md
+++ b/.changeset/silent-pugs-fetch.md
@@ -1,7 +1,7 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**template/lambda-sqs-worker-cdk:** Run _Test, Lint & Build_ step in prod
+**template/lambda-sqs-worker-cdk:** Run "Test, Lint & Build" step in prod
 
 This reduces our dependence on a dev environment to successfully deploy to prod.

--- a/.changeset/silly-deers-draw.md
+++ b/.changeset/silly-deers-draw.md
@@ -1,7 +1,9 @@
 ---
-'skuba': minor
+"skuba": minor
 ---
 
-**deps:** TypeScript 4.4
+deps: TypeScript 4.4
 
 This major release includes breaking changes. See the [announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/) for more information.
+
+Note that new syntax in TypeScript 4.4 will only be supported by `skuba format` and `skuba lint` once ESLint v8 is released.

--- a/.changeset/sour-stingrays-doubt.md
+++ b/.changeset/sour-stingrays-doubt.md
@@ -1,7 +1,7 @@
 ---
-'skuba': minor
+"skuba": minor
 ---
 
-**build:** Remove experimental Babel support
+build: Remove experimental Babel support
 
 There's limited upside to switching to [Babel-based builds](https://github.com/seek-oss/skuba/tree/master/docs/deep-dives/babel.md) for backend use cases, and it would be difficult to guarantee backwards compatibility with existing `tsconfig.json`-based configuration. Dropping Babel dependencies reduces our package size and resolves [SNYK-JS-SETVALUE-1540541](https://app.snyk.io/vuln/SNYK-JS-SETVALUE-1540541).

--- a/.changeset/stale-numbers-carry.md
+++ b/.changeset/stale-numbers-carry.md
@@ -1,5 +1,5 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
 **build-package, lint:** Use minimalist logging prefix

--- a/.changeset/sweet-spies-beam.md
+++ b/.changeset/sweet-spies-beam.md
@@ -1,5 +1,0 @@
----
-'skuba': patch
----
-
-**template:** pino-pretty ^6.0.0

--- a/.changeset/tender-ads-cover.md
+++ b/.changeset/tender-ads-cover.md
@@ -1,7 +1,7 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**template:** Propagate BUILDKITE environment variable to Docker
+template: Propagate BUILDKITE environment variable to Docker
 
 This forces serial execution of certain **skuba** commands to avoid overwhelming underprovisioned Buildkite agents. See our [Buildkite topic](https://github.com/seek-oss/skuba/tree/master/docs/deep-dives/buildkite.md) for more information.

--- a/.changeset/twelve-monkeys-cough.md
+++ b/.changeset/twelve-monkeys-cough.md
@@ -1,5 +1,5 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
 **build-package, lint:** Limit concurrency to CPU core count

--- a/.changeset/wet-penguins-switch.md
+++ b/.changeset/wet-penguins-switch.md
@@ -1,7 +1,7 @@
 ---
-'skuba': patch
+"skuba": patch
 ---
 
-**template:** Remove Yarn cache from worker Docker images
+template: Remove Yarn cache from worker Docker images
 
 This shrinks the cached Docker images that our worker templates generate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,17 +218,17 @@ The Changesets CLI is interactive and follows [semantic versioning]:
 - Minor release `0.X.0`: new, backwards-compatible functionality
 - Major release `X.0.0`: backwards-incompatible modification
 
-Prefix your changeset title with a `**scope:**`.
+Prefix your changeset title with a `scope:`.
 This makes it easy to eyeball which part of **skuba** a change relates to.
 
 ```text
-**test:** Fix command
+test: Fix command
 
-**template:** Add next steps to READMEs
+template: Add next steps to READMEs
 
-**template/koa-rest-api:** Switch to Express
+template/koa-rest-api: Switch to Express
 
-**format, lint:** Introduce new ESLint rule
+format, lint: Introduce new ESLint rule
 ```
 
 The Changesets CLI will generate a Markdown file under [.changeset](https://github.com/seek-oss/skuba/tree/master/.changeset),


### PR DESCRIPTION
This makes it easier to use changeset-default formatting. We override the Prettier config to accept double quotes in the `.changeset` directory, and bold the commit title scope during changelog generation rather than requiring everyone to manually type out the asterisks.