### PR TITLE
Reset exit code between tests

### DIFF
--- a/src/cli/format.int.test.ts
+++ b/src/cli/format.int.test.ts
@@ -84,7 +84,11 @@ const prepareTempDirectory = async (baseDir: string, tempDir: string) => {
 
 const originalCwd = process.cwd();
 
-beforeEach(jest.clearAllMocks);
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  process.exitCode = undefined;
+});
 
 afterAll(() => {
   // Restore the original working directory to avoid confusion in other tests.


### PR DESCRIPTION
We lucked out by listing the exit code-setting test case last, but this will avoid future confusion.