### PR TITLE
Register `tsconfig-paths` for development

### DIFF
--- a/.changeset/funny-snails-share.md
+++ b/.changeset/funny-snails-share.md
@@ -1,0 +1,19 @@
+---
+"skuba": minor
+---
+
+node, start: Register `tsconfig-paths`
+
+You can now define module aliases other than `src` for local development and scripting. Specify these through the `paths` compiler option in your `tsconfig.json`:
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src": ["src"]
+    }
+  }
+}
+```

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -23,7 +23,6 @@ Runs a TypeScript source file:
 ```shell
 skuba node src/some-cli-script.ts
 
-# src → /my-repo/src
 # ...
 ```
 
@@ -32,13 +31,12 @@ or launches a [`ts-node`] REPL if a file is not provided:
 ```shell
 skuba node src/some-cli-script.ts
 
-# src → /my-repo/src
 >
 ```
 
-`skuba node` automatically registers a `src` module alias for ease of local development.
-If you use this alias in your production code,
-your entry point(s) will need to import a runtime module alias resolver like [`skuba-dive/register`].
+`skuba node` automatically registers your `tsconfig.json` paths as module aliases for ease of local development.
+If you use these aliases in your production code,
+your entry point(s) will need to import a runtime module alias resolver like [`skuba-dive/register`] or [`tsconfig-paths`].
 For example, your `src/app.ts` may look like:
 
 ```typescript
@@ -65,9 +63,9 @@ The entry point is chosen from:
 1. Manifest configuration: `package.json#/skuba/entryPoint`
 1. Default: `src/app.ts`
 
-`skuba start` automatically registers a `src` module alias for ease of local development.
-If you use this alias in your production code,
-your entry point(s) will need to import a runtime module alias resolver like [`skuba-dive/register`].
+`skuba start` automatically registers your `tsconfig.json` paths as module aliases for ease of local development.
+If you use these aliases in your production code,
+your entry point(s) will need to import a runtime module alias resolver like [`skuba-dive/register`] or [`tsconfig-paths`].
 For example, your `src/app.ts` may look like:
 
 ```typescript
@@ -189,6 +187,7 @@ Execution should pause on the breakpoint until we hit `F5` or the `▶️` butto
 [`skuba-dive/register`]: https://github.com/seek-oss/skuba-dive#register
 [`ts-node-dev`]: https://github.com/whitecolor/ts-node-dev
 [`ts-node`]: https://github.com/typestrong/ts-node
+[`tsconfig-paths`]: https://github.com/dividab/tsconfig-paths
 [express]: https://expressjs.com/
 [koa]: https://koajs.com/
 [node.js options]: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "jest": "^27.1.0",
     "latest-version": "^5.1.0",
     "lodash.mergewith": "^4.6.2",
-    "module-alias": "^2.2.2",
     "normalize-package-data": "^3.0.0",
     "npm-run-path": "^4.0.1",
     "npm-which": "^3.0.1",
@@ -97,6 +96,7 @@
     "ts-node": "^9.1.1",
     "ts-node-dev": "^1.1.8",
     "tsconfig-seek": "1.0.2",
+    "tsconfig-paths": "^3.11.0",
     "typescript": "~4.4.4"
   },
   "peerDependencies": {

--- a/src/register.ts
+++ b/src/register.ts
@@ -13,37 +13,11 @@
  * Production code should be compiled down to JavaScript and run with Node.js.
  *
  * For equivalent module alias and source map support in production,
- * import the `skuba-dive/register` hook.
+ * import the `skuba-dive/register` and/or `tsconfig-paths/register` hook.
  *
  * {@link https://github.com/seek-oss/skuba-dive#register}
  */
 
 import 'source-map-support/register';
 
-import path from 'path';
-
-import { addAlias } from 'module-alias';
-import readPkgUp from 'read-pkg-up';
-
-import { log } from './utils/logging';
-
-const registerModuleAliases = () => {
-  // This may pick the wrong `package.json` if we are in a nested directory.
-  // Consider revisiting this when we decide how to better support monorepos.
-  const result = readPkgUp.sync();
-
-  if (result === undefined) {
-    log.warn(log.bold('src'), '→', 'not found');
-
-    return;
-  }
-
-  const root = path.dirname(result.path);
-  const src = path.join(root, 'src');
-
-  log.subtle(log.bold('src'), '→', src);
-
-  addAlias('src', src);
-};
-
-registerModuleAliases();
+import 'tsconfig-paths/register';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5826,11 +5826,6 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-module-alias@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/module-alias/-/module-alias-2.2.2.tgz#151cdcecc24e25739ff0aa6e51e1c5716974c0e0"
-  integrity sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Note that this does not modify our typical `skuba-dive/register` runtime hook. The drift between the two may be a bit puzzling in the time being, but it's somewhat rare for production applications to include `tsconfig.json` in their final bundle or container. Alignment should eventually come as we investigate shifting over to `esbuild`, which supports compile-time `tsconfig-paths` resolution.