### PR TITLE
Remove Unnecessary Serverless Permission

### DIFF
--- a/.changeset/sharp-ads-clean.md
+++ b/.changeset/sharp-ads-clean.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 template/lambda-sqs-worker: Remove unnecessary IAM permission

--- a/.changeset/sharp-ads-clean.md
+++ b/.changeset/sharp-ads-clean.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+template/lambda-sqs-worker: Remove unnecessary IAM permission

--- a/template/lambda-sqs-worker/serverless.yml
+++ b/template/lambda-sqs-worker/serverless.yml
@@ -54,9 +54,6 @@ provider:
         - Action: sns:Publish
           Effect: Allow
           Resource: !Ref DestinationTopic
-        - Action: sqs:SendMessage*
-          Effect: Allow
-          Resource: !GetAtt DeadLetterQueue.Arn
   stackTags:
     # TODO: add data classification tags
     # https://rfc.skinfra.xyz/RFC019-AWS-Tagging-Standard.html#seekdataconsumers


### PR DESCRIPTION
This perm is only needed if we configure asynchronous invocation and use the `onError` configuration but SQS is a synchronous invocation and SQS handles the dead-lettering itself.