### PR TITLE
No-longer mutate underlying defaults when calling Jest.mergePreset

### DIFF
--- a/.changeset/bright-oranges-heal.md
+++ b/.changeset/bright-oranges-heal.md
@@ -1,0 +1,9 @@
+---
+"skuba": patch
+---
+
+Jest.mergePreset: No-longer mutates underlying defaults
+
+Calls to `Jest.mergePreset` no-longer mutates the internal jest-preset object. Subsequence calls to `Jest.mergePreset` will no-longer return results merged in from previous calls.
+
+**Warning:** If you rely on mutating the core jest-preset object for later access with this call this is a _Breaking Change_.

--- a/.changeset/bright-oranges-heal.md
+++ b/.changeset/bright-oranges-heal.md
@@ -2,8 +2,8 @@
 "skuba": patch
 ---
 
-Jest.mergePreset: No-longer mutates underlying defaults
+Jest.mergePreset: Do not mutate underlying defaults
 
-Calls to `Jest.mergePreset` no-longer mutates the internal jest-preset object. Subsequence calls to `Jest.mergePreset` will no-longer return results merged in from previous calls.
+`Jest.mergePreset` no longer mutates the internal `jest-preset` object. Subsequent calls to `Jest.mergePreset` will no longer return results merged in from previous calls.
 
-**Warning:** If you rely on mutating the core jest-preset object for later access with this call this is a _Breaking Change_.
+**Warning:** If you rely on mutating the core `jest-preset` object for later access, this is a _Breaking Change_.

--- a/src/api/jest/index.test.ts
+++ b/src/api/jest/index.test.ts
@@ -22,7 +22,7 @@ describe('mergePreset', () => {
 
     expect(config).toHaveProperty('testEnvironment', 'node');
     expect(config.collectCoverageFrom).toContain('abc');
-    expect(config.setupFiles).toEqual(['abc']);
+    expect(config.setupFiles).toBeUndefined();
   });
 
   it('overrides colliding non-array props', () => {

--- a/src/cli/configure/processing/record.test.ts
+++ b/src/cli/configure/processing/record.test.ts
@@ -17,25 +17,49 @@ describe('getFirstDefined', () => {
 });
 
 describe('merge', () => {
-  it('concats, dedupes and sorts arrays', () =>
-    expect(merge({ a: [1, 3] }, { a: [2, 4, 3] })).toStrictEqual({
+  it('concats, dedupes and sorts arrays', () => {
+    const target = { a: [1, 3] };
+    const source = { a: [2, 4, 3] };
+    expect(merge(target, source)).toStrictEqual({
       a: [1, 2, 3, 4],
-    }));
+    });
+    expect(target).toStrictEqual({
+      a: [2, 4, 3],
+    });
+    expect(source).toStrictEqual({
+      a: [1, 2],
+    });
+  });
 
-  it('merges nested objects', () =>
-    expect(
-      merge({ a1: { b1: { c1: null } } }, { a1: { b1: {}, b2: true } }),
-    ).toStrictEqual({ a1: { b1: { c1: null }, b2: true } }));
+  it('merges nested objects', () => {
+    const target = { a1: { b1: { c1: null } } };
+    const source = { a1: { b1: {}, b2: true } };
+    expect(merge(target, source)).toStrictEqual({
+      a1: { b1: { c1: null }, b2: true },
+    });
+    expect(target).toStrictEqual({ a1: { b1: { c1: null } } });
+    expect(source).toStrictEqual({ a1: { b1: {}, b2: true } });
+  });
 });
 
 describe('mergeRaw', () => {
-  it('concats arrays', () =>
-    expect(mergeRaw({ a: [1, 3] }, { a: [2, 4, 3] })).toStrictEqual({
+  it('concats arrays', () => {
+    const target = { a: [1, 3] };
+    const source = { a: [2, 4, 3] };
+    expect(mergeRaw(target, source)).toStrictEqual({
       a: [1, 3, 2, 4, 3],
-    }));
+    });
+    expect(target).toStrictEqual({ a: [1, 3] });
+    expect(source).toStrictEqual({ a: [2, 4, 3] });
+  });
 
-  it('merges nested objects', () =>
-    expect(
-      mergeRaw({ a1: { b1: { c1: null } } }, { a1: { b1: {}, b2: true } }),
-    ).toStrictEqual({ a1: { b1: { c1: null }, b2: true } }));
+  it('merges nested objects', () => {
+    const target = { a1: { b1: { c1: null } } };
+    const source = { a1: { b1: {}, b2: true } };
+    expect(mergeRaw(target, source)).toStrictEqual({
+      a1: { b1: { c1: null }, b2: true },
+    });
+    expect(target).toStrictEqual({ a1: { b1: { c1: null } } });
+    expect(source).toStrictEqual({ a1: { b1: {}, b2: true } });
+  });
 });

--- a/src/cli/configure/processing/record.test.ts
+++ b/src/cli/configure/processing/record.test.ts
@@ -23,12 +23,8 @@ describe('merge', () => {
     expect(merge(target, source)).toStrictEqual({
       a: [1, 2, 3, 4],
     });
-    expect(target).toStrictEqual({
-      a: [2, 4, 3],
-    });
-    expect(source).toStrictEqual({
-      a: [1, 2],
-    });
+    expect(target).toStrictEqual({ a: [1, 3] });
+    expect(source).toStrictEqual({ a: [2, 4, 3] });
   });
 
   it('merges nested objects', () => {

--- a/src/cli/configure/processing/record.ts
+++ b/src/cli/configure/processing/record.ts
@@ -22,7 +22,7 @@ export const getFirstDefined = <T>(
  * Array properties are sorted and deduped.
  */
 export const merge = <A, B>(obj: A, src: B) =>
-  mergeWith(obj, src, (objValue: unknown, srcValue: unknown) => {
+  mergeWith({}, obj, src, (objValue: unknown, srcValue: unknown) => {
     if (isArray(objValue) && isArray(srcValue)) {
       return [...new Set(objValue.concat(srcValue))].sort();
     }
@@ -34,7 +34,7 @@ export const merge = <A, B>(obj: A, src: B) =>
  * Like `merge`, but arrays are not deduped or sorted to preserve order.
  */
 export const mergeRaw = <A, B>(obj: A, src: B) =>
-  mergeWith(obj, src, (objValue: unknown, srcValue: unknown) =>
+  mergeWith({}, obj, src, (objValue: unknown, srcValue: unknown) =>
     isArray(objValue) && isArray(srcValue)
       ? objValue.concat(srcValue)
       : undefined,


### PR DESCRIPTION
closes: https://github.com/seek-oss/skuba/issues/593

As discussed in https://github.com/seek-oss/skuba/issues/593 this chance could be considered a breaking change. However, if this hasn't been intended functionality and users wouldn't be expecting it, it seems fine to make this change as a patch.

Alternatively we could deprecate this call and create a new method like `withDefaults`.

Details in Changeset.