### PR TITLE
List `BUILDKITE_AGENT_ACCESS_TOKEN`

### DIFF
--- a/docs/deep-dives/buildkite.md
+++ b/docs/deep-dives/buildkite.md
@@ -29,6 +29,8 @@ steps:
       - *private-npm
       - *docker-ecr-cache
       - docker#v3.12.0:
+          environment:
+            - BUILDKITE_AGENT_ACCESS_TOKEN
           # Disable SEEK BuildAgency's wrapped agent that requires Bash.
           mount-buildkite-agent: false
           # Enable Buildkite integrations.


### PR DESCRIPTION
Looks like this is required when `mount-buildkite-agent: false`.