### PR TITLE
Add OpenTelemetry support for Koa template

### DIFF
--- a/.changeset/brown-bananas-repair.md
+++ b/.changeset/brown-bananas-repair.md
@@ -2,4 +2,4 @@
 "skuba": minor
 ---
 
-template/koa-rest-api: Add opentelemetry support
+template/koa-rest-api: Add opt-in OpenTelemetry support

--- a/.changeset/brown-bananas-repair.md
+++ b/.changeset/brown-bananas-repair.md
@@ -1,0 +1,5 @@
+---
+"skuba": minor
+---
+
+template/koa-rest-api: Add opentelemetry support

--- a/template/koa-rest-api/.gantry/dev.yml
+++ b/template/koa-rest-api/.gantry/dev.yml
@@ -5,3 +5,6 @@ isProduction: false
 
 maxInstanceCount: 1
 minInstanceCount: 1
+
+openTelemetry:
+  enabled: false

--- a/template/koa-rest-api/.gantry/prod.yml
+++ b/template/koa-rest-api/.gantry/prod.yml
@@ -5,3 +5,6 @@ isProduction: true
 
 maxInstanceCount: 10
 minInstanceCount: 3
+
+openTelemetry:
+  enabled: false

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -31,4 +31,4 @@ ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD ["--require", "./lib/tracing.js", "lib/listen.js"]
+CMD ["--require", "./lib/tracing.js", "./lib/listen.js"]

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -31,4 +31,4 @@ ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}
 
-CMD ["lib/listen.js"]
+CMD ["--require", "./lib/tracing.js", "lib/listen.js"]

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -12,6 +12,7 @@ env:
 
   ENVIRONMENT: '{{.Environment}}'
   SERVICE: '{{values "service"}}'
+  OPENTELEMETRY_ENABLED: '{{.Values.openTelemetry.enabled | default false}}'
 
   {{range $key, $value := .Values.env}}
   {{$key}}: {{$value}}
@@ -21,6 +22,13 @@ env:
 datadogSecretId: '{{values "datadogSecretId"}}'
 {{end}}
 
+openTelemetry:
+  enabled: {{.Values.openTelemetry.enabled | default false}}
+  {{if .Values.isProduction}}
+  datadogEnvironmentName: production
+  {{else}}
+  datadogEnvironmentName: development
+  {{end}}
 {{if .Values.pagerDutyEndpoint}}
 pagerDutyEndpoint: '{{values "pagerDutyEndpoint"}}'
 {{end}}

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -11,8 +11,8 @@ env:
   AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
 
   ENVIRONMENT: '{{.Environment}}'
-  SERVICE: '{{values "service"}}'
   OPENTELEMETRY_ENABLED: '{{.Values.openTelemetry.enabled | default false}}'
+  SERVICE: '{{values "service"}}'
 
   {{range $key, $value := .Values.env}}
   {{$key}}: {{$value}}

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -1,8 +1,13 @@
 {
   "dependencies": {
     "@koa/router": "^10.1.1",
+    "@opentelemetry/api": "^1.0.3",
+    "@opentelemetry/exporter-collector-grpc": "^0.25.0",
+    "@opentelemetry/instrumentation-aws-sdk": "^0.1.0",
+    "@opentelemetry/instrumentation-http": "^0.26.0",
+    "@opentelemetry/sdk-node": "^0.26.0",
     "@seek/logger": "^5.0.1",
-    "skuba-dive": "^1.2.0",
+    "aws-sdk": "^2.1039.0",
     "hot-shots": "^9.0.0",
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",
@@ -11,6 +16,7 @@
     "runtypes-filter": "^0.6.0",
     "seek-datadog-custom-metrics": "^4.0.0",
     "seek-koala": "^5.1.0",
+    "skuba-dive": "^1.2.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/template/koa-rest-api/src/listen.ts
+++ b/template/koa-rest-api/src/listen.ts
@@ -1,5 +1,3 @@
-import './register';
-
 import app from './app';
 import { config } from './config';
 import { rootLogger } from './framework/logging';

--- a/template/koa-rest-api/src/tracing.ts
+++ b/template/koa-rest-api/src/tracing.ts
@@ -38,7 +38,7 @@ const main = () => {
 
   sdk
     .start()
-    .then(() => log('info', 'Opentelemetry initialised'))
+    .then(() => log('info', 'OpenTelemetry initialised'))
     .catch((err: Error) =>
       log('error', 'Opentelemetry not initialised', { err }),
     );

--- a/template/koa-rest-api/src/tracing.ts
+++ b/template/koa-rest-api/src/tracing.ts
@@ -19,8 +19,8 @@ const log = (level: string, msg: string, extra = {}) => {
 };
 
 const main = () => {
-  // Use B3 propagation to ensure proper propagation between systems use OpenTelemetry and
-  // native Datadog APM, such as Istio/Envoy
+  // Use B3 propagation to ensure proper propagation between systems that use
+  // OpenTelemetry and native Datadog APM, such as Istio/Envoy.
   propagation.setGlobalPropagator(
     new CompositePropagator({
       propagators: [

--- a/template/koa-rest-api/src/tracing.ts
+++ b/template/koa-rest-api/src/tracing.ts
@@ -1,5 +1,5 @@
 /**
- * Opentelemetry tracing initialisation. This is a standalone ts/js module that is not
+ * OpenTelemetry tracing initialisation. This is a standalone TS/JS module that is not
  * referenced by application source code directly. It is required at runtime using the
  * node command's `--require` argument, see Dockerfile for details.
  */

--- a/template/koa-rest-api/src/tracing.ts
+++ b/template/koa-rest-api/src/tracing.ts
@@ -1,0 +1,61 @@
+/**
+ * Opentelemetry tracing initialisation. This is a standalone ts/js module that is not
+ * referenced by application source code directly. It is required at runtime using the
+ * node command's `--require` argument, see Dockerfile for details.
+ */
+
+import { propagation } from '@opentelemetry/api';
+import { CompositePropagator } from '@opentelemetry/core';
+import { CollectorTraceExporter } from '@opentelemetry/exporter-collector-grpc';
+import { AwsInstrumentation } from '@opentelemetry/instrumentation-aws-sdk';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+
+const app = 'opentelemetry';
+const log = (level: string, msg: string, extra = {}) => {
+  const toLog = { msg, level, app, time: new Date().toISOString(), ...extra };
+  console.log(JSON.stringify(toLog)); // eslint-disable-line no-console
+};
+
+const main = () => {
+  // Use B3 propagation to ensure proper propagation between systems use OpenTelemetry and
+  // native Datadog APM, such as Istio/Envoy
+  propagation.setGlobalPropagator(
+    new CompositePropagator({
+      propagators: [
+        new B3Propagator(),
+        new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
+      ],
+    }),
+  );
+
+  const sdk = new NodeSDK({
+    traceExporter: new CollectorTraceExporter(),
+    autoDetectResources: false,
+    instrumentations: [new HttpInstrumentation(), new AwsInstrumentation()],
+  });
+
+  sdk
+    .start()
+    .then(() => log('info', 'Opentelemetry initialised'))
+    .catch((err: Error) =>
+      log('error', 'Opentelemetry not initialised', { err }),
+    );
+
+  process.on('SIGTERM', () => {
+    sdk
+      .shutdown()
+      .then(() => log('info', 'Opentelemetry successfully terminated'))
+      .catch((err: Error) =>
+        log('error', 'Opentelemetry terminating error', { err }),
+      )
+      .finally(() => process.exit(0)); // eslint-disable-line no-process-exit
+  });
+};
+
+if (process.env.OPENTELEMETRY_ENABLED === 'true') {
+  main();
+} else {
+  log('info', 'Opentelemetry not enabled');
+}

--- a/template/koa-rest-api/src/tracing.ts
+++ b/template/koa-rest-api/src/tracing.ts
@@ -40,15 +40,15 @@ const main = () => {
     .start()
     .then(() => log('info', 'OpenTelemetry initialised'))
     .catch((err: Error) =>
-      log('error', 'Opentelemetry not initialised', { err }),
+      log('error', 'OpenTelemetry not initialised', { err }),
     );
 
   process.on('SIGTERM', () => {
     sdk
       .shutdown()
-      .then(() => log('info', 'Opentelemetry successfully terminated'))
+      .then(() => log('info', 'OpenTelemetry successfully terminated'))
       .catch((err: Error) =>
-        log('error', 'Opentelemetry terminating error', { err }),
+        log('error', 'OpenTelemetry failed to terminate', { err }),
       )
       .finally(() => process.exit(0)); // eslint-disable-line no-process-exit
   });
@@ -57,5 +57,5 @@ const main = () => {
 if (process.env.OPENTELEMETRY_ENABLED === 'true') {
   main();
 } else {
-  log('info', 'Opentelemetry not enabled');
+  log('info', 'OpenTelemetry not enabled');
 }


### PR DESCRIPTION
This brings https://opentelemetry.io/ support, which can be enabled via gantry config (deploys another sidecar that collects the data). According to @bernos it's here to stay and should no longer be considered an experimental feature. Yet has to be widely announced. 

All traces can be viewed in "Technology Platforms" DD org.

This PR is a first step - one template only - koa app.

  