### PR TITLE
Fix local Changesets formatting weirdness

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "scripts": {
     "build": "ts-node --transpile-only src/skuba build && scripts/postbuild.sh",
+    "changeset": "changeset && prettier --loglevel silent --write '.changeset/*.md'",
     "deploy": "scripts/deploy.sh",
     "format": "yarn skuba format",
     "lint": "yarn skuba lint",


### PR DESCRIPTION
We specify a custom Prettier config for our `.changeset` directory which accepts the double-quoted Markdown files that the GitHub Changesets bot generates. Unfortunately the Changesets CLI seems to ignore this file and only uses the root config, so it often generates non-compliant single-quoted files.

To fix this, we just have Prettier clean up after Changesets.