### PR TITLE
Try supplying the seek-oss-ci token to checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,13 @@ permissions: {}
 jobs:
   release:
     name: Publish & Deploy
-    permissions:
-      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
       - name: Set up Node.js 16.x
         uses: actions/setup-node@v2


### PR DESCRIPTION
It looks like #802 didn't do the trick. In theory this means that the actual push will use `seek-oss-ci` now and trigger workflow runs.

- https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
- https://github.com/seek-oss/skuba/pull/798/commits/11060cbdcb1bcc88e1251601a84fb195a00b1379