### PR TITLE
Skip integration on release PR

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,6 +71,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - if: github.head_ref != 'skip-integration-release' && github.ref_name != 'skip-integration-release'
+      - if: github.head_ref != 'changeset-release/master' && github.ref_name != 'changeset-release/master'
         name: Test template
         run: yarn test:template ${{ matrix.template }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,5 +71,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Test template
+      - if: github.head_ref != 'skip-integration-release' && github.ref_name != 'skip-integration-release'
+        name: Test template
         run: yarn test:template ${{ matrix.template }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -71,6 +71,6 @@ jobs:
         with:
           node-version: 16.x
 
-      - if: github.head_ref != 'changeset-release/master' && github.ref_name != 'changeset-release/master'
+      - if: github.head_ref != 'beta' && github.head_ref != 'changeset-release/master' && github.ref_name != 'beta' && github.ref_name != 'changeset-release/master'
         name: Test template
         run: yarn test:template ${{ matrix.template }}


### PR DESCRIPTION
These try to reference the to-be-published version which doesn't yet exist on the npm registry.

Resolves ❌ on #798.