### PR TITLE
Restore reason to changeset formatting

### DIFF
--- a/.changeset/.prettierrc.js
+++ b/.changeset/.prettierrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  ...require("../config/prettier"),
-
-  // Changesets are generated with double quotes by default.
-  singleQuote: false,
-};

--- a/.changeset/brave-peas-carry.md
+++ b/.changeset/brave-peas-carry.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 template/lambda-sqs-worker-cdk: Fix progress configuration in `cdk.json`

--- a/.changeset/bright-rivers-hear.md
+++ b/.changeset/bright-rivers-hear.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 Jest.mergePreset: Allow additional props via type parameter

--- a/.changeset/brown-experts-tease.md
+++ b/.changeset/brown-experts-tease.md
@@ -1,5 +1,5 @@
 ---
-"skuba": minor
+'skuba': minor
 ---
 
 deps: TypeScript 4.6

--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -1,7 +1,7 @@
 const {
   getInfo,
   getInfoFromPullRequest,
-} = require("@changesets/get-github-info");
+} = require('@changesets/get-github-info');
 
 /**
  * Bold the scope of the changelog entry.
@@ -10,7 +10,7 @@ const {
  *
  * @param {string} firstLine
  */
-const boldScope = (firstLine) => firstLine.replace(/^([^:]+): /, "**$1:** ");
+const boldScope = (firstLine) => firstLine.replace(/^([^:]+): /, '**$1:** ');
 
 /**
  * Adapted from `@changesets/cli`.
@@ -21,7 +21,7 @@ const boldScope = (firstLine) => firstLine.replace(/^([^:]+): /, "**$1:** ");
  */
 const defaultChangelogFunctions = {
   getDependencyReleaseLine: async (changesets, dependenciesUpdated) => {
-    if (dependenciesUpdated.length === 0) return "";
+    if (dependenciesUpdated.length === 0) return '';
 
     const changesetLinks = changesets.map(
       (changeset) => `- Updated dependencies [${changeset.commit}]`,
@@ -31,11 +31,11 @@ const defaultChangelogFunctions = {
       (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
     );
 
-    return [...changesetLinks, ...updatedDependenciesList].join("\n");
+    return [...changesetLinks, ...updatedDependenciesList].join('\n');
   },
   getReleaseLine: async (changeset) => {
     const [firstLine, ...futureLines] = changeset.summary
-      .split("\n")
+      .split('\n')
       .map((l) => l.trimRight());
 
     const formattedFirstLine = boldScope(firstLine);
@@ -43,8 +43,8 @@ const defaultChangelogFunctions = {
     const suffix = changeset.commit;
 
     return `\n\n- ${formattedFirstLine}${
-      suffix ? ` (${suffix})` : ""
-    }\n${futureLines.map((l) => `  ${l}`).join("\n")}`;
+      suffix ? ` (${suffix})` : ''
+    }\n${futureLines.map((l) => `  ${l}`).join('\n')}`;
   },
 };
 
@@ -66,7 +66,7 @@ const gitHubChangelogFunctions = {
         'Please provide a repo to this changelog generator like this:\n"changelog": ["./changelog.js", { "repo": "org/repo" }]',
       );
     }
-    if (dependenciesUpdated.length === 0) return "";
+    if (dependenciesUpdated.length === 0) return '';
 
     const changesetLink = `- Updated dependencies [${(
       await Promise.all(
@@ -82,13 +82,13 @@ const gitHubChangelogFunctions = {
       )
     )
       .filter((_) => _)
-      .join(", ")}]:`;
+      .join(', ')}]:`;
 
     const updatedDependenciesList = dependenciesUpdated.map(
       (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
     );
 
-    return [changesetLink, ...updatedDependenciesList].join("\n");
+    return [changesetLink, ...updatedDependenciesList].join('\n');
   },
   getReleaseLine: async (changeset, _type, options) => {
     if (!options || !options.repo) {
@@ -106,20 +106,20 @@ const gitHubChangelogFunctions = {
       .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
         let num = Number(pr);
         if (!isNaN(num)) prFromSummary = num;
-        return "";
+        return '';
       })
       .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
         commitFromSummary = commit;
-        return "";
+        return '';
       })
       .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
         usersFromSummary.push(user);
-        return "";
+        return '';
       })
       .trim();
 
     const [firstLine, ...futureLines] = replacedChangelog
-      .split("\n")
+      .split('\n')
       .map((l) => l.trimRight());
 
     const links = await (async () => {
@@ -156,9 +156,9 @@ const gitHubChangelogFunctions = {
     const suffix = links.pull ?? links.commit;
 
     return [
-      `\n- ${formattedFirstLine}${suffix ? ` (${suffix})` : ""}`,
+      `\n- ${formattedFirstLine}${suffix ? ` (${suffix})` : ''}`,
       ...futureLines.map((l) => `  ${l}`),
-    ].join("\n");
+    ].join('\n');
   },
 };
 

--- a/.changeset/cool-melons-work.md
+++ b/.changeset/cool-melons-work.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 Git.currentBranch: Add helper function

--- a/.changeset/curvy-papayas-remember.md
+++ b/.changeset/curvy-papayas-remember.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 Git.commitAllChanges: Skip commit and return `undefined` when there are no changes

--- a/.changeset/lazy-ants-brush.md
+++ b/.changeset/lazy-ants-brush.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 template/oss-npm-package: Lock down GitHub workflow permissions

--- a/.changeset/lemon-buttons-move.md
+++ b/.changeset/lemon-buttons-move.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 template: Propagate Buildkite environment variables for lint autofixing

--- a/.changeset/old-points-brush.md
+++ b/.changeset/old-points-brush.md
@@ -1,5 +1,5 @@
 ---
-"skuba": minor
+'skuba': minor
 ---
 
 lint: Autofix in CI

--- a/.changeset/purple-balloons-speak.md
+++ b/.changeset/purple-balloons-speak.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 Git.getOwnerAndRepo: Support reading from CI environment variables

--- a/.changeset/purple-candles-retire.md
+++ b/.changeset/purple-candles-retire.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 Git.getHeadCommitMessage: Add helper function

--- a/.changeset/red-cycles-care.md
+++ b/.changeset/red-cycles-care.md
@@ -18,7 +18,7 @@ If you wish to relax some of the new rules, [extend](https://eslint.org/docs/use
 module.exports = {
   extends: ['skuba'],
   rules: {
-    // Demote new TypeScript ESLint rule from "error" to "warn".
+    // Demote new TypeScript ESLint rule from 'error' to 'warn'.
     '@typescript-eslint/no-unsafe-argument': 'warn',
   },
 };

--- a/.changeset/red-cycles-care.md
+++ b/.changeset/red-cycles-care.md
@@ -1,5 +1,5 @@
 ---
-"skuba": minor
+'skuba': minor
 ---
 
 deps: ESLint 8 + eslint-config-seek 9
@@ -16,10 +16,10 @@ If you wish to relax some of the new rules, [extend](https://eslint.org/docs/use
 
 ```javascript
 module.exports = {
-  extends: ["skuba"],
+  extends: ['skuba'],
   rules: {
     // Demote new TypeScript ESLint rule from "error" to "warn".
-    "@typescript-eslint/no-unsafe-argument": "warn",
+    '@typescript-eslint/no-unsafe-argument': 'warn',
   },
 };
 ```

--- a/.changeset/spicy-gifts-smash.md
+++ b/.changeset/spicy-gifts-smash.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 template/oss-npm-package: Pin GitHub action versions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,7 @@ a changeset is not necessary for:
 - [npm dev dependencies](https://github.com/seek-oss/skuba/blob/master/package.json)
 
 ```shell
-yarn changeset:add
+yarn changeset
 ```
 
 The Changesets CLI is interactive and follows [semantic versioning]:

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   },
   "scripts": {
     "build": "ts-node --transpile-only src/skuba build && scripts/postbuild.sh",
-    "changeset:add": "changeset add && prettier --loglevel silent --write '.changeset/*.md'",
     "deploy": "scripts/deploy.sh",
     "format": "yarn skuba format",
     "lint": "yarn skuba lint",


### PR DESCRIPTION
We shouldn't need to worry about the Changesets bot producing double quoted Markdown files now that we push linting autofixes.