### PR TITLE
Allow testEnvironment to be passed to Jest.mergePreset

### DIFF
--- a/.changeset/serious-candles-do.md
+++ b/.changeset/serious-candles-do.md
@@ -2,9 +2,9 @@
 "skuba": minor
 ---
 
-Allow configuration of Jest's test environment
+Jest.mergePreset: Allow configuration of test environment
 
-[Jest's `testEnvironment`](https://jestjs.io/docs/configuration#testenvironment-string) can now be passed to Jest.mergePreset
+[Jest's `testEnvironment`](https://jestjs.io/docs/configuration#testenvironment-string) can now be passed to `Jest.mergePreset`:
 
 ```ts
 export default Jest.mergePreset({

--- a/.changeset/serious-candles-do.md
+++ b/.changeset/serious-candles-do.md
@@ -1,0 +1,13 @@
+---
+"skuba": minor
+---
+
+Allow configuration of Jest's test environment
+
+[Jest's `testEnvironment`](https://jestjs.io/docs/configuration#testenvironment-string) can now be passed to Jest.mergePreset
+
+```ts
+export default Jest.mergePreset({
+  testEnvironment: "jsdom",
+});
+```

--- a/src/api/jest/index.test.ts
+++ b/src/api/jest/index.test.ts
@@ -17,11 +17,17 @@ describe('mergePreset', () => {
     expect(config.setupFiles).toEqual(['abc']);
   });
 
-  it('merges colliding props', () => {
+  it('merges colliding array props', () => {
     const config = mergePreset({ collectCoverageFrom: ['abc'] });
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).toContain('abc');
     expect(config.setupFiles).toEqual(['abc']);
+  });
+
+  it('overrides colliding non-array props', () => {
+    const config = mergePreset({ testEnvironment: 'jsdom' });
+
+    expect(config).toHaveProperty('testEnvironment', 'jsdom');
   });
 });

--- a/src/api/jest/index.ts
+++ b/src/api/jest/index.ts
@@ -16,6 +16,7 @@ type Props = Pick<
   | 'setupFiles'
   | 'setupFilesAfterEnv'
   | 'snapshotSerializers'
+  | 'testEnvironment'
   | 'testPathIgnorePatterns'
   | 'testTimeout'
   | 'watchPathIgnorePatterns'


### PR DESCRIPTION
This change allows npm packages that are targeted to the browser to run their tests using jsdom.

Details in changeset.