### PR TITLE
Generate per-template changelogs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Lint
         run: yarn lint
 
+      - name: Dry-run site packaging
+        run: yarn stage && yarn ts-node --transpile-only scripts/package.ts
+
   template:
     name: Integrate
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Dry-run site packaging
         run: yarn stage && yarn ts-node --transpile-only scripts/package.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   template:
     name: Integrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,7 +123,7 @@
 
 - 13b3bce: **template/lambda-sqs-worker-cdk:** Add new template
 - 78c9a48: **format, lint:** Support `--debug` flag
-- e7cd7ed: **all:** Upgrade templates to Node 14
+- e7cd7ed: **template:** Upgrade to Node 14
 
   Node.js 14 is [now supported on AWS Lambda](https://aws.amazon.com/about-aws/whats-new/2021/02/aws-lambda-now-supports-node-js-14/). This lets us upgrade the Node.js requirement for skuba's templates.
 
@@ -662,7 +662,7 @@
 - 5753b38: **template/lambda-sqs-worker:** Drop `hot-shots` dependency
 - 0c1e129: **configure, init:** Sort dependencies
 - 93cdf6c: **template:** Redact `Authorization` headers in logs
-- 1b9b9c4: **template/package:** Make prompt unskippable
+- 1b9b9c4: **template/\*-npm-package:** Make prompt unskippable
 - 5283618: **configure, init:** Exclude `lib-` directories from compilation
 - 676030a: **template/private-npm-package:** Fix ReferenceError on init
 - f36b136: **help:** Show `build-package` correctly
@@ -674,7 +674,7 @@
 - 35b4b2e: **configure:** Sort more `package.json` props
 - 23d4e09: **init:** Install matching skuba version
 - bac749a: **init:** Extend validation on initial GitHub fields
-- cbce20b: **template/package:** Drop module aliasing from `tsconfig.json`
+- cbce20b: **template/\*-npm-package:** Drop module aliasing from `tsconfig.json`
 - b480dac: **template:** Redact `err.config.sockets` from logs
 - a52b995: **template/koa-rest-api:** Support improved Runtypes error messaging
 - 1fbb097: **configure:** Handle `skuba-dive` dependency upfront
@@ -723,7 +723,7 @@
 
 ### Minor Changes
 
-- 84a3262: ESLint 7 + `typescript-eslint` 3
+- 84a3262: **format, lint:** ESLint 7 + `typescript-eslint` 3
 
   This upgrade introduces stricter rules around `any` and `object` usage for type safety.
 
@@ -771,7 +771,8 @@
 
 - b39a0e0: **configure:** Use `latest-version` to check package versions
 - 70ae29a: **configure, init:** Switch to oss `skuba-dive` package
-- b44523a: Switch to `seek-datadog-custom-metrics` + `seek-koala`
+- b44523a: **template:** Switch to `seek-datadog-custom-metrics`
+- b44523a: **template/koa-rest-api:** Switch to `seek-koala`
 - 030ebb4: **configure:** Keep name, readme and version fields in package.json
 - a311624: **configure:** Drop `--ignore-optional` from `yarn install`
 - b61a3ca: **start:** Remove support for a custom port logging function
@@ -785,4 +786,4 @@
 
 ### Patch Changes
 
-- ef3abbe: Release on `seek-oss`
+- ef3abbe: **pkg:** Release on `seek-oss`

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/supertest": "2.0.11",
     "express": "4.17.1",
     "koa": "2.13.1",
+    "semver": "7.3.5",
     "supertest": "6.1.6",
     "type-fest": "2.3.2"
   },

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,29 +4,7 @@ set -e
 
 echo '=> Packaging...'
 
-rm -rf dist-docs
-
-mkdir -p dist-docs
-
-changelog="$(cat CHANGELOG.md)"
-
-old_header='# skuba'
-
-new_header="$(cat << EOF
----
-nav_order: 98
----
-
-# Changelog
-
----
-EOF
-)"
-
-echo "${changelog/#"${old_header}"/"${new_header}"}" > dist-docs/CHANGELOG.md
-
-cp CONTRIBUTING.md index.md site/_config.yml dist-docs/
-cp -R docs/ dist-docs/docs/
+yarn ts-node --transpile-only scripts/package.ts
 
 cd dist-docs
 

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -1,0 +1,252 @@
+/* eslint-disable no-console */
+
+import path from 'path';
+
+import fs from 'fs-extra';
+import semver from 'semver';
+
+import {
+  TEMPLATE_DOCUMENTATION_CONFIG,
+  TEMPLATE_NAMES,
+} from '../src/utils/template';
+
+const SCOPE_REGEX = /\*\*([^:]+):\*\* /;
+
+const versionLink = (version: string) =>
+  `[${version}](https://github.com/seek-oss/skuba/releases/tag/v${version})`;
+
+/**
+ * Ensures that our template constant matches the `/template` directory.
+ */
+const ensureTemplateConsistency = async (root: string) => {
+  const templatesInCode = TEMPLATE_NAMES;
+  const templateSetInCode = new Set<string>(templatesInCode);
+
+  const templatesOnDisk = (
+    await fs.promises.readdir(path.join(root, 'template'))
+  ).filter((filename) => filename !== 'base');
+  const templateSetOnDisk = new Set(templatesOnDisk);
+
+  for (const templateName of TEMPLATE_NAMES) {
+    if (!templateSetOnDisk.has(templateName)) {
+      console.error(
+        'Template',
+        templateName,
+        'is defined in code but missing on disk.',
+      );
+      process.exitCode = 1;
+    }
+  }
+
+  for (const templateName of templatesInCode) {
+    if (!templateSetOnDisk.has(templateName)) {
+      console.error(
+        'Template',
+        templateName,
+        'is defined in code but missing on disk.',
+      );
+      process.exitCode = 1;
+    }
+  }
+
+  for (const templateName of templatesOnDisk) {
+    if (!templateSetInCode.has(templateName)) {
+      console.error(
+        'Template',
+        templateName,
+        'is defined on disk but missing in code.',
+      );
+      process.exitCode = 1;
+    }
+  }
+};
+
+/**
+ * Modifies the changelog header to work better with Just the Docs.
+ *
+ * This is JIT-executed because Changesets doesn't like us mucking with the
+ * actual committed `CHANGELOG.md` source.
+ */
+const processChangelogHeader = (changelog: string) =>
+  changelog.replace(
+    /^# skuba/,
+    `
+---
+nav_order: 98
+---
+
+# Changelog
+
+---
+`.trim(),
+  );
+
+/**
+ * Compiles changelog entries for each template for rendering on our
+ * documentation site.
+ */
+const compileChangesByTemplate = (changelog: string) => {
+  const changesByTemplate: Record<string, string[]> = Object.fromEntries(
+    TEMPLATE_NAMES.map((template) => [template, []]),
+  );
+
+  const sections = changelog
+    // Split by version, which is denoted by a `h2`.
+    .split('\n## ')
+    // Skip the `h1` in the first section.
+    .slice(1);
+
+  for (const section of sections) {
+    const split = section.indexOf('\n');
+
+    const version = section.slice(0, split);
+
+    const entries = section
+      .slice(split)
+      .split('\n')
+      // Filter out headings, such as those denoting major/minor/patch.
+      // Our templates aren't semantically versioned so these don't matter.
+      .filter((line) => !line.startsWith('#'))
+      .join('\n')
+      // Split by list item prefix, which denotes a new changelog entry.
+      .split('\n- ')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    for (const entry of entries) {
+      const scope = SCOPE_REGEX.exec(entry)?.[1];
+
+      if (!scope) {
+        // Changelog entry is bad. Consider fixing this at the source.
+        console.error('Changelog entry is missing a scope:', entry);
+        process.exitCode = 1;
+        continue;
+      }
+
+      if (!scope.startsWith('template')) {
+        // Changelog entry relates to something other than a template.
+        continue;
+      }
+
+      const templateMatcher = new RegExp(
+        scope
+          .replace(
+            // Strip out the template prefix.
+            /^template\/?/,
+            '',
+          )
+          .replace(
+            // Handle scopes like `*-npm-package` and `lambda-sqs-worker*`.
+            // Note that this is a subset matcher so the latter is redundant.
+            /\\\*/g,
+            '.*',
+          ),
+      );
+
+      for (const templateName of TEMPLATE_NAMES) {
+        const { added } = TEMPLATE_DOCUMENTATION_CONFIG[templateName];
+
+        // Note that the changeset entry applies to the template if it existed
+        // as of this version and the scope is a match.
+        if (semver.gt(version, added) && templateMatcher.test(templateName)) {
+          changesByTemplate[templateName].push(
+            `- ${versionLink(version)}: ${entry
+              // Strip out the scope as it is needlessly repetitive here.
+              .replace(SCOPE_REGEX, '')
+              // Auto-link a commit hash prefix to GitHub.
+              .replace(
+                /^([0-9a-f]{7,}): /,
+                '[`$1`](https://github.com/seek-oss/skuba/commit/$1): ',
+              )}`,
+          );
+        }
+      }
+    }
+  }
+
+  return changesByTemplate;
+};
+
+const main = async () => {
+  const root = path.join(__dirname, '..');
+
+  await ensureTemplateConsistency(root);
+
+  process.chdir(root);
+
+  await fs.promises.rm('dist-docs', { force: true, recursive: true });
+
+  await fs.promises.mkdir('dist-docs', { recursive: true });
+
+  const changelog = await fs.promises.readFile('CHANGELOG.md', 'utf8');
+
+  const siteChangelog = processChangelogHeader(changelog);
+
+  await Promise.all([
+    fs.promises.writeFile(
+      path.join('dist-docs', 'CHANGELOG.md'),
+      siteChangelog,
+    ),
+    fs.promises.copyFile(
+      'CONTRIBUTING.md',
+      path.join('dist-docs', 'CONTRIBUTING.md'),
+    ),
+    fs.promises.copyFile('index.md', path.join('dist-docs', 'index.md')),
+    fs.promises.cp('site', 'dist-docs', { recursive: true }),
+    fs.promises.cp('docs', path.join('dist-docs', 'docs'), { recursive: true }),
+  ]);
+
+  const templateChanges = compileChangesByTemplate(changelog);
+
+  // Run serially to avoid clobbering files that house multiple templates.
+  for (const templateName of TEMPLATE_NAMES) {
+    const changes = templateChanges[templateName];
+
+    if (!changes.length) {
+      // Add a friendly placeholder if the template is fresh out of the oven.
+      changes.push("🍞 There's nothing here yet.");
+    }
+
+    const filepath = path.join(
+      'dist-docs',
+      'docs',
+      'templates',
+      TEMPLATE_DOCUMENTATION_CONFIG[templateName].filename,
+    );
+
+    const input = await fs.promises.readFile(filepath, 'utf8');
+
+    // Find the start of the section for this template.
+    const templateHeadingIndex = input.indexOf(`## ${templateName}`);
+
+    // Find the end of the section as denoted by a `View on GitHub` link.
+    const viewOnGitHubIndex = input.indexOf(
+      'View on GitHub',
+      templateHeadingIndex,
+    );
+
+    // Find the line after the `View of GitHub` link.
+    const changelogIndex = 1 + input.indexOf('\n', viewOnGitHubIndex);
+
+    // Insert the changelog inside of a collapsed `details` element.
+    const output = `
+${input.slice(0, changelogIndex)}
+<details markdown="block">
+  <summary>
+    Changelog
+  </summary>
+  {: .text-delta }
+
+${changes.join('\n\n')}
+
+</details>
+
+${input.slice(changelogIndex + 1)}`.trimStart();
+
+    await fs.promises.writeFile(filepath, output);
+  }
+};
+
+main().catch((err) => {
+  throw err;
+});

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -216,14 +216,31 @@ const main = async () => {
 
     const input = await fs.promises.readFile(filepath, 'utf8');
 
+    const templateHeading = `## ${templateName}`;
+
     // Find the start of the section for this template.
-    const templateHeadingIndex = input.indexOf(`## ${templateName}`);
+    const templateHeadingIndex = input.indexOf(templateHeading);
+
+    if (templateHeadingIndex === -1) {
+      console.error(filepath, `Could not locate \`${templateHeading}\`.`);
+      process.exitCode = 1;
+      continue;
+    }
 
     // Find the end of the section as denoted by a `View on GitHub` link.
     const viewOnGitHubIndex = input.indexOf(
       'View on GitHub',
       templateHeadingIndex,
     );
+
+    if (viewOnGitHubIndex === -1) {
+      console.error(
+        filepath,
+        `Could not locate \`View on GitHub\` line within \`${templateHeading}\`.`,
+      );
+      process.exitCode = 1;
+      continue;
+    }
 
     // Find the line after the `View of GitHub` link.
     const changelogIndex = 1 + input.indexOf('\n', viewOnGitHubIndex);

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -12,8 +12,15 @@ import {
 
 const SCOPE_REGEX = /\*\*([^:]+):\*\* /;
 
+const commitLink = (commit: string) =>
+  `[\`${commit}\`](https://github.com/seek-oss/skuba/commit/${encodeURIComponent(
+    commit,
+  )})`;
+
 const versionLink = (version: string) =>
-  `[${version}](https://github.com/seek-oss/skuba/releases/tag/v${version})`;
+  `[${version}](https://github.com/seek-oss/skuba/releases/tag/v${encodeURIComponent(
+    version,
+  )})`;
 
 /**
  * Ensures that our template constant matches the `/template` directory.
@@ -156,7 +163,7 @@ const compileChangesByTemplate = (changelog: string) => {
               // Auto-link a commit hash prefix to GitHub.
               .replace(
                 /^([0-9a-f]{7,}): /,
-                '[`$1`](https://github.com/seek-oss/skuba/commit/$1): ',
+                (_, commit: string) => `${commitLink(commit)}: `,
               )}`,
           );
         }

--- a/src/cli/init/prompts.ts
+++ b/src/cli/init/prompts.ts
@@ -1,6 +1,8 @@
 import { Input, Select } from 'enquirer';
 import { pathExists } from 'fs-extra';
 
+import { TEMPLATE_NAMES_WITH_BYO } from '../../utils/template';
+
 import { isGitHubOrg, isGitHubRepo, isGitHubTeam } from './validation';
 
 export type BaseFields = Record<typeof BASE_CHOICES[number]['name'], string>;
@@ -66,16 +68,7 @@ export const GIT_PATH_PROMPT = new Input({
 });
 
 export const TEMPLATE_PROMPT = new Select({
-  choices: [
-    'express-rest-api',
-    'greeter',
-    'koa-rest-api',
-    'lambda-sqs-worker',
-    'lambda-sqs-worker-cdk',
-    'oss-npm-package',
-    'private-npm-package',
-    'github →',
-  ] as const,
+  choices: TEMPLATE_NAMES_WITH_BYO,
   message: 'Select a template:',
   name: 'templateName',
 });

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -7,6 +7,70 @@ import * as t from 'runtypes';
 
 import { ProjectType } from './manifest';
 
+export const TEMPLATE_NAMES = [
+  'express-rest-api',
+  'greeter',
+  'koa-rest-api',
+  'lambda-sqs-worker',
+  'lambda-sqs-worker-cdk',
+  'oss-npm-package',
+  'private-npm-package',
+] as const;
+
+export type TemplateName = typeof TEMPLATE_NAMES[number];
+
+export const TEMPLATE_NAMES_WITH_BYO = [...TEMPLATE_NAMES, 'github →'] as const;
+
+interface TemplateDocumentationConfig {
+  /**
+   * The semantic version in which the template was first added.
+   *
+   * This is used to filter out historical changelogs.
+   */
+  added: string;
+
+  /**
+   * The Markdown file for the template in our `/docs`.
+   *
+   * This is used to compile per-template changelogs for our documentation site.
+   */
+  filename: string;
+}
+
+export const TEMPLATE_DOCUMENTATION_CONFIG: Record<
+  TemplateName,
+  TemplateDocumentationConfig
+> = {
+  'express-rest-api': {
+    added: '3.8.0',
+    filename: 'api.md',
+  },
+  greeter: {
+    added: '3.4.1',
+    filename: 'barebones.md',
+  },
+  'koa-rest-api': {
+    added: '3.4.1',
+    filename: 'api.md',
+  },
+  'lambda-sqs-worker': {
+    added: '3.4.1',
+    filename: 'worker.md',
+  },
+  'lambda-sqs-worker-cdk': {
+    added: '3.13.0',
+    filename: 'worker.md',
+  },
+  'oss-npm-package': {
+    added: '3.7.0',
+    filename: 'package.md',
+  },
+  'private-npm-package': {
+    added: '3.6.0',
+    filename: 'package.md',
+  },
+};
+
 export type TemplateConfig = t.Static<typeof TemplateConfig>;
 
 export const TemplateConfig = t.Record({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7156,7 +7156,7 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.x, semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+semver@7.3.5, semver@7.x, semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==


### PR DESCRIPTION
These are now available on each page under this section:

https://seek-oss.github.io/skuba/docs/templates/

---

This feature relies on a certain level of structure being applied to our templates and changelogs. To that end, we now validate in CI that template configuration is internally consistent and require all changelog entries to have a scope.