### PR TITLE
Update build agent queue

### DIFF
--- a/.changeset/brave-owls-join.md
+++ b/.changeset/brave-owls-join.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+template/private-npm-package: Use `npm2` build agent queue

--- a/template/private-npm-package/.buildkite/pipeline.yml
+++ b/template/private-npm-package/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: artefacts:npm
+  queue: artefacts:npm2
 
 steps:
   - command: aws s3 cp s3://seek-npm-package-buildkite-pipeline/pipeline-latest.sh - | bash | buildkite-agent pipeline upload


### PR DESCRIPTION
The "npm" agent queue is no longer updated. Instead, the "npm2" queue is used for new repositories. See https://github.com/SEEK-Jobs/gutenberg#installing-on-your-repository