### PR TITLE
feat: use `AsyncLocalStorage` to track logger context

### DIFF
--- a/.changeset/olive-worms-run.md
+++ b/.changeset/olive-worms-run.md
@@ -4,10 +4,10 @@
 
 template/koa-rest-api: Use [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html#asynchronous-context-tracking) to track logger context
 
-
 We now employ [RequestLogging.createContextStorage](https://github.com/seek-oss/koala/blob/master/src/requestLogging/README.md#context-logging) to thread logging context through the middleware stack of your Koa application. This enables use of a singleton `logger` instance instead of manually propagating Koa context and juggling `rootLogger`s and `contextLogger`s.
 
 Before:
+
 ```typescript
 import createLogger from '@seek/logger';
 import Koa from 'koa';
@@ -20,7 +20,9 @@ const app = new Koa().use((ctx) => {
   contextLogger(ctx).info('Has context');
 });
 ```
+
 After:
+
 ```typescript
 import createLogger from '@seek/logger';
 import Koa from 'koa';

--- a/.changeset/olive-worms-run.md
+++ b/.changeset/olive-worms-run.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/koa-rest-api: Use AsyncLocalStorage to track logger context

--- a/.changeset/olive-worms-run.md
+++ b/.changeset/olive-worms-run.md
@@ -2,4 +2,34 @@
 'skuba': patch
 ---
 
-template/koa-rest-api: Use `createContextStorage` from seek-koala to track logger context
+template/koa-rest-api: Use [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html#asynchronous-context-tracking) to track logger context
+
+
+We now employ [RequestLogging.createContextStorage](https://github.com/seek-oss/koala/blob/master/src/requestLogging/README.md#context-logging) to thread logging context through the middleware stack of your Koa application. This enables use of a singleton `logger` instance instead of manually propagating Koa context and juggling `rootLogger`s and `contextLogger`s.
+
+Before:
+```typescript
+import createLogger from '@seek/logger';
+import Koa from 'koa';
+import { RequestLogging } from 'seek-koala';
+const rootLogger = createLogger();
+const contextLogger = (ctx: Context) =>
+  rootLogger.child(RequestLogging.contextFields(ctx));
+const app = new Koa().use((ctx) => {
+  rootLogger.info('Has no context');
+  contextLogger(ctx).info('Has context');
+});
+```
+After:
+```typescript
+import createLogger from '@seek/logger';
+import Koa from 'koa';
+import { RequestLogging } from 'seek-koala';
+const { createContextMiddleware, mixin } =
+  RequestLogging.createContextStorage();
+const contextMiddleware = createContextMiddleware();
+const logger = createLogger({ mixin });
+const app = new Koa().use(contextMiddleware).use((ctx) => {
+  logger.info('Has context');
+});
+```

--- a/.changeset/olive-worms-run.md
+++ b/.changeset/olive-worms-run.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/koa-rest-api: Use [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html#asynchronous-context-tracking) to track logger context
+template/koa-rest-api: Use `createContextStorage` from seek-koala to track logger context

--- a/.changeset/olive-worms-run.md
+++ b/.changeset/olive-worms-run.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/koa-rest-api: Use AsyncLocalStorage to track logger context
+template/koa-rest-api: Use [AsyncLocalStorage](https://nodejs.org/docs/latest-v16.x/api/async_context.html#asynchronous-context-tracking) to track logger context

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![GitHub Release](https://github.com/seek-oss/skuba/workflows/Release/badge.svg?branch=master)](https://github.com/seek-oss/skuba/actions?query=workflow%3ARelease)
 [![GitHub Validate](https://github.com/seek-oss/skuba/workflows/Validate/badge.svg?branch=master)](https://github.com/seek-oss/skuba/actions?query=workflow%3AValidate)
-[![Node.js version](https://img.shields.io/badge/node-%3E%3D%2012-brightgreen)](https://nodejs.org/en/)
+[![Node.js version](https://img.shields.io/badge/node-%3E%3D%2014.18-brightgreen)](https://nodejs.org/en/)
 [![npm package](https://img.shields.io/npm/v/skuba)](https://www.npmjs.com/package/skuba)
 
 ---

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -15,7 +15,7 @@
     "runtypes": "^6.4.1",
     "runtypes-filter": "^0.6.0",
     "seek-datadog-custom-metrics": "^4.0.0",
-    "seek-koala": "^5.1.0",
+    "seek-koala": "^5.2.0",
     "skuba-dive": "^2.0.0",
     "uuid": "^8.3.2"
   },

--- a/template/koa-rest-api/src/api/jobs/getJobs.ts
+++ b/template/koa-rest-api/src/api/jobs/getJobs.ts
@@ -1,4 +1,4 @@
-import { contextLogger } from 'src/framework/logging';
+import { logger } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 import * as storage from 'src/storage/jobs';
 import { Middleware } from 'src/types/koa';
@@ -7,7 +7,7 @@ export const getJobsHandler: Middleware = async (ctx) => {
   const jobs = await storage.readJobs();
 
   // no PII in these jobs
-  contextLogger(ctx).debug({ jobs }, 'read jobs');
+  logger.debug({ jobs }, 'read jobs');
 
   metricsClient.increment('job.reads', jobs.length);
 

--- a/template/koa-rest-api/src/api/jobs/postJob.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.ts
@@ -1,4 +1,4 @@
-import { contextLogger } from 'src/framework/logging';
+import { logger } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 import { validateRequestBody } from 'src/framework/validation';
 import * as storage from 'src/storage/jobs';
@@ -11,7 +11,7 @@ export const postJobHandler: Middleware = async (ctx) => {
   const job = await storage.createJob(jobInput);
 
   // no PII in these jobs
-  contextLogger(ctx).debug({ job }, 'created job');
+  logger.debug({ job }, 'created job');
 
   metricsClient.increment('job.creations');
 

--- a/template/koa-rest-api/src/framework/logging.ts
+++ b/template/koa-rest-api/src/framework/logging.ts
@@ -9,9 +9,7 @@ import { Middleware } from 'src/types/koa';
 export const loggingContext = new AsyncLocalStorage<RequestLogging.Fields>();
 
 export const loggingContextMiddleware: Middleware = async (ctx, next) => {
-  await loggingContext.run(RequestLogging.contextFields(ctx), async () =>
-    next(),
-  );
+  await loggingContext.run(RequestLogging.contextFields(ctx), () => next());
 };
 
 export const logger = createLogger({

--- a/template/koa-rest-api/src/framework/logging.ts
+++ b/template/koa-rest-api/src/framework/logging.ts
@@ -1,16 +1,12 @@
-import { AsyncLocalStorage } from 'async_hooks';
-
 import createLogger from '@seek/logger';
 import { RequestLogging } from 'seek-koala';
 
 import { config } from 'src/config';
-import { Middleware } from 'src/types/koa';
 
-const loggerContext = new AsyncLocalStorage<RequestLogging.Fields>();
+const { createContextMiddleware, mixin } =
+  RequestLogging.createContextStorage();
 
-export const loggerContextMiddleware: Middleware = async (ctx, next) => {
-  await loggerContext.run(RequestLogging.contextFields(ctx), next);
-};
+export const contextMiddleware = createContextMiddleware();
 
 export const logger = createLogger({
   base: {
@@ -18,9 +14,7 @@ export const logger = createLogger({
     version: config.version,
   },
 
-  mixin() {
-    return loggerContext.getStore() ?? {};
-  },
+  mixin,
 
   level: config.logLevel,
 

--- a/template/koa-rest-api/src/framework/logging.ts
+++ b/template/koa-rest-api/src/framework/logging.ts
@@ -9,7 +9,7 @@ import { Middleware } from 'src/types/koa';
 const loggerContext = new AsyncLocalStorage<RequestLogging.Fields>();
 
 export const loggerContextMiddleware: Middleware = async (ctx, next) => {
-  await loggerContext.run(RequestLogging.contextFields(ctx), () => next());
+  await loggerContext.run(RequestLogging.contextFields(ctx), next);
 };
 
 export const logger = createLogger({

--- a/template/koa-rest-api/src/framework/logging.ts
+++ b/template/koa-rest-api/src/framework/logging.ts
@@ -6,10 +6,10 @@ import { RequestLogging } from 'seek-koala';
 import { config } from 'src/config';
 import { Middleware } from 'src/types/koa';
 
-export const loggingContext = new AsyncLocalStorage<RequestLogging.Fields>();
+const loggerContext = new AsyncLocalStorage<RequestLogging.Fields>();
 
-export const loggingContextMiddleware: Middleware = async (ctx, next) => {
-  await loggingContext.run(RequestLogging.contextFields(ctx), () => next());
+export const loggerContextMiddleware: Middleware = async (ctx, next) => {
+  await loggerContext.run(RequestLogging.contextFields(ctx), () => next());
 };
 
 export const logger = createLogger({
@@ -19,7 +19,7 @@ export const logger = createLogger({
   },
 
   mixin() {
-    return loggingContext.getStore() ?? {};
+    return loggerContext.getStore() ?? {};
   },
 
   level: config.logLevel,

--- a/template/koa-rest-api/src/framework/metrics.ts
+++ b/template/koa-rest-api/src/framework/metrics.ts
@@ -3,9 +3,9 @@ import { createStatsDClient } from 'seek-datadog-custom-metrics';
 
 import { config } from 'src/config';
 
-import { rootLogger } from './logging';
+import { logger } from './logging';
 
 /* istanbul ignore next: StatsD client is not our responsibility */
 export const metricsClient = createStatsDClient(StatsD, config, (err) =>
-  rootLogger.error({ err }, 'StatsD error'),
+  logger.error({ err }, 'StatsD error'),
 );

--- a/template/koa-rest-api/src/framework/server.test.ts
+++ b/template/koa-rest-api/src/framework/server.test.ts
@@ -1,6 +1,6 @@
 import Router from '@koa/router';
 
-import { rootLogger } from 'src/testing/logging';
+import { logger } from 'src/testing/logging';
 import { metricsClient } from 'src/testing/metrics';
 import { agentFromRouter } from 'src/testing/server';
 import { chance } from 'src/testing/types';
@@ -15,10 +15,10 @@ const router = new Router()
 const agent = agentFromRouter(router);
 
 describe('createApp', () => {
-  beforeAll(rootLogger.spy);
+  beforeAll(logger.spy);
 
   afterEach(metricsClient.clear);
-  afterEach(rootLogger.clear);
+  afterEach(logger.clear);
 
   it('handles root route', async () => {
     middleware.mockImplementation((ctx) => (ctx.body = ''));
@@ -29,9 +29,9 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).not.toBeCalled();
+    expect(logger.error).not.toBeCalled();
 
-    expect(rootLogger.info).not.toBeCalled();
+    expect(logger.info).not.toBeCalled();
 
     metricsClient.expectTagSubset(['env:test', 'version:test']);
     metricsClient.expectTagSubset([
@@ -51,9 +51,9 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).not.toBeCalled();
+    expect(logger.error).not.toBeCalled();
 
-    expect(rootLogger.info).not.toBeCalled();
+    expect(logger.info).not.toBeCalled();
 
     metricsClient.expectTagSubset([
       'http_method:put',
@@ -72,9 +72,9 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).not.toBeCalled();
+    expect(logger.error).not.toBeCalled();
 
-    expect(rootLogger.info).nthCalledWith(
+    expect(logger.info).nthCalledWith(
       1,
       expect.objectContaining({ status: 404 }),
       'Client error',
@@ -102,9 +102,9 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).not.toBeCalled();
+    expect(logger.error).not.toBeCalled();
 
-    expect(rootLogger.info).nthCalledWith(
+    expect(logger.info).nthCalledWith(
       1,
       expect.objectContaining({ status: 400 }),
       'Client error',
@@ -129,9 +129,9 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).not.toBeCalled();
+    expect(logger.error).not.toBeCalled();
 
-    expect(rootLogger.info).nthCalledWith(
+    expect(logger.info).nthCalledWith(
       1,
       expect.objectContaining({ err: expect.any(Error), status: 400 }),
       'Client error',
@@ -156,13 +156,13 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).nthCalledWith(
+    expect(logger.error).nthCalledWith(
       1,
       expect.objectContaining({ err: expect.any(Error), status: 500 }),
       'Server error',
     );
 
-    expect(rootLogger.info).not.toBeCalled();
+    expect(logger.info).not.toBeCalled();
 
     metricsClient.expectTagSubset([
       'http_method:get',
@@ -185,13 +185,13 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).nthCalledWith(
+    expect(logger.error).nthCalledWith(
       1,
       expect.objectContaining({ err, status: 500 }),
       'Server error',
     );
 
-    expect(rootLogger.info).not.toBeCalled();
+    expect(logger.info).not.toBeCalled();
 
     metricsClient.expectTagSubset([
       'http_method:get',
@@ -213,13 +213,13 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).nthCalledWith(
+    expect(logger.error).nthCalledWith(
       1,
       expect.objectContaining({ err: null, status: 500 }),
       'Server error',
     );
 
-    expect(rootLogger.info).not.toBeCalled();
+    expect(logger.info).not.toBeCalled();
 
     metricsClient.expectTagSubset([
       'http_method:get',
@@ -242,13 +242,13 @@ describe('createApp', () => {
       .expect('server', /.+/)
       .expect('x-api-version', /.+/);
 
-    expect(rootLogger.error).nthCalledWith(
+    expect(logger.error).nthCalledWith(
       1,
       expect.objectContaining({ err, status: 500 }),
       'Server error',
     );
 
-    expect(rootLogger.info).not.toBeCalled();
+    expect(logger.info).not.toBeCalled();
 
     metricsClient.expectTagSubset([
       'http_method:get',

--- a/template/koa-rest-api/src/framework/server.ts
+++ b/template/koa-rest-api/src/framework/server.ts
@@ -9,7 +9,7 @@ import {
 } from 'seek-koala';
 
 import { config } from 'src/config';
-import { logger, loggerContextMiddleware } from 'src/framework/logging';
+import { logger, contextMiddleware } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 
 const metrics = MetricsMiddleware.create(
@@ -43,7 +43,7 @@ export const createApp = <State, Context>(
     // https://github.com/seek-oss/koala/tree/master/src/secureHeaders
     // https://github.com/venables/koa-helmet
     // .use(SecureHeaders.middleware)
-    .use(loggerContextMiddleware)
+    .use(contextMiddleware)
     .use(requestLogging)
     .use(metrics)
     .use(ErrorMiddleware.handle)

--- a/template/koa-rest-api/src/framework/server.ts
+++ b/template/koa-rest-api/src/framework/server.ts
@@ -9,7 +9,7 @@ import {
 } from 'seek-koala';
 
 import { config } from 'src/config';
-import { logger, contextMiddleware } from 'src/framework/logging';
+import { contextMiddleware, logger } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 
 const metrics = MetricsMiddleware.create(

--- a/template/koa-rest-api/src/framework/server.ts
+++ b/template/koa-rest-api/src/framework/server.ts
@@ -9,7 +9,7 @@ import {
 } from 'seek-koala';
 
 import { config } from 'src/config';
-import { rootLogger } from 'src/framework/logging';
+import { logger, loggingContextMiddleware } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 
 const metrics = MetricsMiddleware.create(
@@ -26,8 +26,8 @@ const requestLogging = RequestLogging.createMiddleware((ctx, fields, err) => {
   }
 
   return ctx.status < 500
-    ? rootLogger.info(fields, 'Client error')
-    : rootLogger.error(fields, 'Server error');
+    ? logger.info(fields, 'Client error')
+    : logger.error(fields, 'Server error');
 });
 
 const version = VersionMiddleware.create({
@@ -43,6 +43,7 @@ export const createApp = <State, Context>(
     // https://github.com/seek-oss/koala/tree/master/src/secureHeaders
     // https://github.com/venables/koa-helmet
     // .use(SecureHeaders.middleware)
+    .use(loggingContextMiddleware)
     .use(requestLogging)
     .use(metrics)
     .use(ErrorMiddleware.handle)

--- a/template/koa-rest-api/src/framework/server.ts
+++ b/template/koa-rest-api/src/framework/server.ts
@@ -9,7 +9,7 @@ import {
 } from 'seek-koala';
 
 import { config } from 'src/config';
-import { logger, loggingContextMiddleware } from 'src/framework/logging';
+import { logger, loggerContextMiddleware } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 
 const metrics = MetricsMiddleware.create(
@@ -43,7 +43,7 @@ export const createApp = <State, Context>(
     // https://github.com/seek-oss/koala/tree/master/src/secureHeaders
     // https://github.com/venables/koa-helmet
     // .use(SecureHeaders.middleware)
-    .use(loggingContextMiddleware)
+    .use(loggerContextMiddleware)
     .use(requestLogging)
     .use(metrics)
     .use(ErrorMiddleware.handle)

--- a/template/koa-rest-api/src/listen.ts
+++ b/template/koa-rest-api/src/listen.ts
@@ -2,7 +2,7 @@ import './register';
 
 import app from './app';
 import { config } from './config';
-import { rootLogger } from './framework/logging';
+import { logger } from './framework/logging';
 
 // This implements a minimal version of `koa-cluster`'s interface
 // If your application is deployed with more than 1 vCPU you can delete this
@@ -12,6 +12,6 @@ const listener = app.listen(config.port, () => {
   const address = listener.address();
 
   if (typeof address === 'object' && address) {
-    rootLogger.debug(`listening on port ${address.port}`);
+    logger.debug(`listening on port ${address.port}`);
   }
 });

--- a/template/koa-rest-api/src/testing/logging.ts
+++ b/template/koa-rest-api/src/testing/logging.ts
@@ -1,31 +1,16 @@
 import * as logging from 'src/framework/logging';
 
-export const contextLogger = {
+export const logger = {
   error: jest.fn(),
   info: jest.fn(),
 
   clear: () => {
-    contextLogger.error.mockClear();
-    contextLogger.info.mockClear();
-  },
-
-  spy: () =>
-    jest.spyOn(logging, 'contextLogger').mockReturnValue(contextLogger as any),
-};
-
-export const rootLogger = {
-  error: jest.fn(),
-  info: jest.fn(),
-
-  clear: () => {
-    rootLogger.error.mockClear();
-    rootLogger.info.mockClear();
+    logger.error.mockClear();
+    logger.info.mockClear();
   },
 
   spy: () => {
-    jest
-      .spyOn(logging.rootLogger, 'error')
-      .mockImplementation(rootLogger.error);
-    jest.spyOn(logging.rootLogger, 'info').mockImplementation(rootLogger.info);
+    jest.spyOn(logging.logger, 'error').mockImplementation(logger.error);
+    jest.spyOn(logging.logger, 'info').mockImplementation(logger.info);
   },
 };


### PR DESCRIPTION
This might be a little radical but overall improves the DX and allows users to not need to worry about passing a context object around and/or a context logger around the codebase.

Some local testing confirms `x-request-id` is still present:

<img width="545" alt="image" src="https://user-images.githubusercontent.com/18017094/168406529-002ab91e-b3be-4754-b857-dd4e80d9fee6.png">

Performance hit of ~1.75% according to this which is negligible

https://github.com/nodejs/node/issues/34493#issuecomment-845094849