### PR TITLE
Enforce consistent type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   extends: ['skuba'],
   rules: {
     // internal to skuba itself
+    '@typescript-eslint/consistent-type-imports': 'error',
     'no-process-exit': 'off',
   },
 };

--- a/jest-preset.d.ts
+++ b/jest-preset.d.ts
@@ -1,4 +1,4 @@
-import { Config } from '@jest/types';
+import type { Config } from '@jest/types';
 
 declare const moduleExports: Config.InitialOptions;
 

--- a/src/api/github/checkRun.test.ts
+++ b/src/api/github/checkRun.test.ts
@@ -1,9 +1,10 @@
 import { Octokit } from '@octokit/rest';
-import { Endpoints } from '@octokit/types';
-import git, { ReadCommitResult } from 'isomorphic-git';
+import type { Endpoints } from '@octokit/types';
+import type { ReadCommitResult } from 'isomorphic-git';
+import git from 'isomorphic-git';
 import { mocked } from 'ts-jest/utils';
 
-import * as GitHub from '../github';
+import type * as GitHub from '../github';
 
 import { createCheckRun } from './checkRun';
 

--- a/src/api/github/checkRun.ts
+++ b/src/api/github/checkRun.ts
@@ -1,5 +1,5 @@
 import { Octokit } from '@octokit/rest';
-import { Endpoints } from '@octokit/types';
+import type { Endpoints } from '@octokit/types';
 import fs from 'fs-extra';
 import git from 'isomorphic-git';
 

--- a/src/api/jest/index.ts
+++ b/src/api/jest/index.ts
@@ -1,4 +1,4 @@
-import { Config } from '@jest/types';
+import type { Config } from '@jest/types';
 
 import jestPreset from '../../../jest-preset';
 import { mergeRaw } from '../../cli/configure/processing/record';

--- a/src/api/net/waitFor.ts
+++ b/src/api/net/waitFor.ts
@@ -1,5 +1,6 @@
 import { resolveComposeAddress } from './compose';
-import { SocketAddress, pollSocket } from './socket';
+import type { SocketAddress } from './socket';
+import { pollSocket } from './socket';
 
 /**
  * Wait for a resource to start listening on a socket address.

--- a/src/cli/adapter/eslint.ts
+++ b/src/cli/adapter/eslint.ts
@@ -1,9 +1,11 @@
 import path from 'path';
 
 import chalk from 'chalk';
-import { ESLint, Linter } from 'eslint';
+import type { Linter } from 'eslint';
+import { ESLint } from 'eslint';
 
-import { Logger, pluralise } from '../../utils/logging';
+import type { Logger } from '../../utils/logging';
+import { pluralise } from '../../utils/logging';
 
 const symbolForResult = (result: ESLint.LintResult) => {
   if (result.errorCount) {

--- a/src/cli/adapter/prettier.ts
+++ b/src/cli/adapter/prettier.ts
@@ -1,17 +1,12 @@
 import path from 'path';
 
 import fs from 'fs-extra';
-import {
-  Options,
-  SupportLanguage,
-  check,
-  format,
-  getSupportInfo,
-  resolveConfig,
-} from 'prettier';
+import type { Options, SupportLanguage } from 'prettier';
+import { check, format, getSupportInfo, resolveConfig } from 'prettier';
 
 import { crawlDirectory } from '../../utils/dir';
-import { Logger, pluralise } from '../../utils/logging';
+import type { Logger } from '../../utils/logging';
+import { pluralise } from '../../utils/logging';
 import { getConsumerManifest } from '../../utils/manifest';
 
 let languages: SupportLanguage[] | undefined;

--- a/src/cli/configure/analyseConfiguration.ts
+++ b/src/cli/configure/analyseConfiguration.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs-extra';
 
 import { log } from '../../utils/logging';
-import { ProjectType } from '../../utils/manifest';
+import type { ProjectType } from '../../utils/manifest';
 
 import { diffFiles } from './analysis/project';
 

--- a/src/cli/configure/analyseDependencies.ts
+++ b/src/cli/configure/analyseDependencies.ts
@@ -2,17 +2,18 @@ import path from 'path';
 
 import fs from 'fs-extra';
 import latestVersion from 'latest-version';
-import { NormalizedReadResult } from 'read-pkg-up';
+import type { NormalizedReadResult } from 'read-pkg-up';
 
-import { TextProcessor, copyFiles } from '../../utils/copy';
+import type { TextProcessor } from '../../utils/copy';
+import { copyFiles } from '../../utils/copy';
 import { log } from '../../utils/logging';
-import { ProjectType } from '../../utils/manifest';
+import type { ProjectType } from '../../utils/manifest';
 import { getSkubaVersion } from '../../utils/version';
 
 import { diffDependencies, generateNotices } from './analysis/package';
 import * as dependencyMutators from './dependencies';
 import { formatPackage } from './processing/package';
-import { DependencyDiff } from './types';
+import type { DependencyDiff } from './types';
 
 const logDiff = (diff: DependencyDiff): boolean => {
   const entries = Object.entries(diff);

--- a/src/cli/configure/analysis/package.ts
+++ b/src/cli/configure/analysis/package.ts
@@ -1,7 +1,7 @@
 import readPkgUp from 'read-pkg-up';
 
 import { log } from '../../../utils/logging';
-import { DependencyDiff, DependencySet } from '../types';
+import type { DependencyDiff, DependencySet } from '../types';
 
 import { determineOperation } from './diff';
 

--- a/src/cli/configure/analysis/project.ts
+++ b/src/cli/configure/analysis/project.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import { buildPatternToFilepathMap, crawlDirectory } from '../../../utils/dir';
 import { isErrorWithCode } from '../../../utils/error';
 import { loadModules } from '../modules';
-import { FileDiff, Files, Module, Options } from '../types';
+import type { FileDiff, Files, Module, Options } from '../types';
 
 import { determineOperation } from './diff';
 

--- a/src/cli/configure/dependencies/seekDatadogCustomMetrics.ts
+++ b/src/cli/configure/dependencies/seekDatadogCustomMetrics.ts
@@ -1,5 +1,5 @@
 import { replacePackageReferences } from '../processing/module';
-import { DependencySet } from '../types';
+import type { DependencySet } from '../types';
 
 const OLD_NAME = '@seek/node-datadog-custom-metrics';
 const NEW_NAME = 'seek-datadog-custom-metrics';

--- a/src/cli/configure/dependencies/seekKoala.ts
+++ b/src/cli/configure/dependencies/seekKoala.ts
@@ -1,5 +1,5 @@
 import { replacePackageReferences } from '../processing/module';
-import { DependencySet } from '../types';
+import type { DependencySet } from '../types';
 
 const OLD_NAME = '@seek/koala';
 const NEW_NAME = 'seek-koala';

--- a/src/cli/configure/dependencies/skuba.ts
+++ b/src/cli/configure/dependencies/skuba.ts
@@ -1,5 +1,5 @@
 import { replacePackageReferences } from '../processing/module';
-import { DependencySet } from '../types';
+import type { DependencySet } from '../types';
 
 const OLD_NAME = '@seek/skuba';
 const NEW_NAME = 'skuba';

--- a/src/cli/configure/dependencies/skubaDeps.ts
+++ b/src/cli/configure/dependencies/skubaDeps.ts
@@ -1,4 +1,4 @@
-import { DependencySet } from '../types';
+import type { DependencySet } from '../types';
 
 const DEV_DEPENDENCIES = [
   // replaced

--- a/src/cli/configure/dependencies/skubaDive.ts
+++ b/src/cli/configure/dependencies/skubaDive.ts
@@ -1,5 +1,5 @@
 import { replacePackageReferences } from '../processing/module';
-import { DependencySet } from '../types';
+import type { DependencySet } from '../types';
 
 const OLD_NAME = '@seek/skuba-dive';
 const NEW_NAME = 'skuba-dive';

--- a/src/cli/configure/ensureTemplateCompletion.ts
+++ b/src/cli/configure/ensureTemplateCompletion.ts
@@ -2,14 +2,12 @@ import path from 'path';
 
 import chalk from 'chalk';
 import fs from 'fs-extra';
-import { NormalizedReadResult } from 'read-pkg-up';
+import type { NormalizedReadResult } from 'read-pkg-up';
 
 import { copyFiles, createEjsRenderer } from '../../utils/copy';
 import { log } from '../../utils/logging';
-import {
-  TemplateConfig,
-  ensureTemplateConfigDeletion,
-} from '../../utils/template';
+import type { TemplateConfig } from '../../utils/template';
+import { ensureTemplateConfigDeletion } from '../../utils/template';
 import { hasStringProp } from '../../utils/validation';
 import { getTemplateConfig, runForm } from '../init/getConfig';
 

--- a/src/cli/configure/getEntryPoint.ts
+++ b/src/cli/configure/getEntryPoint.ts
@@ -2,11 +2,11 @@ import path from 'path';
 
 import chalk from 'chalk';
 import { Input } from 'enquirer';
-import { NormalizedReadResult } from 'read-pkg-up';
+import type { NormalizedReadResult } from 'read-pkg-up';
 
 import { log } from '../../utils/logging';
-import { ProjectType } from '../../utils/manifest';
-import { TemplateConfig } from '../../utils/template';
+import type { ProjectType } from '../../utils/manifest';
+import type { TemplateConfig } from '../../utils/template';
 import { hasStringProp } from '../../utils/validation';
 
 import { tsFileExists } from './analysis/files';

--- a/src/cli/configure/getProjectType.ts
+++ b/src/cli/configure/getProjectType.ts
@@ -1,9 +1,9 @@
 import { Select } from 'enquirer';
-import { NormalizedReadResult } from 'read-pkg-up';
+import type { NormalizedReadResult } from 'read-pkg-up';
 
 import { log } from '../../utils/logging';
 import { PROJECT_TYPES, ProjectType } from '../../utils/manifest';
-import { TemplateConfig } from '../../utils/template';
+import type { TemplateConfig } from '../../utils/template';
 import { hasProp } from '../../utils/validation';
 
 interface Props {

--- a/src/cli/configure/modules/eslint.ts
+++ b/src/cli/configure/modules/eslint.ts
@@ -3,7 +3,7 @@ import { deleteFiles } from '../processing/deleteFiles';
 import { mergeWithIgnoreFile } from '../processing/ignoreFile';
 import { withPackage } from '../processing/package';
 import { formatPrettier } from '../processing/prettier';
-import { Module } from '../types';
+import type { Module } from '../types';
 
 export const eslintModule = async (): Promise<Module> => {
   const [configFile, ignoreFile] = await Promise.all([

--- a/src/cli/configure/modules/ignore.ts
+++ b/src/cli/configure/modules/ignore.ts
@@ -1,6 +1,6 @@
 import { readBaseTemplateFile } from '../../../utils/template';
 import { mergeWithIgnoreFile } from '../processing/ignoreFile';
-import { Module } from '../types';
+import type { Module } from '../types';
 
 export const ignoreModule = async (): Promise<Module> => {
   const [dockerFile, gitFile] = await Promise.all([

--- a/src/cli/configure/modules/index.ts
+++ b/src/cli/configure/modules/index.ts
@@ -1,4 +1,4 @@
-import { Module, Options } from '../types';
+import type { Module, Options } from '../types';
 
 import { eslintModule } from './eslint';
 import { ignoreModule } from './ignore';

--- a/src/cli/configure/modules/jest.ts
+++ b/src/cli/configure/modules/jest.ts
@@ -8,7 +8,7 @@ import {
   readModuleExports,
   transformModuleImportsAndExports,
 } from '../processing/typescript';
-import { Module } from '../types';
+import type { Module } from '../types';
 
 // Jest options to preserve during migration
 const filterProps = createPropFilter([

--- a/src/cli/configure/modules/nodemon.ts
+++ b/src/cli/configure/modules/nodemon.ts
@@ -1,4 +1,4 @@
 import { deleteFiles } from '../processing/deleteFiles';
-import { Module } from '../types';
+import type { Module } from '../types';
 
 export const nodemonModule = (): Module => deleteFiles('nodemon.json');

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -2,7 +2,7 @@ import { getSkubaVersion } from '../../../utils/version';
 import { deleteFiles } from '../processing/deleteFiles';
 import { withPackage } from '../processing/package';
 import { merge } from '../processing/record';
-import { Module, Options } from '../types';
+import type { Module, Options } from '../types';
 
 const DEFAULT_PACKAGE_FILES = [
   'lib*/**/*.d.ts',

--- a/src/cli/configure/modules/prettier.ts
+++ b/src/cli/configure/modules/prettier.ts
@@ -2,7 +2,7 @@ import { readBaseTemplateFile } from '../../../utils/template';
 import { deleteFiles } from '../processing/deleteFiles';
 import { mergeWithIgnoreFile } from '../processing/ignoreFile';
 import { withPackage } from '../processing/package';
-import { Module } from '../types';
+import type { Module } from '../types';
 
 export const prettierModule = async (): Promise<Module> => {
   const [configFile, ignoreFile] = await Promise.all([

--- a/src/cli/configure/modules/renovate.ts
+++ b/src/cli/configure/modules/renovate.ts
@@ -3,7 +3,7 @@ import { deleteFiles } from '../processing/deleteFiles';
 import { withPackage } from '../processing/package';
 import { formatPrettier } from '../processing/prettier';
 import { getFirstDefined } from '../processing/record';
-import { Module, Options } from '../types';
+import type { Module, Options } from '../types';
 
 const OTHER_CONFIG_FILENAMES = [
   '.github/renovate.json',

--- a/src/cli/configure/modules/serverless.ts
+++ b/src/cli/configure/modules/serverless.ts
@@ -1,4 +1,4 @@
-import { Module, Options } from '../types';
+import type { Module, Options } from '../types';
 
 export const serverlessModule = ({}: Options): Module => ({
   '**/serverless*.yml': (inputFile, _files, _initialFiles) => {

--- a/src/cli/configure/modules/skubaDive.ts
+++ b/src/cli/configure/modules/skubaDive.ts
@@ -4,7 +4,7 @@ import { SKUBA_DIVE_HOOKS } from '../dependencies/skubaDive';
 import { prependImport, stripImports } from '../processing/javascript';
 import { loadFiles } from '../processing/loadFiles';
 import { parsePackage } from '../processing/package';
-import { Module, Options } from '../types';
+import type { Module, Options } from '../types';
 
 const DEFAULT_FILENAME = 'src/register.ts';
 

--- a/src/cli/configure/modules/tsconfig.test.ts
+++ b/src/cli/configure/modules/tsconfig.test.ts
@@ -5,7 +5,7 @@ import {
   defaultPackageOpts,
   executeModule,
 } from '../testing/module';
-import { TsConfigJson } from '../types';
+import type { TsConfigJson } from '../types';
 
 import { tsconfigModule } from './tsconfig';
 

--- a/src/cli/configure/modules/tsconfig.ts
+++ b/src/cli/configure/modules/tsconfig.ts
@@ -3,7 +3,7 @@ import { hasProp, hasStringProp, isObject } from '../../../utils/validation';
 import { formatObject, parseObject } from '../processing/json';
 import { loadFiles } from '../processing/loadFiles';
 import { merge } from '../processing/record';
-import { Module, Options } from '../types';
+import type { Module, Options } from '../types';
 
 export const tsconfigModule = async ({
   firstRun,

--- a/src/cli/configure/modules/tslint.ts
+++ b/src/cli/configure/modules/tslint.ts
@@ -1,5 +1,5 @@
 import { deleteFiles } from '../processing/deleteFiles';
-import { Module } from '../types';
+import type { Module } from '../types';
 
 export const tslintModule = (): Module =>
   deleteFiles('tslint.json', 'tslint.yaml');

--- a/src/cli/configure/processing/deleteFiles.ts
+++ b/src/cli/configure/processing/deleteFiles.ts
@@ -1,4 +1,4 @@
-import { Module } from '../types';
+import type { Module } from '../types';
 
 /**
  * Load files into cache and schedule them for deletion.

--- a/src/cli/configure/processing/loadFiles.ts
+++ b/src/cli/configure/processing/loadFiles.ts
@@ -1,4 +1,4 @@
-import { Module } from '../types';
+import type { Module } from '../types';
 
 /**
  * Load files into cache to perform side effects in another module.

--- a/src/cli/configure/processing/package.ts
+++ b/src/cli/configure/processing/package.ts
@@ -1,7 +1,7 @@
 import normalizeData from 'normalize-package-data';
 
 import { isObject } from '../../../utils/validation';
-import { PackageJson } from '../types';
+import type { PackageJson } from '../types';
 
 import { formatObject, parseObject } from './json';
 

--- a/src/cli/configure/testing/module.ts
+++ b/src/cli/configure/testing/module.ts
@@ -1,6 +1,6 @@
 import picomatch from 'picomatch';
 
-import { Files, Module, Options } from '../types';
+import type { Files, Module, Options } from '../types';
 
 export function assertDefined<T>(value?: T): asserts value is T {
   expect(value).toBeDefined();

--- a/src/cli/configure/types.ts
+++ b/src/cli/configure/types.ts
@@ -1,6 +1,6 @@
 import type { PackageJson as TypeFestPackageJson } from 'type-fest';
 
-import { ProjectType } from '../../utils/manifest';
+import type { ProjectType } from '../../utils/manifest';
 
 export type { TsConfigJson } from 'type-fest';
 

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 
 import chalk from 'chalk';
-import { Form, FormChoice } from 'enquirer';
+import type { FormChoice } from 'enquirer';
+import { Form } from 'enquirer';
 import fs from 'fs-extra';
 
 import { copyFiles } from '../../utils/copy';
@@ -15,14 +16,15 @@ import {
 } from '../../utils/template';
 
 import { downloadGitHubTemplate } from './git';
+import type { BaseFields } from './prompts';
 import {
   BASE_PROMPT_PROPS,
-  BaseFields,
   GIT_PATH_PROMPT,
   SHOULD_CONTINUE_PROMPT,
   TEMPLATE_PROMPT,
 } from './prompts';
-import { InitConfig, InitConfigInput } from './types';
+import type { InitConfig } from './types';
+import { InitConfigInput } from './types';
 
 export const runForm = <T = Record<string, string>>(props: {
   choices: Readonly<FormChoice[]>;

--- a/src/cli/init/writePackageJson.ts
+++ b/src/cli/init/writePackageJson.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 
-import { ProjectType } from '../../utils/manifest';
+import type { ProjectType } from '../../utils/manifest';
 import { getDestinationManifest } from '../configure/analysis/package';
 import { formatPackage } from '../configure/processing/package';
 

--- a/src/cli/lint/annotate/buildkite/eslint.ts
+++ b/src/cli/lint/annotate/buildkite/eslint.ts
@@ -1,5 +1,5 @@
 import * as Buildkite from '../../../../api/buildkite';
-import { ESLintOutput } from '../../../../cli/adapter/eslint';
+import type { ESLintOutput } from '../../../../cli/adapter/eslint';
 
 export const createEslintAnnotations = (eslint: ESLintOutput): string[] =>
   !eslint.ok ? ['**ESLint**', Buildkite.md.terminal(eslint.output.trim())] : [];

--- a/src/cli/lint/annotate/buildkite/index.ts
+++ b/src/cli/lint/annotate/buildkite/index.ts
@@ -1,7 +1,7 @@
 import * as Buildkite from '../../../../api/buildkite';
-import { ESLintOutput } from '../../../../cli/adapter/eslint';
-import { PrettierOutput } from '../../../../cli/adapter/prettier';
-import { StreamInterceptor } from '../../../../cli/lint/external';
+import type { ESLintOutput } from '../../../../cli/adapter/eslint';
+import type { PrettierOutput } from '../../../../cli/adapter/prettier';
+import type { StreamInterceptor } from '../../../../cli/lint/external';
 
 import { createEslintAnnotations } from './eslint';
 import { createPrettierAnnotations } from './prettier';

--- a/src/cli/lint/annotate/buildkite/prettier.ts
+++ b/src/cli/lint/annotate/buildkite/prettier.ts
@@ -1,5 +1,5 @@
 import * as Buildkite from '../../../../api/buildkite';
-import { PrettierOutput } from '../../../../cli/adapter/prettier';
+import type { PrettierOutput } from '../../../../cli/adapter/prettier';
 
 export const createPrettierAnnotations = (prettier: PrettierOutput): string[] =>
   !prettier.ok

--- a/src/cli/lint/annotate/buildkite/tsc.ts
+++ b/src/cli/lint/annotate/buildkite/tsc.ts
@@ -1,5 +1,5 @@
 import * as Buildkite from '../../../../api/buildkite';
-import { StreamInterceptor } from '../../../../cli/lint/external';
+import type { StreamInterceptor } from '../../../../cli/lint/external';
 
 export const createTscAnnotations = (
   tscOk: boolean,

--- a/src/cli/lint/annotate/github/eslint.test.ts
+++ b/src/cli/lint/annotate/github/eslint.test.ts
@@ -1,5 +1,5 @@
-import * as GitHub from '../../../../api/github';
-import { ESLintOutput } from '../../../../cli/adapter/eslint';
+import type * as GitHub from '../../../../api/github';
+import type { ESLintOutput } from '../../../../cli/adapter/eslint';
 
 import { createEslintAnnotations } from './eslint';
 

--- a/src/cli/lint/annotate/github/eslint.ts
+++ b/src/cli/lint/annotate/github/eslint.ts
@@ -1,5 +1,5 @@
-import * as GitHub from '../../../../api/github';
-import { ESLintOutput } from '../../../../cli/adapter/eslint';
+import type * as GitHub from '../../../../api/github';
+import type { ESLintOutput } from '../../../../cli/adapter/eslint';
 
 export const createEslintAnnotations = (
   eslint: ESLintOutput,

--- a/src/cli/lint/annotate/github/index.test.ts
+++ b/src/cli/lint/annotate/github/index.test.ts
@@ -1,9 +1,9 @@
 import { mocked } from 'ts-jest/utils';
 
 import * as GitHub from '../../../../api/github';
-import { ESLintOutput } from '../../../../cli/adapter/eslint';
-import { PrettierOutput } from '../../../../cli/adapter/prettier';
-import { StreamInterceptor } from '../../../../cli/lint/external';
+import type { ESLintOutput } from '../../../../cli/adapter/eslint';
+import type { PrettierOutput } from '../../../../cli/adapter/prettier';
+import type { StreamInterceptor } from '../../../../cli/lint/external';
 
 import { createEslintAnnotations } from './eslint';
 import { createPrettierAnnotations } from './prettier';

--- a/src/cli/lint/annotate/github/index.ts
+++ b/src/cli/lint/annotate/github/index.ts
@@ -3,9 +3,9 @@ import {
   buildNameFromEnvironment,
   enabledFromEnvironment,
 } from '../../../../api/github/environment';
-import { ESLintOutput } from '../../../../cli/adapter/eslint';
-import { PrettierOutput } from '../../../../cli/adapter/prettier';
-import { StreamInterceptor } from '../../../../cli/lint/external';
+import type { ESLintOutput } from '../../../../cli/adapter/eslint';
+import type { PrettierOutput } from '../../../../cli/adapter/prettier';
+import type { StreamInterceptor } from '../../../../cli/lint/external';
 
 import { createEslintAnnotations } from './eslint';
 import { createPrettierAnnotations } from './prettier';

--- a/src/cli/lint/annotate/github/prettier.test.ts
+++ b/src/cli/lint/annotate/github/prettier.test.ts
@@ -1,5 +1,5 @@
-import * as GitHub from '../../../../api/github';
-import { PrettierOutput } from '../../../../cli/adapter/prettier';
+import type * as GitHub from '../../../../api/github';
+import type { PrettierOutput } from '../../../../cli/adapter/prettier';
 
 import { createPrettierAnnotations } from './prettier';
 

--- a/src/cli/lint/annotate/github/prettier.ts
+++ b/src/cli/lint/annotate/github/prettier.ts
@@ -1,5 +1,5 @@
-import * as GitHub from '../../../../api/github';
-import { PrettierOutput } from '../../../../cli/adapter/prettier';
+import type * as GitHub from '../../../../api/github';
+import type { PrettierOutput } from '../../../../cli/adapter/prettier';
 
 export const createPrettierAnnotations = (
   prettier: PrettierOutput,

--- a/src/cli/lint/annotate/github/tsc.test.ts
+++ b/src/cli/lint/annotate/github/tsc.test.ts
@@ -1,5 +1,5 @@
-import * as GitHub from '../../../../api/github';
-import { StreamInterceptor } from '../../../../cli/lint/external';
+import type * as GitHub from '../../../../api/github';
+import type { StreamInterceptor } from '../../../../cli/lint/external';
 
 import { createTscAnnotations } from './tsc';
 

--- a/src/cli/lint/annotate/github/tsc.ts
+++ b/src/cli/lint/annotate/github/tsc.ts
@@ -1,7 +1,7 @@
 import stripAnsi from 'strip-ansi';
 
-import * as GitHub from '../../../../api/github';
-import { StreamInterceptor } from '../../../../cli/lint/external';
+import type * as GitHub from '../../../../api/github';
+import type { StreamInterceptor } from '../../../../cli/lint/external';
 
 type TscLevel = 'error' | 'warning' | 'info';
 

--- a/src/cli/lint/annotate/index.ts
+++ b/src/cli/lint/annotate/index.ts
@@ -1,7 +1,7 @@
-import { ESLintOutput } from 'cli/adapter/eslint';
-import { PrettierOutput } from 'cli/adapter/prettier';
+import type { ESLintOutput } from 'cli/adapter/eslint';
+import type { PrettierOutput } from 'cli/adapter/prettier';
 
-import { StreamInterceptor } from '../external';
+import type { StreamInterceptor } from '../external';
 
 import { createBuildkiteAnnotations } from './buildkite';
 import { createGitHubAnnotations } from './github';

--- a/src/cli/lint/eslint.ts
+++ b/src/cli/lint/eslint.ts
@@ -5,7 +5,8 @@ import chalk from 'chalk';
 
 import { createLogger } from '../../utils/logging';
 import { execWorkerThread, postWorkerOutput } from '../../utils/worker';
-import { ESLintOutput, runESLint } from '../adapter/eslint';
+import type { ESLintOutput } from '../adapter/eslint';
+import { runESLint } from '../adapter/eslint';
 
 import type { Input } from './types';
 

--- a/src/cli/lint/prettier.ts
+++ b/src/cli/lint/prettier.ts
@@ -5,7 +5,8 @@ import chalk from 'chalk';
 
 import { createLogger } from '../../utils/logging';
 import { execWorkerThread, postWorkerOutput } from '../../utils/worker';
-import { PrettierOutput, runPrettier } from '../adapter/prettier';
+import type { PrettierOutput } from '../adapter/prettier';
+import { runPrettier } from '../adapter/prettier';
 
 import type { Input } from './types';
 

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,6 +1,6 @@
 /* eslint-disable new-cap */
 
-import { ExecaError } from 'execa';
+import type { ExecaError } from 'execa';
 import * as t from 'runtypes';
 
 import { log } from './logging';

--- a/src/utils/exec.ts
+++ b/src/utils/exec.ts
@@ -4,7 +4,8 @@ import util from 'util';
 
 import type { Color } from 'chalk';
 import concurrently from 'concurrently';
-import execa, { ExecaChildProcess } from 'execa';
+import type { ExecaChildProcess } from 'execa';
+import execa from 'execa';
 import npmRunPath from 'npm-run-path';
 import npmWhich from 'npm-which';
 

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -1,6 +1,7 @@
 /* eslint-disable new-cap */
 
-import readPkgUp, { NormalizedPackageJson } from 'read-pkg-up';
+import type { NormalizedPackageJson } from 'read-pkg-up';
+import readPkgUp from 'read-pkg-up';
 import * as t from 'runtypes';
 
 import { hasStringProp } from './validation';

--- a/src/wrapper/http.ts
+++ b/src/wrapper/http.ts
@@ -1,5 +1,5 @@
 import http from 'http';
-import { AddressInfo } from 'net';
+import type { AddressInfo } from 'net';
 
 import { serializeError } from 'serialize-error';
 

--- a/src/wrapper/requestListener.ts
+++ b/src/wrapper/requestListener.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import type http from 'http';
 
 import { isFunction, isIpPort, isObject } from '../utils/validation';
 


### PR DESCRIPTION
Fun times. This is auto-fixable and is internal to skuba for now.

https://github.com/typescript-eslint/typescript-eslint/blob/v5.4.0/packages/eslint-plugin/docs/rules/consistent-type-imports.md