### PR TITLE
Time out Buildkite test steps after 10 minutes

### DIFF
--- a/.changeset/honest-apes-vanish.md
+++ b/.changeset/honest-apes-vanish.md
@@ -1,0 +1,13 @@
+---
+'skuba': patch
+---
+
+template: Time out Buildkite test steps after 10 minutes
+
+Successful testing and linting should complete within this window. This timeout prevents commands from hanging and indefinitely preoccupying your Buildkite agents.
+
+```diff
+steps:
+  - label: 🧪 Test & Lint
++   timeout_in_minutes: 10
+```

--- a/template/express-rest-api/.buildkite/pipeline.yml
+++ b/template/express-rest-api/.buildkite/pipeline.yml
@@ -53,6 +53,7 @@ steps:
       - *docker-ecr-cache
       - docker-compose#v3.9.0:
           run: app
+    timeout_in_minutes: 10
 
   - label: 📦 Build & Package
     depends_on: warm-prod

--- a/template/greeter/.buildkite/pipeline.yml
+++ b/template/greeter/.buildkite/pipeline.yml
@@ -34,3 +34,4 @@ steps:
       - *docker-ecr-cache
       - docker-compose#v3.9.0:
           run: app
+    timeout_in_minutes: 10

--- a/template/koa-rest-api/.buildkite/pipeline.yml
+++ b/template/koa-rest-api/.buildkite/pipeline.yml
@@ -53,6 +53,7 @@ steps:
       - *docker-ecr-cache
       - docker-compose#v3.9.0:
           run: app
+    timeout_in_minutes: 10
 
   - label: 📦 Build & Package
     depends_on: warm-prod

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -59,6 +59,7 @@ steps:
       - *docker-ecr-cache
       - docker-compose#v3.9.0:
           run: app
+    timeout_in_minutes: 10
 
   - agents:
       queue: <%- devBuildkiteQueueName %>

--- a/template/lambda-sqs-worker/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker/.buildkite/pipeline.yml
@@ -63,6 +63,7 @@ steps:
       - *docker-ecr-cache
       - docker-compose#v3.9.0:
           run: app
+    timeout_in_minutes: 10
 
   - agents:
       queue: <%- devBuildkiteQueueName %>


### PR DESCRIPTION
Our projects should aim for a shorter duration for testing and linting. Taking longer than 10 minutes usually indicates a command or request has hung and will indefinitely hog the build agent, so we define a timeout.