### PR TITLE
Reduce #592 to a patch

### DIFF
--- a/.changeset/serious-candles-do.md
+++ b/.changeset/serious-candles-do.md
@@ -1,5 +1,5 @@
 ---
-"skuba": minor
+"skuba": patch
 ---
 
 Jest.mergePreset: Allow configuration of test environment


### PR DESCRIPTION
This is valid as a `minor`, but I'm leaning `patch` to make it seamless to automerge. The change is simple and only affects TypeScript types.