### PR TITLE
Handle worker thread errors more gracefully

### DIFF
--- a/.changeset/shy-colts-warn.md
+++ b/.changeset/shy-colts-warn.md
@@ -1,0 +1,7 @@
+---
+"skuba": patch
+---
+
+build-package, lint: Handle worker thread errors more gracefully
+
+The worker threads now correctly propagate an exit code and log errors instead of triggering an `UnhandledPromiseRejectionWarning`.

--- a/src/cli/lint/eslint.ts
+++ b/src/cli/lint/eslint.ts
@@ -9,8 +9,10 @@ import { ESLintOutput, runESLint } from '../adapter/eslint';
 
 import type { Input } from './types';
 
+const LOG_PREFIX = chalk.magenta('ESLint   │');
+
 export const runESLintInCurrentThread = ({ debug }: Input) =>
-  runESLint('lint', createLogger(debug, chalk.magenta('ESLint   │')));
+  runESLint('lint', createLogger(debug, LOG_PREFIX));
 
 export const runESLintInWorkerThread = (input: Input) =>
   execWorkerThread<Input, ESLintOutput>(
@@ -19,7 +21,5 @@ export const runESLintInWorkerThread = (input: Input) =>
   );
 
 if (!isMainThread) {
-  postWorkerOutput(runESLintInCurrentThread).catch((err) => {
-    throw err;
-  });
+  postWorkerOutput(runESLintInCurrentThread, createLogger(false, LOG_PREFIX));
 }

--- a/src/cli/lint/prettier.ts
+++ b/src/cli/lint/prettier.ts
@@ -9,8 +9,10 @@ import { PrettierOutput, runPrettier } from '../adapter/prettier';
 
 import type { Input } from './types';
 
+const LOG_PREFIX = chalk.cyan('Prettier │');
+
 export const runPrettierInCurrentThread = ({ debug }: Input) =>
-  runPrettier('lint', createLogger(debug, chalk.cyan('Prettier │')));
+  runPrettier('lint', createLogger(debug, LOG_PREFIX));
 
 export const runPrettierInWorkerThread = (input: Input) =>
   execWorkerThread<Input, PrettierOutput>(
@@ -19,7 +21,5 @@ export const runPrettierInWorkerThread = (input: Input) =>
   );
 
 if (!isMainThread) {
-  postWorkerOutput(runPrettierInCurrentThread).catch((err) => {
-    throw err;
-  });
+  postWorkerOutput(runPrettierInCurrentThread, createLogger(false, LOG_PREFIX));
 }


### PR DESCRIPTION
We were getting some real sketchy output:

```
(node:212) UnhandledPromiseRejectionWarning: Error: EBADF: bad file descriptor, close
(Use `node --trace-warnings ...` to show where the warning was created)
(node:212) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:212) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
Error: Worker exited without posting a message
```