### PR TITLE
Prefer verbose failure message in exec annotations

### DIFF
--- a/.changeset/rich-spoons-exist.md
+++ b/.changeset/rich-spoons-exist.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+test: Prefer verbose failure message in execution error annotations

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "serialize-error": "^8.0.1",
     "simple-git": "^3.5.0",
     "strip-ansi": "^6.0.1",
+    "ts-dedent": "^2.2.0",
     "ts-jest": "^28.0.2",
     "ts-node": "^10.7.0",
     "ts-node-dev": "^2.0.0",

--- a/src/cli/test/reporters/github/annotations.test.ts
+++ b/src/cli/test/reporters/github/annotations.test.ts
@@ -162,6 +162,7 @@ it('should create annotation from Jest exec error', () => {
       '\x1B[7m \x1B[0m \x1B[91m                  ~~~\x1B[0m',
   } as SerializableError;
 
+  // Prefer `failureMessage` for its "Test suite failed to run" headline
   const testResult: TestResult = {
     ...COMMON_TEST_RESULT_FIELDS,
     failureMessage:
@@ -173,6 +174,38 @@ it('should create annotation from Jest exec error', () => {
 
   const annotations = createAnnotations([testResult]);
   expect(annotations).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "annotation_level": "failure",
+        "end_line": 1,
+        "message": "  ● Test suite failed to run
+
+        src/test.ts:1:1 - error TS6133: 'a' is declared but its value is never read.
+
+        1 import { a } from 'b';
+          ~~~~~~~~~~~~~~~~~~~~~~
+        src/test.ts:1:19 - error TS2307: Cannot find module 'b' or its corresponding type declarations.
+
+        1 import { a } from 'b';
+                            ~~~
+    ",
+        "path": "src/test.test.ts",
+        "start_line": 1,
+        "title": "Jest",
+      },
+    ]
+  `);
+
+  // Fall back on the off chance we have no `failureMessage`
+  const testResultWithoutFailureMessage: TestResult = {
+    ...testResult,
+    failureMessage: null,
+  };
+
+  const annotationsForNoFailureMessage = createAnnotations([
+    testResultWithoutFailureMessage,
+  ]);
+  expect(annotationsForNoFailureMessage).toMatchInlineSnapshot(`
     Array [
       Object {
         "annotation_level": "failure",

--- a/src/cli/test/reporters/github/annotations.test.ts
+++ b/src/cli/test/reporters/github/annotations.test.ts
@@ -180,15 +180,14 @@ it('should create annotation from Jest exec error', () => {
         "end_line": 1,
         "message": "  ● Test suite failed to run
 
-        src/test.ts:1:1 - error TS6133: 'a' is declared but its value is never read.
+    src/test.ts:1:1 - error TS6133: 'a' is declared but its value is never read.
 
-        1 import { a } from 'b';
-          ~~~~~~~~~~~~~~~~~~~~~~
-        src/test.ts:1:19 - error TS2307: Cannot find module 'b' or its corresponding type declarations.
+    1 import { a } from 'b';
+      ~~~~~~~~~~~~~~~~~~~~~~
+    src/test.ts:1:19 - error TS2307: Cannot find module 'b' or its corresponding type declarations.
 
-        1 import { a } from 'b';
-                            ~~~
-    ",
+    1 import { a } from 'b';
+                        ~~~",
         "path": "src/test.test.ts",
         "start_line": 1,
         "title": "Jest",

--- a/src/cli/test/reporters/github/annotations.ts
+++ b/src/cli/test/reporters/github/annotations.ts
@@ -52,7 +52,9 @@ export const createAnnotations = (
         path: path.relative(cwd, testResult.testFilePath),
         start_line: 1,
         end_line: 1,
-        message: stripAnsi(testResult.testExecError.message),
+        message: stripAnsi(
+          testResult.failureMessage ?? testResult.testExecError.message,
+        ),
         title: 'Jest',
       };
     }

--- a/src/cli/test/reporters/github/annotations.ts
+++ b/src/cli/test/reporters/github/annotations.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import type { TestResult } from '@jest/test-result';
 import stripAnsi from 'strip-ansi';
+import dedent from 'ts-dedent';
 
 import type * as GitHub from '../../../../api/github';
 
@@ -53,7 +54,9 @@ export const createAnnotations = (
         start_line: 1,
         end_line: 1,
         message: stripAnsi(
-          testResult.failureMessage ?? testResult.testExecError.message,
+          testResult.failureMessage
+            ? dedent(testResult.failureMessage)
+            : testResult.testExecError.message,
         ),
         title: 'Jest',
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7624,6 +7624,11 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
+ts-dedent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
+
 ts-jest@^28.0.2:
   version "28.0.5"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-28.0.5.tgz#31776f768fba6dfc8c061d488840ed0c8eeac8b9"


### PR DESCRIPTION
I think the "Test suite failed to run" headline here could be useful. The indentation looks a bit annoying though; should I dedent the paragraph?