### PR TITLE
Sync ignore files on format and lint

### DIFF
--- a/.changeset/wet-carrots-argue.md
+++ b/.changeset/wet-carrots-argue.md
@@ -1,0 +1,7 @@
+---
+"skuba": minor
+---
+
+format, lint: Synchronise ignore files
+
+`skuba format` and `skuba lint` will now keep `.eslintignore`, `.gitignore` and `.prettierignore` in sync. This automatically applies new exclusions like `.eslintcache` without the need for a manual `skuba configure`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # managed by skuba
+.cdk.staging/
 .idea/
 .serverless/
 .vscode/
+cdk.out/
 node_modules*/
 
 /coverage*/

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,8 @@ node_modules*/
 /tmp*/
 
 # Gantry resource files support non-standard template syntax
+/.gantry/**/*.yaml
+/.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
 # end managed by skuba

--- a/src/cli/__snapshots__/format.int.test.ts.snap
+++ b/src/cli/__snapshots__/format.int.test.ts.snap
@@ -62,8 +62,14 @@ Prettier
 Initialising Prettier...
 Detected project root: <random>
 Discovering files...
-Discovered 6 files.
+Discovered 9 files.
 Formatting files...
+.eslintignore
+  parser: -
+.gitignore
+  parser: -
+.prettierignore
+  parser: -
 b.md
   parser: markdown
 c.json

--- a/src/cli/__snapshots__/lint.int.test.ts.snap
+++ b/src/cli/__snapshots__/lint.int.test.ts.snap
@@ -64,8 +64,14 @@ ESLint   │ ○ d.js
 Prettier │ Initialising Prettier...
 Prettier │ Detected project root: <random>
 Prettier │ Discovering files...
-Prettier │ Discovered 6 files.
+Prettier │ Discovered 9 files.
 Prettier │ Linting files...
+Prettier │ .eslintignore
+Prettier │   parser: -
+Prettier │ .gitignore
+Prettier │   parser: -
+Prettier │ .prettierignore
+Prettier │   parser: -
 Prettier │ b.md
 Prettier │   parser: markdown
 Prettier │ c.json

--- a/src/cli/configure/refreshIgnoreFiles.ts
+++ b/src/cli/configure/refreshIgnoreFiles.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import fs from 'fs-extra';
 
+import { log } from '../../utils/logging';
 import { readBaseTemplateFile } from '../../utils/template';
 
 import { getDestinationManifest } from './analysis/package';
@@ -35,4 +36,13 @@ export const refreshIgnoreFiles = async () => {
     refreshIgnoreFile('.gitignore'),
     refreshIgnoreFile('.prettierignore'),
   ]);
+};
+
+export const tryRefreshIgnoreFiles = async () => {
+  try {
+    await refreshIgnoreFiles();
+  } catch (err) {
+    log.warn('Failed to refresh ignore files.');
+    log.warn(err);
+  }
 };

--- a/src/cli/configure/refreshIgnoreFiles.ts
+++ b/src/cli/configure/refreshIgnoreFiles.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+
+import fs from 'fs-extra';
+
+import { readBaseTemplateFile } from '../../utils/template';
+
+import { getDestinationManifest } from './analysis/package';
+import { createDestinationFileReader } from './analysis/project';
+import { mergeWithIgnoreFile } from './processing/ignoreFile';
+
+export const refreshIgnoreFiles = async () => {
+  const manifest = await getDestinationManifest();
+
+  const destinationRoot = path.dirname(manifest.path);
+
+  const readDestinationFile = createDestinationFileReader(destinationRoot);
+
+  const refreshIgnoreFile = async (filename: string) => {
+    const [inputFile, templateFile] = await Promise.all([
+      readDestinationFile(filename),
+      readBaseTemplateFile(`_${filename}`),
+    ]);
+
+    const data = inputFile
+      ? mergeWithIgnoreFile(templateFile)(inputFile)
+      : templateFile;
+
+    const filepath = path.join(destinationRoot, filename);
+
+    await fs.promises.writeFile(filepath, data);
+  };
+
+  await Promise.all([
+    refreshIgnoreFile('.eslintignore'),
+    refreshIgnoreFile('.gitignore'),
+    refreshIgnoreFile('.prettierignore'),
+  ]);
+};

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -5,10 +5,10 @@ import { createLogger, log } from '../utils/logging';
 
 import { runESLint } from './adapter/eslint';
 import { runPrettier } from './adapter/prettier';
-import { refreshIgnoreFiles } from './configure/refreshIgnoreFiles';
+import { tryRefreshIgnoreFiles } from './configure/refreshIgnoreFiles';
 
 export const format = async (args = process.argv) => {
-  await refreshIgnoreFiles();
+  await tryRefreshIgnoreFiles();
 
   const debug = hasDebugFlag(args);
 

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -5,8 +5,11 @@ import { createLogger, log } from '../utils/logging';
 
 import { runESLint } from './adapter/eslint';
 import { runPrettier } from './adapter/prettier';
+import { refreshIgnoreFiles } from './configure/refreshIgnoreFiles';
 
 export const format = async (args = process.argv) => {
+  await refreshIgnoreFiles();
+
   const debug = hasDebugFlag(args);
 
   log.plain(chalk.magenta('ESLint'));

--- a/src/cli/lint/index.ts
+++ b/src/cli/lint/index.ts
@@ -1,4 +1,5 @@
 import { hasDebugFlag, hasSerialFlag } from '../../utils/args';
+import { refreshIgnoreFiles } from '../configure/refreshIgnoreFiles';
 
 import { externalLint } from './external';
 import { internalLint } from './internal';
@@ -9,6 +10,8 @@ export const lint = async (
   tscOutputStream: NodeJS.WritableStream | undefined = undefined,
   workerThreads = true,
 ) => {
+  await refreshIgnoreFiles();
+
   const opts: Input = {
     debug: hasDebugFlag(args),
     serial: hasSerialFlag(args),

--- a/src/cli/lint/index.ts
+++ b/src/cli/lint/index.ts
@@ -1,5 +1,5 @@
 import { hasDebugFlag, hasSerialFlag } from '../../utils/args';
-import { refreshIgnoreFiles } from '../configure/refreshIgnoreFiles';
+import { tryRefreshIgnoreFiles } from '../configure/refreshIgnoreFiles';
 
 import { externalLint } from './external';
 import { internalLint } from './internal';
@@ -10,7 +10,7 @@ export const lint = async (
   tscOutputStream: NodeJS.WritableStream | undefined = undefined,
   workerThreads = true,
 ) => {
-  await refreshIgnoreFiles();
+  await tryRefreshIgnoreFiles();
 
   const opts: Input = {
     debug: hasDebugFlag(args),


### PR DESCRIPTION
Closes #637.

This should be the minimum required to release #645 without users committing `.eslintcache`s to Git.