### PR TITLE
Remove tty from serverless template

### DIFF
--- a/.changeset/rare-walls-draw.md
+++ b/.changeset/rare-walls-draw.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/lambda-sqs-worker: Remove tty disable from pipeline

--- a/template/lambda-sqs-worker/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker/.buildkite/pipeline.yml
@@ -35,7 +35,6 @@ configs:
         - docker-compose#v3.10.0:
             dependencies: false
             run: app
-            tty: false
       retry:
         manual:
           # Only use this if you need to roll back a deployment ASAP.


### PR DESCRIPTION
Noticed one of my repos working fine without this.

Looks like they disable interactivity when the process.env.CI environment variable is detected so this is no longer needed.

https://github.com/serverless/utils/pull/162