### PR TITLE
Fix lambda-sqs-worker-cdk template

### DIFF
--- a/.changeset/stupid-pets-explain.md
+++ b/.changeset/stupid-pets-explain.md
@@ -2,4 +2,4 @@
 "skuba": patch
 ---
 
-**template/lambda-sqs-worker-cdk:** Fix docker-compose volume mount and deploy output
+template/lambda-sqs-worker-cdk: Fix docker-compose volume mount and deploy output

--- a/.changeset/stupid-pets-explain.md
+++ b/.changeset/stupid-pets-explain.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+**template/lambda-sqs-worker-cdk:** Fix docker-compose volume mount and deploy output

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -56,13 +56,12 @@ steps:
     label: 🧪 Test, Lint & Build
     artifact_paths: lib/**/*
     commands:
-      - yarn package
-      - echo '--- yarn build'
-      - yarn build
       - echo '+++ yarn test:ci'
       - yarn test
       - echo '--- yarn lint'
       - yarn lint
+      - echo '--- yarn build'
+      - yarn build
     env:
       GET_GITHUB_TOKEN: please
     plugins:

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -56,12 +56,13 @@ steps:
     label: 🧪 Test, Lint & Build
     artifact_paths: lib/**/*
     commands:
+      - yarn package
+      - echo '--- yarn build'
+      - yarn build
       - echo '+++ yarn test:ci'
       - yarn test
       - echo '--- yarn lint'
       - yarn lint
-      - echo '--- yarn build'
-      - yarn build
     env:
       GET_GITHUB_TOKEN: please
     plugins:

--- a/template/lambda-sqs-worker-cdk/docker-compose.yml
+++ b/template/lambda-sqs-worker-cdk/docker-compose.yml
@@ -23,3 +23,4 @@ services:
       - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
       # Mount cached dependencies.
       - /workdir/node_modules
+      - /workdir/lib/node_modules

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -25,7 +25,7 @@
     "deploy": "cdk deploy appStack --require-approval never --context stage=${ENVIRONMENT} --progress events",
     "format": "skuba format",
     "lint": "skuba lint",
-    "package": "yarn install --ignore-optional --ignore-scripts --modules-folder ./lib/node_modules --non-interactive --production",
+    "package": "yarn install --ignore-optional --ignore-scripts --modules-folder ./lib/node_modules --non-interactive --offline --production",
     "test": "skuba test",
     "test:ci": "skuba test --coverage",
     "test:watch": "skuba test --watch"

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -25,7 +25,7 @@
     "deploy": "cdk deploy appStack --require-approval never --context stage=${ENVIRONMENT} --progress events",
     "format": "skuba format",
     "lint": "skuba lint",
-    "package": "yarn install --ignore-optional --ignore-scripts --modules-folder ./lib/node_modules --non-interactive --offline --production",
+    "package": "yarn install --ignore-optional --ignore-scripts --modules-folder ./lib/node_modules --non-interactive --production",
     "test": "skuba test",
     "test:ci": "skuba test --coverage",
     "test:watch": "skuba test --watch"

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -22,7 +22,7 @@
   "private": true,
   "scripts": {
     "build": "skuba build",
-    "deploy": "cdk deploy appStack --require-approval never --context stage=${ENVIRONMENT}",
+    "deploy": "cdk deploy appStack --require-approval never --context stage=${ENVIRONMENT} --progress events",
     "format": "skuba format",
     "lint": "skuba lint",
     "package": "yarn install --ignore-optional --ignore-scripts --modules-folder ./lib/node_modules --non-interactive --offline --production",


### PR DESCRIPTION
Did these things in https://github.com/SEEK-Jobs/asia-jobs-data-migrator in order to get it working:

1. Fixed the yarn test step in buildkite (it passes locally)
2. Fixed errors where node_modules weren't being included in the lambda


3. fixed the weird logs in cicd on deploying for cdk
![image](https://user-images.githubusercontent.com/15165571/143377563-6393d243-e829-46d9-a028-424ef0a68e5c.png)
