### PR TITLE
Restore Node.js 12 compatibility

### DIFF
--- a/.changeset/dull-ravens-reflect.md
+++ b/.changeset/dull-ravens-reflect.md
@@ -1,0 +1,16 @@
+---
+"skuba": patch
+---
+
+test: Restore Node.js 12 compatibility
+
+This resolves the following error in Node.js 12 environments:
+
+```typescript
+Object.entries(parsedConfig.options.paths ?? DEFAULT_PATHS).flatMap(
+                                                 ^
+
+SyntaxError: Unexpected token '?'
+```
+
+Note that Node.js 12 will reach its end of life in May 2022.

--- a/jest/moduleNameMapper.js
+++ b/jest/moduleNameMapper.js
@@ -20,6 +20,7 @@ const DEFAULT_PATHS = { src: ['src'], 'src/*': ['src/*'] };
  */
 const getConfigFromDisk = () => {
   const filename =
+    // TODO: drop Node.js 12 compatibility and switch to ?? in skuba v4.
     findConfigFile('.', sys.fileExists.bind(this)) || 'tsconfig.json';
 
   return readConfigFile(filename, sys.readFile.bind(this)).config;
@@ -32,7 +33,8 @@ module.exports.createModuleNameMapper = (getConfig = getConfigFromDisk) => {
     const parsedConfig = parseJsonConfigFileContent(json, sys, '.');
 
     const paths = Object.fromEntries(
-      Object.entries(parsedConfig.options.paths ?? DEFAULT_PATHS).flatMap(
+      // TODO: drop Node.js 12 compatibility and switch to ?? in skuba v4.
+      Object.entries(parsedConfig.options.paths || DEFAULT_PATHS).flatMap(
         ([key, values]) => [
           // Pass through the input path entry almost verbatim.
           // We trim a trailing slash because TypeScript allows `import 'src'`
@@ -64,6 +66,7 @@ module.exports.createModuleNameMapper = (getConfig = getConfigFromDisk) => {
       ),
     );
 
+    // TODO: drop Node.js 12 compatibility and switch to ?? in skuba v4.
     const prefix = path.join('<rootDir>', parsedConfig.options.baseUrl || '.');
 
     const moduleNameMapper = pathsToModuleNameMapper(paths, { prefix });


### PR DESCRIPTION
While Node.js 12 is going out of support soon, this was an unintended breaking change.