### PR TITLE
Improve autofixing

### DIFF
--- a/.changeset/brave-owls-join.md
+++ b/.changeset/brave-owls-join.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 template/private-npm-package: Use `npm2` build agent queue

--- a/.changeset/six-worms-jump.md
+++ b/.changeset/six-worms-jump.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+lint: Detect and autofix ESLint warnings

--- a/.changeset/tasty-steaks-count.md
+++ b/.changeset/tasty-steaks-count.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+lint: Skip autofixing when ESLint reports no fixable issues

--- a/src/cli/adapter/eslint.ts
+++ b/src/cli/adapter/eslint.ts
@@ -22,9 +22,10 @@ export interface ESLintResult {
 
 export interface ESLintOutput {
   errors: ESLintResult[];
-  warnings: ESLintResult[];
+  fixable: boolean;
   ok: boolean;
   output: string;
+  warnings: ESLintResult[];
 }
 
 export const runESLint = async (
@@ -81,9 +82,14 @@ export const runESLint = async (
 
   const errors: ESLintResult[] = [];
   const warnings: ESLintResult[] = [];
+  let fixable = false;
 
   for (const result of results) {
     const relativePath = path.relative(cwd, result.filePath);
+    if (result.fixableErrorCount + result.fixableWarningCount) {
+      fixable = true;
+    }
+
     if (result.errorCount) {
       errors.push({
         filePath: relativePath,
@@ -111,5 +117,5 @@ export const runESLint = async (
     logger.plain(output);
   }
 
-  return { ok, output, errors, warnings };
+  return { errors, fixable, ok, output, warnings };
 };

--- a/src/cli/lint/annotate/github/eslint.test.ts
+++ b/src/cli/lint/annotate/github/eslint.test.ts
@@ -24,6 +24,7 @@ it('should create failure annotations for ESLint errors', () => {
         ],
       },
     ],
+    fixable: false,
     ok: false,
     output: '',
     warnings: [],
@@ -49,6 +50,7 @@ it('should create failure annotations for ESLint errors', () => {
 it('should create warning annotations for ESLint warnings', () => {
   const eslintOutput: ESLintOutput = {
     errors: [],
+    fixable: false,
     ok: true,
     output: '',
     warnings: [
@@ -110,6 +112,7 @@ it('should create both failure and warning annotations for ESLint errors and war
         ],
       },
     ],
+    fixable: false,
     ok: false,
     output: '',
     warnings: [
@@ -181,6 +184,7 @@ it('should not specify columns when an annotation spans multiple lines', () => {
         ],
       },
     ],
+    fixable: false,
     ok: false,
     output: '',
     warnings: [],

--- a/src/cli/lint/annotate/github/index.test.ts
+++ b/src/cli/lint/annotate/github/index.test.ts
@@ -36,6 +36,7 @@ const eslintOutput: ESLintOutput = {
       ],
     },
   ],
+  fixable: false,
   ok: false,
   output: '',
   warnings: [],


### PR DESCRIPTION
1. Skip when ESLint reports no fixable issues
2. Detect ESLint warnings instead of just errors