### PR TITLE
Bump prominence of ESLint rule changes

### DIFF
--- a/.changeset/olive-ghosts-battle.md
+++ b/.changeset/olive-ghosts-battle.md
@@ -1,5 +1,12 @@
 ---
-"skuba": patch
+"skuba": minor
 ---
 
 deps: eslint-config-skuba 1.0.12
+
+This adds a couple new linting rules:
+
+- [jest/prefer-expect-resolves](https://github.com/jest-community/eslint-plugin-jest/blob/v25.2.2/docs/rules/prefer-expect-resolves.md)
+- [jest/prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/v25.2.2/docs/rules/prefer-to-be.md)
+
+Run `skuba format` to automatically align your code with these rules.


### PR DESCRIPTION
These will likely require a good number of consumers to re-format their code. This kind of thing will be smoother once we land #644, but that will still require consumers to enable Buildkite write access to their repos.