### PR TITLE
Add a `?` placeholder for unnamed function args

### DIFF
--- a/.changeset/lemon-apes-battle.md
+++ b/.changeset/lemon-apes-battle.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+start: Add a `?` placeholder for unnamed function arguments

--- a/src/wrapper/functionHandler.ts
+++ b/src/wrapper/functionHandler.ts
@@ -34,7 +34,13 @@ export const runFunctionHandler = async ({
     return;
   }
 
-  log.warn(log.bold(functionName), `(${fnArgs(fn).join(', ')})`);
+  log.warn(
+    log.bold(functionName),
+    `(${fnArgs(fn)
+      // Add a `?` placeholder for unnamed arguments.
+      .map((arg) => arg || '?')
+      .join(', ')})`,
+  );
 
   const requestListener = createRequestListenerFromFunction(fn);
 


### PR DESCRIPTION
These appeared like `fn(a, , , d)`, which was a bit weird.