### PR TITLE
Use `--enable-source-maps`

### DIFF
--- a/.changeset/shaggy-jobs-breathe.md
+++ b/.changeset/shaggy-jobs-breathe.md
@@ -1,0 +1,46 @@
+---
+"skuba": major
+---
+
+template: Use `--enable-source-maps`
+
+Stable source map support has landed in Node.js 14.18+ via the built-in `--enable-source-maps` option.
+
+We recommend migrating off of custom source map implementations in favour of this option. Upgrading to [**skuba-dive** v2](https://github.com/seek-oss/skuba-dive/releases/tag/v2.0.0) will remove `source-map-support` from the `skuba-dive/register` hook.
+
+For a containerised application, update your Dockerfile:
+
+```diff
+- FROM gcr.io/distroless/nodejs:14 AS runtime
++ FROM gcr.io/distroless/nodejs:16 AS runtime
+
++ # https://nodejs.org/api/cli.html#cli_node_options_options
++ ENV NODE_OPTIONS --enable-source-maps
+```
+
+For a Serverless Lambda application, update your `serverless.yml`:
+
+```diff
+provider:
+- runtime: nodejs12.x
++ runtime: nodejs14.x
+
+functions:
+  Worker:
+    environment:
++     # https://nodejs.org/api/cli.html#cli_node_options_options
++     NODE_OPTIONS: --enable-source-maps
+```
+
+For a CDK Lambda application, update your stack:
+
+```diff
+new aws_lambda.Function(this, 'worker', {
+- runtime: aws_lambda.Runtime.NODEJS_12_X,
++ runtime: aws_lambda.Runtime.NODEJS_14_X,
+  environment: {
++   // https://nodejs.org/api/cli.html#cli_node_options_options
++   NODE_OPTIONS: '--enable-source-maps',
+  },
+});
+```

--- a/.changeset/shaggy-jobs-breathe.md
+++ b/.changeset/shaggy-jobs-breathe.md
@@ -11,7 +11,7 @@ We recommend migrating off of custom source map implementations in favour of thi
 For a containerised application, update your Dockerfile:
 
 ```diff
-- FROM gcr.io/distroless/nodejs:14 AS runtime
+- FROM gcr.io/distroless/nodejs:12 AS runtime
 + FROM gcr.io/distroless/nodejs:16 AS runtime
 
 + # https://nodejs.org/api/cli.html#cli_node_options_options

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "typescript": "~4.4.4"
   },
   "peerDependencies": {
-    "skuba-dive": "1"
+    "skuba-dive": "1 || 2"
   },
   "peerDependenciesMeta": {
     "skuba-dive": {

--- a/template/express-rest-api/Dockerfile
+++ b/template/express-rest-api/Dockerfile
@@ -27,6 +27,9 @@ COPY --from=deps /workdir/node_modules node_modules
 
 ENV NODE_ENV production
 
+# https://nodejs.org/api/cli.html#cli_node_options_options
+ENV NODE_OPTIONS --enable-source-maps
+
 ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -27,6 +27,9 @@ COPY --from=deps /workdir/node_modules node_modules
 
 ENV NODE_ENV production
 
+# https://nodejs.org/api/cli.html#cli_node_options_options
+ENV NODE_OPTIONS --enable-source-maps
+
 ARG PORT=8001
 ENV PORT ${PORT}
 EXPOSE ${PORT}

--- a/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
+++ b/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
@@ -155,6 +155,7 @@ Object {
         "Environment": Object {
           "Variables": Object {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "NODE_OPTIONS": "--enable-source-maps",
             "SOMETHING": "dev",
           },
         },
@@ -509,6 +510,7 @@ Object {
         "Environment": Object {
           "Variables": Object {
             "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1",
+            "NODE_OPTIONS": "--enable-source-maps",
             "SOMETHING": "prod",
           },
         },

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -57,7 +57,10 @@ export class AppStack extends Stack {
       functionName: '<%- serviceName %>',
       environmentEncryption: kmsKey,
       environment: {
+        // https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
+        // https://nodejs.org/api/cli.html#cli_node_options_options
+        NODE_OPTIONS: '--enable-source-maps',
         ...context.workerLambda.environment,
       },
     });

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -85,6 +85,8 @@ functions:
     environment:
       # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
+      # https://nodejs.org/api/cli.html#cli_node_options_options
+      NODE_OPTIONS: --enable-source-maps
 
       ENVIRONMENT: ${env:ENVIRONMENT}
       SERVICE: ${self:service}
@@ -104,6 +106,8 @@ functions:
     environment:
       # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
       AWS_NODEJS_CONNECTION_REUSE_ENABLED: 1
+      # https://nodejs.org/api/cli.html#cli_node_options_options
+      NODE_OPTIONS: --enable-source-maps
 
       FUNCTION_NAME_TO_INVOKE: ${self:functions.Worker.name}
 


### PR DESCRIPTION
We can get rid of the stack trace support in skuba-dive in favour of this Node.js CLI flag. This is stable in Node.js 14.18 which we require as of #760.

- https://github.com/seek-oss/skuba-dive#register
- https://nodejs.org/api/cli.html#cli_enable_source_maps

Closes #399.