### PR TITLE
build-package, lint: Add `--serial` flag

### DIFF
--- a/.changeset/itchy-cobras-bow.md
+++ b/.changeset/itchy-cobras-bow.md
@@ -1,0 +1,19 @@
+---
+"skuba": minor
+---
+
+build-package, lint: Add `--serial` flag
+
+This explicitly disables concurrent command execution.
+
+Propagating the `BUILDKITE` environment variable to these commands no longer constrains their concurrency. If you were relying on this behaviour to reduce resource contention on undersized Buildkite agents, update your commands to pass in the flag:
+
+```diff
+- build-package
++ build-package --serial
+
+- lint
++ lint --serial
+```
+
+See our [Buildkite guide](https://github.com/seek-oss/skuba/tree/master/docs/deep-dives/buildkite.md) for more information.

--- a/.changeset/tender-ads-cover.md
+++ b/.changeset/tender-ads-cover.md
@@ -1,7 +1,0 @@
----
-"skuba": patch
----
-
-template: Propagate BUILDKITE environment variable to Docker
-
-This forces serial execution of certain **skuba** commands to avoid overwhelming underprovisioned Buildkite agents. See our [Buildkite topic](https://github.com/seek-oss/skuba/tree/master/docs/deep-dives/buildkite.md) for more information.

--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -69,10 +69,14 @@ skuba build-package
 # types    | tsc exited with code 0
 ```
 
-`skuba lint` runs processes concurrently up to your [CPU core count].
+`skuba lint` runs operations concurrently up to your [CPU core count].
 On a resource-constrained Buildkite agent,
-you can limit it to run serially by propagating the `BUILDKITE` environment variable.
+you can limit this with the `--serial` flag.
 See our [Buildkite guide] for more information.
+
+| Option     | Description                                      |
+| :--------- | :----------------------------------------------- |
+| `--serial` | Force serial execution of compilation operations |
 
 [`smt build`]: ../migration-guides/seek-module-toolkit.md#building
 [`skuba configure`]: ./configure.md#skuba-configure

--- a/docs/cli/lint.md
+++ b/docs/cli/lint.md
@@ -55,14 +55,15 @@ skuba lint
 # tsc      | tsc --noEmit exited with code 0
 ```
 
-`skuba lint` runs processes concurrently up to your [CPU core count].
+`skuba lint` runs operations concurrently up to your [CPU core count].
 On a resource-constrained Buildkite agent,
-you can limit it to run serially by propagating the `BUILDKITE` environment variable.
+you can limit this with the `--serial` flag.
 See our [Buildkite guide] for more information.
 
-| Option    | Description                 |
-| :-------- | :-------------------------- |
-| `--debug` | Enable debug console output |
+| Option     | Description                                      |
+| :--------- | :----------------------------------------------- |
+| `--debug`  | Enable debug console output (implies `--serial`) |
+| `--serial` | Force serial execution of linting operations     |
 
 [`skuba format`]: #skuba-format
 [buildkite guide]: ../deep-dives/buildkite.md

--- a/docs/deep-dives/buildkite.md
+++ b/docs/deep-dives/buildkite.md
@@ -23,7 +23,7 @@ Coming soon!
 ## Buildkite agent exits with status -1
 
 **Scenario:**
-you're running a **skuba** command like [`skuba lint`],
+you're running a **skuba** command like [`skuba build-package`] or [`skuba lint`],
 and observe the following error message on a Buildkite step:
 
 > Exited with status -1 (process killed or agent lost; see the timeline tab for more information)
@@ -47,6 +47,8 @@ The agent may be tied up running a particularly compute-intensive step.
 
    This will cause them to run their underlying operations serially,
    reducing the chance of resource exhaustion.
+
+   Note that this is automatically inferred for builds on SEEK's central npm publishing pipeline.
 
 1. Reduce the number of agents that run on each instance.
 

--- a/docs/deep-dives/buildkite.md
+++ b/docs/deep-dives/buildkite.md
@@ -6,12 +6,21 @@ parent: Deep dives
 
 ---
 
-Buildkite is SEEK's CI/CD platform of choice.
-This topic details common issues you may run into and their solutions.
+Buildkite is SEEK's [CI/CD] platform of choice.
+See [Builds at SEEK] for more information.
+
+This topic details Buildkite integration features baked into **skuba**,
+as well as common issues faced when running your project on a Buildkite agent.
 
 ---
 
-## My agent exits with status -1
+## Buildkite annotations
+
+Coming soon!
+
+---
+
+## Buildkite agent exits with status -1
 
 **Scenario:**
 you're running a **skuba** command like [`skuba lint`],
@@ -34,33 +43,10 @@ The agent may be tied up running a particularly compute-intensive step.
 
 **Options:**
 
-1. Propagate the `BUILDKITE` environment variable to [`skuba build-package`] and [`skuba lint`] steps.
-   This will cause them to run their underlying processes serially,
+1. Pass the `--serial` flag to [`skuba build-package`] and [`skuba lint`] steps.
+
+   This will cause them to run their underlying operations serially,
    reducing the chance of resource exhaustion.
-
-   With the [Docker Buildkite plugin],
-   you can achieve this in a couple ways:
-
-   ```yaml
-   steps:
-     - plugins:
-         - docker#v3.7.0:
-             # Option 1a: List environment variable explicitly
-             environment:
-               - BUILDKITE
-             # Option 1b: Propagate all pipeline variables
-             propagate-environment: true
-   ```
-
-   With Docker Compose,
-   you can add the variable to your [Compose file]:
-
-   ```yaml
-   services:
-     app:
-       environment:
-         - BUILDKITE
-   ```
 
 1. Reduce the number of agents that run on each instance.
 
@@ -72,5 +58,9 @@ The agent may be tied up running a particularly compute-intensive step.
 
 [`skuba build-package`]: ../cli/build.md#skuba-build-package
 [`skuba lint`]: ../cli/lint.md#skuba-lint
+[`skuba test`]: ../cli/test.md#skuba-test
+[buildkite annotations]: https://buildkite.com/docs/agent/v3/cli-annotate
+[builds at seek]: https://builds-at-seek.ssod.skinfra.xyz/
+[ci/cd]: https://en.wikipedia.org/wiki/CI/CD
 [compose file]: https://docs.docker.com/compose/compose-file
 [docker buildkite plugin]: https://github.com/buildkite-plugins/docker-buildkite-plugin

--- a/src/cli/buildPackage.ts
+++ b/src/cli/buildPackage.ts
@@ -1,23 +1,29 @@
+import { hasSerialFlag } from '../utils/args';
 import { execConcurrently } from '../utils/exec';
 
-export const buildPackage = () =>
-  execConcurrently([
+export const buildPackage = (args = process.argv) =>
+  execConcurrently(
+    [
+      {
+        command:
+          'tsc --module CommonJS --outDir lib-commonjs --project tsconfig.build.json',
+        name: 'commonjs',
+        prefixColor: 'green',
+      },
+      {
+        command:
+          'tsc --module ES2015 --outDir lib-es2015 --project tsconfig.build.json',
+        name: 'es2015',
+        prefixColor: 'yellow',
+      },
+      {
+        command:
+          'tsc --allowJS false --declaration --emitDeclarationOnly --outDir lib-types --project tsconfig.build.json',
+        name: 'types',
+        prefixColor: 'blue',
+      },
+    ],
     {
-      command:
-        'tsc --module CommonJS --outDir lib-commonjs --project tsconfig.build.json',
-      name: 'commonjs',
-      prefixColor: 'green',
+      maxProcesses: hasSerialFlag(args) ? 1 : undefined,
     },
-    {
-      command:
-        'tsc --module ES2015 --outDir lib-es2015 --project tsconfig.build.json',
-      name: 'es2015',
-      prefixColor: 'yellow',
-    },
-    {
-      command:
-        'tsc --allowJS false --declaration --emitDeclarationOnly --outDir lib-types --project tsconfig.build.json',
-      name: 'types',
-      prefixColor: 'blue',
-    },
-  ]);
+  );

--- a/src/cli/lint.test.ts
+++ b/src/cli/lint.test.ts
@@ -19,13 +19,8 @@ const concurrentlyCalls = () =>
 describe('lint', () => {
   afterEach(jest.clearAllMocks);
 
-  const oldProcessArgv = process.argv;
-  afterAll(() => (process.argv = oldProcessArgv));
-
   it('handles no flags', async () => {
-    process.argv = [];
-
-    await expect(lint()).resolves.toBeUndefined();
+    await expect(lint([])).resolves.toBeUndefined();
 
     expect(concurrentlyCalls()).toMatchInlineSnapshot(`
       Array [
@@ -49,6 +44,7 @@ describe('lint', () => {
         },
         Object {
           "maxProcesses": "REDACTED",
+          "outputStream": undefined,
           "prefix": "{name} |",
         },
       ]
@@ -56,9 +52,9 @@ describe('lint', () => {
   });
 
   it('handles debug flag', async () => {
-    process.argv = ['something', '--DeBuG', 'else'];
-
-    await expect(lint()).resolves.toBeUndefined();
+    await expect(
+      lint(['something', '--DeBuG', 'else']),
+    ).resolves.toBeUndefined();
 
     expect(concurrentlyCalls()).toMatchInlineSnapshot(`
       Array [
@@ -82,6 +78,7 @@ describe('lint', () => {
         },
         Object {
           "maxProcesses": "REDACTED",
+          "outputStream": undefined,
           "prefix": "{name} |",
         },
       ]

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -3,34 +3,38 @@ import path from 'path';
 import chalk from 'chalk';
 import { pathExists } from 'fs-extra';
 
-import { hasDebugFlag } from '../utils/args';
+import { hasDebugFlag, hasSerialFlag } from '../utils/args';
 import { execConcurrently } from '../utils/exec';
 import { getConsumerManifest } from '../utils/manifest';
 
-interface Options {
-  debug: boolean;
-}
+import { Input } from './lint/types';
 
-const externalLint = ({ debug }: Options) =>
-  execConcurrently([
+const externalLint = ({ debug, serial }: Input) =>
+  execConcurrently(
+    [
+      {
+        command: `eslint${
+          debug ? ' --debug' : ''
+        } --ext=js,ts,tsx --report-unused-disable-directives .`,
+        name: 'ESLint',
+        prefixColor: 'magenta',
+      },
+      {
+        command: `tsc${debug ? ' --extendedDiagnostics' : ''} --noEmit`,
+        name: 'tsc',
+        prefixColor: 'blue',
+      },
+      {
+        command: `prettier --check${debug ? ' --loglevel debug' : ''} .`,
+        name: 'Prettier',
+        prefixColor: 'cyan',
+      },
+    ],
     {
-      command: `eslint${
-        debug ? ' --debug' : ''
-      } --ext=js,ts,tsx --report-unused-disable-directives .`,
-      name: 'ESLint',
-      prefixColor: 'magenta',
+      // `--debug` implies `--serial`.
+      maxProcesses: debug || serial ? 1 : undefined,
     },
-    {
-      command: `tsc${debug ? ' --extendedDiagnostics' : ''} --noEmit`,
-      name: 'tsc',
-      prefixColor: 'blue',
-    },
-    {
-      command: `prettier --check${debug ? ' --loglevel debug' : ''} .`,
-      name: 'Prettier',
-      prefixColor: 'cyan',
-    },
-  ]);
+  );
 
 const noSkubaTemplateJs = async () => {
   const manifest = await getConsumerManifest();
@@ -57,12 +61,13 @@ export const internalLint = async () => {
   await noSkubaTemplateJs();
 };
 
-export const lint = async () => {
-  const opts: Options = {
-    debug: hasDebugFlag(),
+export const lint = async (args = process.argv) => {
+  const input: Input = {
+    debug: hasDebugFlag(args),
+    serial: hasSerialFlag(args),
   };
 
-  await externalLint(opts);
+  await externalLint(input);
 
   await internalLint();
 };

--- a/src/cli/lint/types.ts
+++ b/src/cli/lint/types.ts
@@ -1,0 +1,25 @@
+export interface Input {
+  /**
+   * Whether to enable verbose debug logging.
+   *
+   * Defaults to `false`.
+   */
+  debug: boolean;
+
+  /**
+   * Whether to disable parallelism to run linting operations serially.
+   *
+   * This can be useful for executing in compute-constrained environments and
+   * snapshotting deterministic output in tests.
+   *
+   * Defaults to `false`.
+   */
+  serial: boolean;
+
+  /**
+   * An override output stream that can be supplied to test `tsc` logging.
+   *
+   * Defaults to `process.stdout`.
+   */
+  tscOutputStream?: NodeJS.WritableStream;
+}

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -1,4 +1,9 @@
-import { hasDebugFlag, parseProcessArgs, parseRunArgs } from './args';
+import {
+  hasDebugFlag,
+  hasSerialFlag,
+  parseProcessArgs,
+  parseRunArgs,
+} from './args';
 
 describe('hasDebugFlag', () => {
   test.each`
@@ -12,6 +17,25 @@ describe('hasDebugFlag', () => {
     ${'matching arg among others'} | ${['something', '--debug', 'else']} | ${true}
   `('$description => $expected', ({ args, expected }) =>
     expect(hasDebugFlag(args)).toBe(expected),
+  );
+});
+
+describe('hasSerialFlag', () => {
+  test.each`
+    description                    | args                                 | env                                                                       | expected
+    ${'no args'}                   | ${[]}                                | ${{}}                                                                     | ${false}
+    ${'unrelated args'}            | ${['something', 'else']}             | ${{}}                                                                     | ${false}
+    ${'single dash'}               | ${['-serial']}                       | ${{}}                                                                     | ${false}
+    ${'matching lowercase arg'}    | ${['--serial']}                      | ${{}}                                                                     | ${true}
+    ${'matching uppercase arg'}    | ${['--SERIAL']}                      | ${{}}                                                                     | ${true}
+    ${'matching spongebob arg'}    | ${['--sERiaL']}                      | ${{}}                                                                     | ${true}
+    ${'matching arg among others'} | ${['something', '--serial', 'else']} | ${{}}                                                                     | ${true}
+    ${'unrelated env'}             | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: '123456789012:cicd' }}               | ${false}
+    ${'matching env'}              | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: 'artefacts:npm' }}                   | ${true}
+    ${'matching env at start'}     | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: 'artefacts:npm,123456789012:cicd' }} | ${true}
+    ${'matching env at end'}       | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: '123456789012:cicd,artefacts:npm' }} | ${true}
+  `('$description => $expected', ({ args, env, expected }) =>
+    expect(hasSerialFlag(args, env)).toBe(expected),
   );
 });
 

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -5,6 +5,9 @@ import { COMMAND_ALIASES } from './command';
 export const hasDebugFlag = (args = process.argv) =>
   args.some((arg) => arg.toLocaleLowerCase() === '--debug');
 
+export const hasSerialFlag = (args = process.argv) =>
+  args.some((arg) => arg.toLocaleLowerCase() === '--serial');
+
 /**
  * Parse process arguments.
  *

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -5,8 +5,13 @@ import { COMMAND_ALIASES } from './command';
 export const hasDebugFlag = (args = process.argv) =>
   args.some((arg) => arg.toLocaleLowerCase() === '--debug');
 
-export const hasSerialFlag = (args = process.argv) =>
-  args.some((arg) => arg.toLocaleLowerCase() === '--serial');
+export const hasSerialFlag = (args = process.argv, env = process.env) =>
+  args.some((arg) => arg.toLocaleLowerCase() === '--serial') ||
+  Boolean(
+    // Run serially on SEEK's central npm publishing pipeline.
+    // Exhausting agents here can cause grief.
+    env.BUILDKITE_AGENT_META_DATA_QUEUE?.split(',').includes('artefacts:npm'),
+  );
 
 /**
  * Parse process arguments.


### PR DESCRIPTION
Previously, we had a Buildkite-specific hack to propagate the BUILDKITE environment variable in order to run these commands serially. This is potentially surprising behaviour, particularly if the consumer is propagating the variable for some other purpose.

That point will become less hypothetical once skuba adds built-in support for Buildkite annotations. We replace the inference with a very explicit flag.