### PR TITLE
Remove Serverless `variablesResolutionMode`

### DIFF
--- a/.changeset/gentle-dogs-melt.md
+++ b/.changeset/gentle-dogs-melt.md
@@ -1,0 +1,12 @@
+---
+"skuba": patch
+---
+
+template/lambda-sqs-worker: Remove `variablesResolutionMode`
+
+This resolves the following deprecation warning in Serverless Framework v3:
+
+```console
+Starting with v3.0, the "variablesResolutionMode" option is now useless. You can safely remove it from the configuration
+More info: https://serverless.com/framework/docs/deprecations/#VARIABLES_RESOLUTION_MODE
+```

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -1,7 +1,6 @@
 service: <%- serviceName %>
 
 configValidationMode: error
-variablesResolutionMode: 20210326
 
 params:
   default:


### PR DESCRIPTION
```
Starting with v3.0, the "variablesResolutionMode" option is now useless. You can safely remove it from the configuration
More info: https://serverless.com/framework/docs/deprecations/#VARIABLES_RESOLUTION_MODE
```