### PR TITLE
Reorganise test scripts

### DIFF
--- a/.changeset/ten-snails-act.md
+++ b/.changeset/ten-snails-act.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+Jest.mergePreset: Allow `watchPathIgnorePatterns`

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test
-        run: yarn test
+        run: yarn test:ci
 
       - name: Lint
         run: yarn lint

--- a/jest.config.int.ts
+++ b/jest.config.int.ts
@@ -1,0 +1,10 @@
+import { Jest } from './src';
+
+export default Jest.mergePreset({
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['<rootDir>/template/', '/test\\.ts'],
+  watchPathIgnorePatterns: [
+    '<rootDir>/integration/format/',
+    '<rootDir>/integration/lint/',
+  ],
+});

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,5 +2,9 @@ import { Jest } from './src';
 
 export default Jest.mergePreset({
   setupFiles: ['<rootDir>/jest.setup.ts'],
-  testPathIgnorePatterns: ['<rootDir>/template/', '/test\\.ts'],
+  testPathIgnorePatterns: [
+    '<rootDir>/template/',
+    '\\.int\\.test\\.ts',
+    '/test\\.ts',
+  ],
 });

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     "release": "yarn build && changeset publish",
     "stage": "changeset version && yarn format",
     "skuba": "ts-node --transpile-only src/skuba build && node lib/skuba",
-    "test": "yarn skuba test --runInBand",
-    "test:watch": "yarn skuba test --runInBand --watch",
-    "test:template": "scripts/test-template.sh"
+    "test": "yarn skuba test",
+    "test:ci": "yarn skuba test --config jest.config.int.ts --runInBand",
+    "test:int": "yarn skuba test --config jest.config.int.ts --runInBand",
+    "test:template": "scripts/test-template.sh",
+    "test:watch": "yarn skuba test --config jest.config.int.ts --runInBand --watch"
   },
   "repository": {
     "type": "git",

--- a/src/api/jest/index.ts
+++ b/src/api/jest/index.ts
@@ -18,6 +18,7 @@ type Props = Pick<
   | 'snapshotSerializers'
   | 'testPathIgnorePatterns'
   | 'testTimeout'
+  | 'watchPathIgnorePatterns'
 >;
 
 /**


### PR DESCRIPTION
Our integration tests mess with some `process` globals so they need to be `--runInBand`. This is a bit annoying for the rest of the tests though, so we keep an integration-less `yarn test` that allows for parallelism.

This also fixes a loop that can occur when `--watch`ing the integration tests due to the resulting file I/O in the `integration` directory.