### PR TITLE
Restore release `contents` permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions: {}
 jobs:
   release:
     name: Publish & Deploy
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo


### PR DESCRIPTION
I got "Publish to npm" working nicely in #809 but inadvertently broke the subsequent "Deploy to GitHub Pages" step 🙃