### PR TITLE
Change deployment method to `direct`

### DIFF
--- a/.changeset/loud-kiwis-mate.md
+++ b/.changeset/loud-kiwis-mate.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/lambda-sqs-worker: Change deployment method to `direct`

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -27,6 +27,7 @@ provider:
   region: ap-southeast-2
   runtime: nodejs16.x
   architecture: arm64
+  deploymentMethod: direct
   stackName: ${self:service}
   stage: ${env:ENVIRONMENT}
   deploymentBucket:


### PR DESCRIPTION
https://www.serverless.com/framework/docs/providers/aws/guide/deploying/#

```
Direct deployments are faster and have no downsides (unless you specifically use the generated change sets). They will become the default in Serverless Framework 4.
```