### PR TITLE
Suppress `eslint-plugin-react` warning

### DIFF
--- a/.changeset/popular-vans-film.md
+++ b/.changeset/popular-vans-film.md
@@ -1,0 +1,9 @@
+---
+"skuba": patch
+---
+
+format, lint: Suppress `eslint-plugin-react` warning
+
+```console
+Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.
+```

--- a/src/cli/adapter/eslint.ts
+++ b/src/cli/adapter/eslint.ts
@@ -54,6 +54,8 @@ export const runESLint = async (
       // `eslint-plugin-react` prints this annoying error on non-React repos.
       // We still want to support React linting for repos that have React code,
       // so we have to manually suppress it.
+      //
+      // https://github.com/yannickcr/eslint-plugin-react/blob/7484acaca8351a8568fa99344bc811c5cd8396bd/lib/util/version.js#L61-L65
       'Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.'
     ) {
       ogConsoleError(...args);

--- a/src/cli/adapter/eslint.ts
+++ b/src/cli/adapter/eslint.ts
@@ -46,10 +46,27 @@ export const runESLint = async (
 
   const start = process.hrtime.bigint();
 
+  /* eslint-disable no-console */
+  const ogConsoleError = console.error;
+  console.error = (...args: any[]) => {
+    if (
+      args[0] !==
+      // `eslint-plugin-react` prints this annoying error on non-React repos.
+      // We still want to support React linting for repos that have React code,
+      // so we have to manually suppress it.
+      'Warning: React version was set to "detect" in eslint-plugin-react settings, but the "react" package is not installed. Assuming latest React version for linting.'
+    ) {
+      ogConsoleError(...args);
+    }
+  };
+
   const [formatter, results] = await Promise.all([
     engine.loadFormatter(),
     engine.lintFiles('.'),
   ]);
+
+  console.error = ogConsoleError;
+  /* eslint-enable no-console */
 
   const end = process.hrtime.bigint();
 

--- a/src/cli/adapter/eslint.ts
+++ b/src/cli/adapter/eslint.ts
@@ -48,7 +48,7 @@ export const runESLint = async (
 
   /* eslint-disable no-console */
   const ogConsoleError = console.error;
-  console.error = (...args: any[]) => {
+  console.error = (...args: unknown[]) => {
     if (
       args[0] !==
       // `eslint-plugin-react` prints this annoying error on non-React repos.


### PR DESCRIPTION
We got bitten by seek-oss/eslint-config-seek#68.

Example: https://github.com/seek-oss/skuba/runs/5490668838?check_suite_focus=true#step:6:10