### PR TITLE
Speed up lint integration

### DIFF
--- a/integration/base/fixable/tsconfig.json
+++ b/integration/base/fixable/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "incremental": true,
     "moduleResolution": "node",
-    "outDir": "lib"
+    "outDir": "lib",
+    "skipLibCheck": true
   },
   "extends": "tsconfig-seek"
 }

--- a/integration/base/ok/tsconfig.json
+++ b/integration/base/ok/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "incremental": true,
     "moduleResolution": "node",
-    "outDir": "lib"
+    "outDir": "lib",
+    "skipLibCheck": true
   },
   "extends": "tsconfig-seek"
 }

--- a/integration/base/unfixable/tsconfig.json
+++ b/integration/base/unfixable/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "incremental": true,
     "moduleResolution": "node",
-    "outDir": "lib"
+    "outDir": "lib",
+    "skipLibCheck": true
   },
   "extends": "tsconfig-seek"
 }


### PR DESCRIPTION
`tsc` was spending a bunch of time churning through internal TypeScript definitions. We don't really care about this for the purposes of our integration tests.