### PR TITLE
Encourage `propagate-environment` usage

### DIFF
--- a/docs/deep-dives/buildkite.md
+++ b/docs/deep-dives/buildkite.md
@@ -114,11 +114,3 @@ The agent may be tied up running a particularly compute- or memory-intensive ste
 [ci/cd]: https://en.wikipedia.org/wiki/CI/CD
 [compose file]: https://docs.docker.com/compose/compose-file
 [docker buildkite plugin]: https://github.com/buildkite-plugins/docker-buildkite-plugin
-
----
-
-## Buildkite pipeline optimisations
-
-### Optimisations for workers
-
-### Optimisations for workers

--- a/docs/deep-dives/buildkite.md
+++ b/docs/deep-dives/buildkite.md
@@ -28,15 +28,11 @@ steps:
       - *aws-sm
       - *private-npm
       - *docker-ecr-cache
-      - docker#v3.8.0:
-          environment:
-            # Enable Buildkite integrations.
-            - BUILDKITE
-            - BUILDKITE_AGENT_ACCESS_TOKEN
-            - BUILDKITE_JOB_ID
-            - BUILDKITE_STEP_ID
+      - docker#v3.12.0:
           # Disable SEEK BuildAgency's wrapped agent that requires Bash.
           mount-buildkite-agent: false
+          # Enable Buildkite integrations.
+          propagate-environment: true
           volumes:
             # Mount agent for Buildkite annotations.
             - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
@@ -118,3 +114,11 @@ The agent may be tied up running a particularly compute- or memory-intensive ste
 [ci/cd]: https://en.wikipedia.org/wiki/CI/CD
 [compose file]: https://docs.docker.com/compose/compose-file
 [docker buildkite plugin]: https://github.com/buildkite-plugins/docker-buildkite-plugin
+
+---
+
+## Buildkite pipeline optimisations
+
+### Optimisations for workers
+
+### Optimisations for workers

--- a/docs/deep-dives/github.md
+++ b/docs/deep-dives/github.md
@@ -32,14 +32,11 @@ steps:
       - *aws-sm
       - *private-npm
       - *docker-ecr-cache
-      - docker#v3.8.0:
+      - docker#v3.12.0:
+          # Enable GitHub integrations.
           environment:
-            # Enable GitHub integrations.
-            - BUILDKITE
-            - BUILDKITE_BRANCH
-            - BUILDKITE_BUILD_NUMBER
-            - BUILDKITE_PIPELINE_DEFAULT_BRANCH
             - GITHUB_API_TOKEN
+          propagate-environment: true
           volumes:
             # Mount cached dependencies.
             - /workdir/node_modules
@@ -65,7 +62,7 @@ services:
 ```
 
 If you're running in GitHub Actions,
-propagate the following environment variables to achieve the same effect:
+your workflow will automatically have access to the following environment variables to achieve the same effect:
 
 - `GITHUB_ACTIONS`
 - `GITHUB_HEAD_REF`


### PR DESCRIPTION
This is less tedious than having to constantly maintain a list of environment variables that skuba uses.