### PR TITLE
Decouple GitHub.createCheckRun from Buildkite

### DIFF
--- a/.changeset/cuddly-forks-give.md
+++ b/.changeset/cuddly-forks-give.md
@@ -2,4 +2,4 @@
 "skuba": minor
 ---
 
-GitHub.createCheckRunFromBuildkite: Add development API for writing annotations
+GitHub.createCheckRun: Add development API for writing annotations

--- a/docs/deep-dives/github.md
+++ b/docs/deep-dives/github.md
@@ -54,6 +54,14 @@ services:
       - /workdir/node_modules
 ```
 
+If you're running in GitHub Actions,
+propagate the following environment variables to achieve the same effect:
+
+- `CI` or `GITHUB_ACTIONS`
+- `GITHUB_JOB`
+- `GITHUB_RUN_NUMBER`
+- `GITHUB_TOKEN`
+
 This feature is also planned for [`skuba test`] in future.
 
 ---

--- a/docs/deep-dives/github.md
+++ b/docs/deep-dives/github.md
@@ -29,8 +29,7 @@ steps:
       - docker#v3.8.0:
           environment:
             # Enable GitHub annotation support.
-            - BUILDKITE_REPO
-            - BUILDKITE_COMMIT
+            - BUILDKITE
             - BUILDKITE_BUILD_NUMBER
             - GITHUB_API_TOKEN
           volumes:
@@ -46,8 +45,7 @@ services:
   app:
     environment:
       # Enable GitHub annotation support.
-      - BUILDKITE_REPO
-      - BUILDKITE_COMMIT
+      - BUILDKITE
       - BUILDKITE_BUILD_NUMBER
       - GITHUB_API_TOKEN
     volumes:

--- a/docs/development-api/github.md
+++ b/docs/development-api/github.md
@@ -6,18 +6,13 @@ parent: Development API
 
 ---
 
-## createCheckRunFromBuildkite
+## createCheckRun
 
 Asynchronously creates a GitHub [check run] with annotations.
 
-This writes the first 50 `annotations` in full to GitHub.
+The first 50 `annotations` are written in full to GitHub.
 
-If the following environment variables are not present,
-the function will silently return without attempting to create a check run:
-
-- `BUILDKITE`
-- `BUILDKITE_BUILD_NUMBER`
-- `GITHUB_API_TOKEN`
+A `GITHUB_API_TOKEN` or `GITHUB_TOKEN` with the `checks:write` permission must be present on the environment.
 
 ```typescript
 import { GitHub } from 'skuba';
@@ -25,7 +20,7 @@ import { GitHub } from 'skuba';
 const main = async () => {
   const annotations = await createAnnotations();
 
-  await GitHub.createCheckRunFromBuildkite({
+  await GitHub.createCheckRun({
     name: 'skuba/lint',
     summary: '`skuba/lint` found issues that require triage.',
     annotations,

--- a/docs/development-api/github.md
+++ b/docs/development-api/github.md
@@ -15,9 +15,8 @@ This writes the first 50 `annotations` in full to GitHub.
 If the following environment variables are not present,
 the function will silently return without attempting to create a check run:
 
+- `BUILDKITE`
 - `BUILDKITE_BUILD_NUMBER`
-- `BUILDKITE_COMMIT`
-- `BUILDKITE_REPO`
 - `GITHUB_API_TOKEN`
 
 ```typescript

--- a/src/api/github/checkRun.ts
+++ b/src/api/github/checkRun.ts
@@ -1,5 +1,7 @@
 import { Octokit } from '@octokit/rest';
 import { Endpoints } from '@octokit/types';
+import fs from 'fs-extra';
+import git from 'isomorphic-git';
 
 type Output = NonNullable<
   Endpoints['POST /repos/{owner}/{repo}/check-runs']['parameters']['output']
@@ -11,9 +13,8 @@ const GITHUB_MAX_ANNOTATIONS = 50;
 
 const isGitHubAnnotationsEnabled = (): boolean =>
   Boolean(
-    process.env.BUILDKITE_BUILD_NUMBER &&
-      process.env.BUILDKITE_COMMIT &&
-      process.env.BUILDKITE_REPO &&
+    process.env.BUILDKITE &&
+      process.env.BUILDKITE_BUILD_NUMBER &&
       process.env.GITHUB_API_TOKEN,
   );
 
@@ -34,21 +35,29 @@ const isGitHubAnnotationsEnabled = (): boolean =>
  */
 const ownerRepoRegex = /github.com(?::|\/)(.+)\/(.+).git$/;
 
-const getOwnerRepo = (): { owner: string; repo: string } => {
-  const match = ownerRepoRegex.exec(process.env.BUILDKITE_REPO as string);
-  const owner = match?.[1];
-  const repo = match?.[2];
+const getOwnerRepo = async (
+  dir: string,
+): Promise<{ owner: string; repo: string }> => {
+  const remotes = await git.listRemotes({ dir, fs });
 
-  if (!owner || !repo) {
-    throw new Error(
-      'Could not extract GitHub owner/repo from BUILDKITE_REPO environment variable',
-    );
+  for (const { url } of remotes) {
+    const match = ownerRepoRegex.exec(url);
+
+    const owner = match?.[1];
+    const repo = match?.[2];
+
+    if (owner && repo) {
+      return { owner, repo };
+    }
   }
 
-  return {
-    owner,
-    repo,
-  };
+  throw new Error('Could not find a GitHub remote');
+};
+
+const getHeadSha = async (dir: string): Promise<string> => {
+  const [commit] = await git.log({ depth: 1, dir, fs });
+
+  return commit.oid;
 };
 
 /**
@@ -90,10 +99,10 @@ const createEnrichedSummary = (
   ].join('\n\n');
 
 interface CreateCheckRunParameters {
-  name: string;
-  summary: string;
   annotations: Annotation[];
   conclusion: 'failure' | 'success';
+  name: string;
+  summary: string;
 }
 
 /**
@@ -104,38 +113,41 @@ interface CreateCheckRunParameters {
  * If the following environment variables are not present,
  * the function will silently return without attempting to annotate:
  *
+ * - `BUILDKITE`
  * - `BUILDKITE_BUILD_NUMBER`
- * - `BUILDKITE_COMMIT`
- * - `BUILDKITE_REPO`
  * - `GITHUB_API_TOKEN`
  */
 export const createCheckRunFromBuildkite = async ({
-  name,
-  summary,
   annotations,
   conclusion,
+  name,
+  summary,
 }: CreateCheckRunParameters): Promise<void> => {
   if (!isGitHubAnnotationsEnabled()) {
     return;
   }
 
-  const client = new Octokit({
-    auth: process.env.GITHUB_API_TOKEN,
-  });
-  const { owner, repo } = getOwnerRepo();
-  const title = createTitle(conclusion, annotations.length);
-  const enrichedSummary = createEnrichedSummary(summary, annotations.length);
+  const dir = process.cwd();
+
+  const [headSha, { owner, repo }] = await Promise.all([
+    getHeadSha(dir),
+    getOwnerRepo(dir),
+  ]);
+
+  const client = new Octokit({ auth: process.env.GITHUB_API_TOKEN });
+
+  const output = {
+    annotations: annotations.slice(0, GITHUB_MAX_ANNOTATIONS),
+    summary: createEnrichedSummary(summary, annotations.length),
+    title: createTitle(conclusion, annotations.length),
+  };
 
   await client.checks.create({
+    conclusion,
+    head_sha: headSha,
+    name,
+    output,
     owner,
     repo,
-    name,
-    output: {
-      title,
-      summary: enrichedSummary,
-      annotations: annotations.slice(0, GITHUB_MAX_ANNOTATIONS),
-    },
-    head_sha: process.env.BUILDKITE_COMMIT!,
-    conclusion,
   });
 };

--- a/src/api/github/environment.test.ts
+++ b/src/api/github/environment.test.ts
@@ -1,0 +1,36 @@
+import {
+  buildNameFromEnvironment,
+  enabledFromEnvironment,
+} from './environment';
+
+describe('buildNameFromEnvironment', () => {
+  it.each`
+    description                 | env                                                     | expected
+    ${'Buildkite'}              | ${{ BUILDKITE_BUILD_NUMBER: '123' }}                    | ${'Build #123'}
+    ${'partial GitHub Actions'} | ${{ GITHUB_RUN_NUMBER: '456' }}                         | ${'Build #456'}
+    ${'full GitHub Actions'}    | ${{ GITHUB_JOB: 'Validate', GITHUB_RUN_NUMBER: '789' }} | ${'Validate #789'}
+    ${'default'}                | ${{}}                                                   | ${'Build'}
+  `('returns "$expected" from $description environment', ({ env, expected }) =>
+    expect(buildNameFromEnvironment(env)).toBe(expected),
+  );
+});
+
+describe('enabledFromEnvironment', () => {
+  it.each`
+    description         | env
+    ${'Buildkite'}      | ${{ BUILDKITE: 'x', GITHUB_API_TOKEN: 'x' }}
+    ${'GitHub Actions'} | ${{ GITHUB_ACTIONS: 'x', GITHUB_TOKEN: 'x' }}
+    ${'generic CI'}     | ${{ CI: 'x', GITHUB_TOKEN: 'x' }}
+  `('accepts $description environment', ({ env }) =>
+    expect(enabledFromEnvironment(env)).toBe(true),
+  );
+
+  it.each`
+    description                                     | env
+    ${'Buildkite environment without token'}        | ${{ BUILDKITE: 'x' }}
+    ${'GitHub Actions environment without CI flag'} | ${{ GITHUB_TOKEN: 'x' }}
+    ${'empty environment'}                          | ${{}}
+  `('rejects $description', ({ env }) =>
+    expect(enabledFromEnvironment(env)).toBe(false),
+  );
+});

--- a/src/api/github/environment.test.ts
+++ b/src/api/github/environment.test.ts
@@ -5,11 +5,11 @@ import {
 
 describe('buildNameFromEnvironment', () => {
   it.each`
-    description                 | env                                                     | expected
-    ${'Buildkite'}              | ${{ BUILDKITE_BUILD_NUMBER: '123' }}                    | ${'Build #123'}
-    ${'partial GitHub Actions'} | ${{ GITHUB_RUN_NUMBER: '456' }}                         | ${'Build #456'}
-    ${'full GitHub Actions'}    | ${{ GITHUB_JOB: 'Validate', GITHUB_RUN_NUMBER: '789' }} | ${'Validate #789'}
-    ${'default'}                | ${{}}                                                   | ${'Build'}
+    description                 | env                                                          | expected
+    ${'Buildkite'}              | ${{ BUILDKITE_BUILD_NUMBER: '123' }}                         | ${'Build #123'}
+    ${'partial GitHub Actions'} | ${{ GITHUB_RUN_NUMBER: '456' }}                              | ${'Build #456'}
+    ${'full GitHub Actions'}    | ${{ GITHUB_RUN_NUMBER: '789', GITHUB_WORKFLOW: 'Validate' }} | ${'Validate #789'}
+    ${'default'}                | ${{}}                                                        | ${'Build'}
   `('returns "$expected" from $description environment', ({ env, expected }) =>
     expect(buildNameFromEnvironment(env)).toBe(expected),
   );

--- a/src/api/github/environment.ts
+++ b/src/api/github/environment.ts
@@ -4,7 +4,7 @@ export const buildNameFromEnvironment = (env = process.env): string => {
   }
 
   if (env.GITHUB_RUN_NUMBER) {
-    return `${env.GITHUB_JOB ?? 'Build'} #${env.GITHUB_RUN_NUMBER}`;
+    return `${env.GITHUB_WORKFLOW ?? 'Build'} #${env.GITHUB_RUN_NUMBER}`;
   }
 
   return 'Build';

--- a/src/api/github/environment.ts
+++ b/src/api/github/environment.ts
@@ -1,0 +1,17 @@
+export const buildNameFromEnvironment = (env = process.env): string => {
+  if (env.BUILDKITE_BUILD_NUMBER) {
+    return `Build #${env.BUILDKITE_BUILD_NUMBER}`;
+  }
+
+  if (env.GITHUB_RUN_NUMBER) {
+    return `${env.GITHUB_JOB ?? 'Build'} #${env.GITHUB_RUN_NUMBER}`;
+  }
+
+  return 'Build';
+};
+
+export const enabledFromEnvironment = (env = process.env): boolean =>
+  // Running in a CI environment.
+  Boolean(env.BUILDKITE || env.CI || env.GITHUB_ACTIONS) &&
+  // Has an API token at the ready.
+  Boolean(env.GITHUB_API_TOKEN || env.GITHUB_TOKEN);

--- a/src/api/github/index.ts
+++ b/src/api/github/index.ts
@@ -1,2 +1,2 @@
 export type { Annotation } from './checkRun';
-export { createCheckRunFromBuildkite } from './checkRun';
+export { createCheckRun } from './checkRun';

--- a/src/cli/lint/annotate/github/index.test.ts
+++ b/src/cli/lint/annotate/github/index.test.ts
@@ -98,7 +98,9 @@ const mockTscAnnotations: GitHub.Annotation[] = [
 
 beforeEach(() => {
   process.env.CI = 'true';
+  process.env.GITHUB_RUN_NUMBER = '123';
   process.env.GITHUB_TOKEN = 'Hello from GITHUB_TOKEN';
+  process.env.GITHUB_WORKFLOW = 'Test';
 
   mocked(createEslintAnnotations).mockReturnValue(mockEslintAnnotations);
   mocked(createPrettierAnnotations).mockReturnValue(mockPrettierAnnotations);
@@ -107,7 +109,9 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.CI;
+  delete process.env.GITHUB_RUN_NUMBER;
   delete process.env.GITHUB_TOKEN;
+  delete process.env.GITHUB_WORKFLOW;
 
   jest.resetAllMocks();
 });
@@ -177,7 +181,7 @@ it('should combine all the annotations into an array for the check run', async (
     summary: expect.any(String),
     annotations: expectedAnnotations,
     conclusion: expect.any(String),
-    title: 'Build failed',
+    title: 'Test #123 failed',
   });
 });
 
@@ -194,7 +198,7 @@ it('should set the conclusion to failure if any output is not ok', async () => {
     summary: expect.any(String),
     annotations: expect.any(Array),
     conclusion: 'failure',
-    title: 'Build failed',
+    title: 'Test #123 failed',
   });
 });
 
@@ -211,7 +215,7 @@ it('should set the conclusion to success if all outputs are ok', async () => {
     summary: expect.any(String),
     annotations: expect.any(Array),
     conclusion: 'success',
-    title: 'Build passed',
+    title: 'Test #123 passed',
   });
 });
 

--- a/src/cli/lint/annotate/github/index.test.ts
+++ b/src/cli/lint/annotate/github/index.test.ts
@@ -98,6 +98,7 @@ const mockTscAnnotations: GitHub.Annotation[] = [
 
 beforeEach(() => {
   process.env.CI = 'true';
+  process.env.GITHUB_ACTIONS = 'true';
   process.env.GITHUB_RUN_NUMBER = '123';
   process.env.GITHUB_TOKEN = 'Hello from GITHUB_TOKEN';
   process.env.GITHUB_WORKFLOW = 'Test';
@@ -109,6 +110,7 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.CI;
+  delete process.env.GITHUB_ACTIONS;
   delete process.env.GITHUB_RUN_NUMBER;
   delete process.env.GITHUB_TOKEN;
   delete process.env.GITHUB_WORKFLOW;
@@ -118,6 +120,7 @@ afterEach(() => {
 
 it('should return immediately if the required environment variables are not set', async () => {
   delete process.env.CI;
+  delete process.env.GITHUB_ACTIONS;
 
   await createGitHubAnnotations(
     eslintOutput,


### PR DESCRIPTION
1. Source GIt metadata from Git repo.

   This reduces the number of Buildkite environment variables required to use `GitHub.createCheckRunFromBuildkite`, while adding the basic `BUILDKITE` variable for symmetry with `Buildkite.annotate`.

2. Move Buildkite specifics out of the GitHub development API and into the lint adapter.

   This provides a cleaner generic interface for our API. We also generalise the adapter code so we can support other CI platforms like GitHub Actions.