### PR TITLE
Fix release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions: {}
 jobs:
   release:
     name: Publish & Deploy
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo


### PR DESCRIPTION
Turns out the regular workflow permissions are used for a force push to `changeset-release/master` instead of the supplied GITHUB_TOKEN env var.

https://github.com/seek-oss/skuba/runs/5652757552?check_suite_focus=true#step:5:429