### PR TITLE
Use new Serverless params

### DIFF
--- a/.changeset/gorgeous-apricots-cross.md
+++ b/.changeset/gorgeous-apricots-cross.md
@@ -2,6 +2,6 @@
 "skuba": patch
 ---
 
-template/lambda-sqs-worker: Replace `custom.env` configuration with params
+template/lambda-sqs-worker: Replace `custom.env` configuration with `params`
 
-You can now define environment specific variables using the new Serverless `params` feature. See https://www.serverless.com/framework/docs/guides/parameters for more details.
+You can now define environment specific variables using the new Serverless `params` feature. See <https://www.serverless.com/framework/docs/guides/parameters> for more details.

--- a/.changeset/gorgeous-apricots-cross.md
+++ b/.changeset/gorgeous-apricots-cross.md
@@ -1,0 +1,7 @@
+---
+"skuba": patch
+---
+
+template/lambda-sqs-worker: Replace `custom.env` configuration with params
+
+You can now define environment specific variables using the new Serverless `params` feature. See https://www.serverless.com/framework/docs/guides/parameters for more details.

--- a/.changeset/gorgeous-apricots-cross.md
+++ b/.changeset/gorgeous-apricots-cross.md
@@ -4,4 +4,4 @@
 
 template/lambda-sqs-worker: Replace `custom.env` configuration with `params`
 
-You can now define environment specific variables using the new Serverless `params` feature. See <https://www.serverless.com/framework/docs/guides/parameters> for more details.
+You can now define environment specific variables using the new Serverless parameters feature. See <https://www.serverless.com/framework/docs/guides/parameters> for more details.

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -6,7 +6,6 @@ variablesResolutionMode: 20210326
 params:
   default:
     description: <%- description %>
-    isProduction: false
   dev:
     deploymentBucket: 'TODO: deploymentBucketName'
     isProduction: false

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -3,16 +3,18 @@ service: <%- serviceName %>
 configValidationMode: error
 variablesResolutionMode: 20210326
 
+params:
+  default:
+    description: <%- description %>
+    isProduction: false
+  dev:
+    deploymentBucket: 'TODO: deploymentBucketName'
+    isProduction: false
+  prod:
+    deploymentBucket: 'TODO: deploymentBucketName'
+    isProduction: true
+
 custom:
-  description: <%- description %>
-  env: ${self:custom.envs.${env:ENVIRONMENT}}
-  envs:
-    dev:
-      deploymentBucket: 'TODO: deploymentBucketName'
-      isProduction: false
-    prod:
-      deploymentBucket: 'TODO: deploymentBucketName'
-      isProduction: true
   prune:
     automatic: true
     number: 3
@@ -33,7 +35,7 @@ provider:
   deploymentBucket:
     # Use a shared account-level bucket for Lambda bundles and other artefacts.
     # This is easier to manage in terms of access, deployment, and tagging.
-    name: ${self:custom.env.deploymentBucket}
+    name: ${param:deploymentBucket}
   iam:
     role:
       statements:
@@ -58,7 +60,7 @@ provider:
     # https://rfc.skinfra.xyz/RFC019-AWS-Tagging-Standard.html#seekdatatypes
     # seek:data:types:restricted: job-ads
     seek:env:label: ${env:ENVIRONMENT}
-    seek:env:production: ${self:custom.env.isProduction}
+    seek:env:production: ${param:isProduction}
     seek:owner:team: '<%- teamName %>'
     seek:source:sha: ${env:BUILDKITE_COMMIT, 'na'}
     seek:source:url: 'https://github.com/SEEK-Jobs/<%- repoName %>'
@@ -73,7 +75,7 @@ functions:
   Worker:
     name: ${self:service}
     handler: lib/app.handler
-    description: ${self:custom.description}
+    description: ${param:description}
     memorySize: 128
     reservedConcurrency: 20
     timeout: 30

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -110,7 +110,7 @@ functions:
 
 resources:
   # This becomes the Lambda application's description
-  Description: ${self:custom.description}
+  Description: ${param:description}
 
   Resources:
     DeadLetterQueue:


### PR DESCRIPTION
Use the fancy smancy new `params` feature. Produces a much cleaner template 💎 

https://www.serverless.com/framework/docs/guides/parameters

`default` didn't have to be used but I thought it was a good example of how it can be used.

I guess overall `custom` should be used more for plugins.