### PR TITLE
Make warning logs more verbose

### DIFF
--- a/.changeset/honest-boxes-talk.md
+++ b/.changeset/honest-boxes-talk.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+cli: Make warning logs more verbose

--- a/src/cli/configure/refreshIgnoreFiles.ts
+++ b/src/cli/configure/refreshIgnoreFiles.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { inspect } from 'util';
 
 import fs from 'fs-extra';
 
@@ -43,6 +44,6 @@ export const tryRefreshIgnoreFiles = async () => {
     await refreshIgnoreFiles();
   } catch (err) {
     log.warn('Failed to refresh ignore files.');
-    log.warn(err);
+    log.subtle(inspect(err));
   }
 };

--- a/src/cli/lint/autofix.test.ts
+++ b/src/cli/lint/autofix.test.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import simpleGit from 'simple-git';
 
 import * as Git from '../../api/git';
@@ -13,10 +15,15 @@ jest.mock('../../cli/adapter/prettier');
 
 const MOCK_ERROR = new Error('Badness!');
 
+const rootDir = path.join(__dirname, '..', '..', '..');
+
 const stdoutMock = jest.fn();
 
 const stdout = () => {
-  const result = stdoutMock.mock.calls.flat(1).join('');
+  const result = stdoutMock.mock.calls
+    .flat(1)
+    .map((line) => line.replaceAll(rootDir, '<rootDir>'))
+    .join('');
   return `\n${result}`;
 };
 
@@ -208,6 +215,16 @@ describe('autofix', () => {
       Failed to push fix commit.
       Does your CI environment have write access to your Git repository?
       Error: Badness!
+          at Object.<anonymous> (<rootDir>/src/cli/lint/autofix.test.ts:16:20)
+          at Runtime._execModule (<rootDir>/node_modules/jest-runtime/build/index.js:1646:24)
+          at Runtime._loadModule (<rootDir>/node_modules/jest-runtime/build/index.js:1185:12)
+          at Runtime.requireModule (<rootDir>/node_modules/jest-runtime/build/index.js:1009:12)
+          at jestAdapter (<rootDir>/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:13)
+          at processTicksAndRejections (node:internal/process/task_queues:96:5)
+          at runTestInternal (<rootDir>/node_modules/jest-runner/build/runTest.js:389:16)
+          at runTest (<rootDir>/node_modules/jest-runner/build/runTest.js:475:34)
+          at TestRunner.runTests (<rootDir>/node_modules/jest-runner/build/index.js:101:12)
+          at TestScheduler.scheduleTests (<rootDir>/node_modules/@jest/core/build/TestScheduler.js:333:13)
       "
     `);
   });
@@ -232,6 +249,16 @@ describe('autofix', () => {
       Failed to push fix commit.
       Does your CI environment have write access to your Git repository?
       Error: Badness!
+          at Object.<anonymous> (<rootDir>/src/cli/lint/autofix.test.ts:16:20)
+          at Runtime._execModule (<rootDir>/node_modules/jest-runtime/build/index.js:1646:24)
+          at Runtime._loadModule (<rootDir>/node_modules/jest-runtime/build/index.js:1185:12)
+          at Runtime.requireModule (<rootDir>/node_modules/jest-runtime/build/index.js:1009:12)
+          at jestAdapter (<rootDir>/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:13)
+          at processTicksAndRejections (node:internal/process/task_queues:96:5)
+          at runTestInternal (<rootDir>/node_modules/jest-runner/build/runTest.js:389:16)
+          at runTest (<rootDir>/node_modules/jest-runner/build/runTest.js:475:34)
+          at TestRunner.runTests (<rootDir>/node_modules/jest-runner/build/index.js:101:12)
+          at TestScheduler.scheduleTests (<rootDir>/node_modules/@jest/core/build/TestScheduler.js:333:13)
       "
     `);
   });

--- a/src/cli/lint/autofix.test.ts
+++ b/src/cli/lint/autofix.test.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import simpleGit from 'simple-git';
 
 import * as Git from '../../api/git';
@@ -15,15 +13,13 @@ jest.mock('../../cli/adapter/prettier');
 
 const MOCK_ERROR = new Error('Badness!');
 
-const rootDir = path.join(__dirname, '..', '..', '..');
-
 const stdoutMock = jest.fn();
 
 const stdout = () => {
   const result = stdoutMock.mock.calls
     .flat(1)
-    .map((line) => line.replaceAll(rootDir, '<rootDir>'))
-    .join('');
+    .join('')
+    .replace(/(at Object\.\<anonymous\>)[\s\S]+$/, '$1...');
   return `\n${result}`;
 };
 
@@ -215,17 +211,7 @@ describe('autofix', () => {
       Failed to push fix commit.
       Does your CI environment have write access to your Git repository?
       Error: Badness!
-          at Object.<anonymous> (<rootDir>/src/cli/lint/autofix.test.ts:16:20)
-          at Runtime._execModule (<rootDir>/node_modules/jest-runtime/build/index.js:1646:24)
-          at Runtime._loadModule (<rootDir>/node_modules/jest-runtime/build/index.js:1185:12)
-          at Runtime.requireModule (<rootDir>/node_modules/jest-runtime/build/index.js:1009:12)
-          at jestAdapter (<rootDir>/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:13)
-          at processTicksAndRejections (node:internal/process/task_queues:96:5)
-          at runTestInternal (<rootDir>/node_modules/jest-runner/build/runTest.js:389:16)
-          at runTest (<rootDir>/node_modules/jest-runner/build/runTest.js:475:34)
-          at TestRunner.runTests (<rootDir>/node_modules/jest-runner/build/index.js:101:12)
-          at TestScheduler.scheduleTests (<rootDir>/node_modules/@jest/core/build/TestScheduler.js:333:13)
-      "
+          at Object.<anonymous>..."
     `);
   });
 
@@ -249,17 +235,7 @@ describe('autofix', () => {
       Failed to push fix commit.
       Does your CI environment have write access to your Git repository?
       Error: Badness!
-          at Object.<anonymous> (<rootDir>/src/cli/lint/autofix.test.ts:16:20)
-          at Runtime._execModule (<rootDir>/node_modules/jest-runtime/build/index.js:1646:24)
-          at Runtime._loadModule (<rootDir>/node_modules/jest-runtime/build/index.js:1185:12)
-          at Runtime.requireModule (<rootDir>/node_modules/jest-runtime/build/index.js:1009:12)
-          at jestAdapter (<rootDir>/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:13)
-          at processTicksAndRejections (node:internal/process/task_queues:96:5)
-          at runTestInternal (<rootDir>/node_modules/jest-runner/build/runTest.js:389:16)
-          at runTest (<rootDir>/node_modules/jest-runner/build/runTest.js:475:34)
-          at TestRunner.runTests (<rootDir>/node_modules/jest-runner/build/index.js:101:12)
-          at TestScheduler.scheduleTests (<rootDir>/node_modules/@jest/core/build/TestScheduler.js:333:13)
-      "
+          at Object.<anonymous>..."
     `);
   });
 });

--- a/src/cli/lint/autofix.ts
+++ b/src/cli/lint/autofix.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'util';
+
 import simpleGit from 'simple-git';
 
 import * as Git from '../../api/git';
@@ -103,6 +105,6 @@ export const autofix = async (input: Pick<Input, 'debug'>): Promise<void> => {
         'Does your CI environment have write access to your Git repository?',
       ),
     );
-    log.subtle(err);
+    log.subtle(inspect(err));
   }
 };

--- a/src/cli/lint/external.ts
+++ b/src/cli/lint/external.ts
@@ -1,4 +1,5 @@
 import stream from 'stream';
+import { inspect } from 'util';
 
 import { log } from '../../utils/logging';
 
@@ -87,8 +88,8 @@ export const externalLint = async (input: Input) => {
   try {
     await createAnnotations(eslint, prettier, tscOk, tscOutputStream);
   } catch (err) {
-    log.warn('Failed to annotate results.');
-    log.warn(err);
+    log.warn('Failed to annotate lint results.');
+    log.subtle(inspect(err));
   }
 
   if (eslint.ok && prettier.ok && tscOk) {

--- a/src/cli/test/reporters/github/index.ts
+++ b/src/cli/test/reporters/github/index.ts
@@ -1,3 +1,5 @@
+import { inspect } from 'util';
+
 import type { Context, Reporter } from '@jest/reporters';
 import type { AggregatedResult } from '@jest/test-result';
 
@@ -44,8 +46,8 @@ export default class GitHubReporter implements Pick<Reporter, 'onRunComplete'> {
         });
       }
     } catch (err) {
-      log.warn('Failed to annotate results.');
-      log.warn(err);
+      log.warn('Failed to report test results to GitHub.');
+      log.subtle(inspect(err));
     }
   }
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,5 +1,7 @@
 /* eslint-disable new-cap */
 
+import { inspect } from 'util';
+
 import type { ExecaError } from 'execa';
 import * as t from 'runtypes';
 
@@ -28,7 +30,7 @@ export const handleCliError = (err: unknown) => {
     return;
   }
 
-  log.err(err);
+  log.err(inspect(err));
   process.exitCode = 1;
   return;
 };

--- a/src/utils/worker.ts
+++ b/src/utils/worker.ts
@@ -1,3 +1,4 @@
+import { inspect } from 'util';
 import { Worker, parentPort, workerData } from 'worker_threads';
 
 import { log } from './logging';
@@ -56,7 +57,7 @@ export const postWorkerOutput = <Input, Output>(
   fn(workerData as Input)
     .then((output) => port.postMessage(output))
     .catch((err) => {
-      logger.err(err);
+      logger.err(inspect(err));
 
       process.exit(1);
     });


### PR DESCRIPTION
I have one repo that's failing on the following, and it's a bit annoying to track down:

```console
Failed to annotate results.
TypeError: Cannot read properties of null (reading 'split')
```