### PR TITLE
Remove `ansi-regex` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,8 +99,7 @@
     "url": "git+https://github.com/seek-oss/skuba.git"
   },
   "resolutions": {
-    "**/@types/node": ">=14.18",
-    "semantic-release/@semantic-release/npm/npm/**/ansi-regex": "5.0.1"
+    "**/@types/node": ">=14.18"
   },
   "scripts": {
     "build": "ts-node --transpile-only src/skuba build && scripts/postbuild.sh",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,7 +1817,7 @@ ansi-escapes@^5.0.0:
   dependencies:
     type-fest "^1.0.2"
 
-ansi-regex@5.0.1, ansi-regex@^5.0.1:
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==


### PR DESCRIPTION
We no longer have a vulnerable transitive dep via `semantic-release`.