### PR TITLE
Check for the "special pipeline name" as a substring of each splitted queuename

### DIFF
--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -34,6 +34,9 @@ describe('hasSerialFlag', () => {
     ${'matching env'}              | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: 'artefacts:npm' }}                   | ${true}
     ${'matching env at start'}     | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: 'artefacts:npm,123456789012:cicd' }} | ${true}
     ${'matching env at end'}       | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: '123456789012:cicd,artefacts:npm' }} | ${true}
+    ${'matching env2 at start'}     | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: 'artefacts:npm2,123456789012:cicd' }} | ${true}
+    ${'matching env2 at end'}       | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: '123456789012:cicd,artefacts:npm2' }} | ${true}
+    ${'unrelated env2'}             | ${[]}                                | ${{ BUILDKITE_AGENT_META_DATA_QUEUE: '123456789012:cicd,artefacts:2npm' }} | ${false}
   `('$description => $expected', ({ args, env, expected }) =>
     expect(hasSerialFlag(args, env)).toBe(expected),
   );

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -10,7 +10,11 @@ export const hasSerialFlag = (args = process.argv, env = process.env) =>
   Boolean(
     // Run serially on SEEK's central npm publishing pipeline.
     // Exhausting agents here can cause grief.
-    env.BUILDKITE_AGENT_META_DATA_QUEUE?.split(',').includes('artefacts:npm'),
+    
+    env.BUILDKITE_AGENT_META_DATA_QUEUE?.split(',').reduce(
+      (accumulator, currentValue) => accumulator || currentValue.includes('artefacts:npm'),
+      false
+    )
   );
 
 /**

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -13,8 +13,8 @@ export const hasSerialFlag = (args = process.argv, env = process.env) =>
     
     env.BUILDKITE_AGENT_META_DATA_QUEUE?.split(',').reduce(
       (accumulator, currentValue) => accumulator || currentValue.includes('artefacts:npm'),
-      false
-    )
+      false,
+    ),
   );
 
 /**


### PR DESCRIPTION
We have more than one central publishing pipeline - `artefacts:npm`, `artefacts:npm2` and possibly others in future?

Test for all of these when setting this flag, by changing this check to be a substring-search.