### PR TITLE
Switch `lambda-sqs-worker` template to ARM64

### DIFF
--- a/.changeset/clever-masks-develop.md
+++ b/.changeset/clever-masks-develop.md
@@ -1,0 +1,10 @@
+---
+'skuba': minor
+---
+
+**template/lambda-sqs-worker:** Switch to Graviton2
+
+These are a bit cheaper and a bit faster than the x86 Lambdas:
+<https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/>
+
+The underlying Lambda architecture should be invisible to typical TypeScript Lambdas.

--- a/.changeset/clever-masks-develop.md
+++ b/.changeset/clever-masks-develop.md
@@ -1,5 +1,5 @@
 ---
-'skuba': minor
+"skuba": minor
 ---
 
 **template/lambda-sqs-worker:** Switch to ARM64 architecture

--- a/.changeset/clever-masks-develop.md
+++ b/.changeset/clever-masks-develop.md
@@ -4,7 +4,7 @@
 
 **template/lambda-sqs-worker:** Switch to ARM64 architecture
 
-These are a bit cheaper and a bit faster than the x86 Lambdas:
+These are a bit cheaper and a bit faster than x86 Lambdas:
 <https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/>
 
 The underlying Lambda architecture should be invisible to typical TypeScript Lambdas.

--- a/.changeset/clever-masks-develop.md
+++ b/.changeset/clever-masks-develop.md
@@ -2,7 +2,7 @@
 'skuba': minor
 ---
 
-**template/lambda-sqs-worker:** Switch to Graviton2
+**template/lambda-sqs-worker:** Switch to ARM64 architecture
 
 These are a bit cheaper and a bit faster than the x86 Lambdas:
 <https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/>

--- a/.changeset/clever-masks-develop.md
+++ b/.changeset/clever-masks-develop.md
@@ -1,5 +1,5 @@
 ---
-"skuba": minor
+"skuba": patch
 ---
 
 **template/lambda-sqs-worker:** Switch to ARM64 architecture

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -27,6 +27,7 @@ provider:
   name: aws
   region: ap-southeast-2
   runtime: nodejs14.x
+  architecture: arm64
   stackName: ${self:service}
   stage: ${env:ENVIRONMENT}
   versionFunctions: true


### PR DESCRIPTION
These are a bit cheaper and a bit faster than the x86 Lambdas:
<https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/>

The underlying Lambda architecture should be invisible to typical TypeScript Lambdas. Indirect Apply has switched over all of their Lambdas, only encountering difficulty with DataDog/serverless-plugin-datadog#184.
