### PR TITLE
Clean up few testing things

### DIFF
--- a/jest.config.int.ts
+++ b/jest.config.int.ts
@@ -1,7 +1,7 @@
 import { Jest } from './src';
 
 export default Jest.mergePreset({
-  displayName: 'integration',
+  coveragePathIgnorePatterns: ['<rootDir>/integration/', '<rootDir>/template/'],
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['<rootDir>/template/', '/test\\.ts'],
   watchPathIgnorePatterns: [

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,8 @@
 import { Jest } from './src';
 
 export default Jest.mergePreset({
+  coveragePathIgnorePatterns: ['<rootDir>/integration/', '<rootDir>/template/'],
+  displayName: 'unit',
   setupFiles: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: [
     '<rootDir>/template/',

--- a/src/wrapper/main.test.ts
+++ b/src/wrapper/main.test.ts
@@ -5,6 +5,8 @@ import request from 'supertest';
 import * as http from './http';
 import { main } from './main';
 
+jest.mock('../utils/logging');
+
 const initWrapper = (entryPoint: string) =>
   main(path.join('src', 'wrapper', 'testing', entryPoint), '8080');
 


### PR DESCRIPTION
- Mock out console logging in a test module
- Set `coveragePathIgnorePatterns` in our configs
- Invert `displayName`; our `jest.config.int.ts` actually runs all tests, which is preferable over multiple independent configs for collecting coverage