### PR TITLE
make linter ignore cdk.out directory

### DIFF
--- a/.changeset/bright-actors-sneeze.md
+++ b/.changeset/bright-actors-sneeze.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+Add ignore cdk.out directory linting rule

--- a/.changeset/bright-actors-sneeze.md
+++ b/.changeset/bright-actors-sneeze.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-Add ignore cdk.out directory linting rule
+template: Add ignore cdk.out directory linting rule

--- a/.changeset/bright-actors-sneeze.md
+++ b/.changeset/bright-actors-sneeze.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template: Add ignore cdk.out directory linting rule
+template: Ignore linting on `cdk.out` directory

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,8 +2,8 @@
 .idea/
 .serverless/
 .vscode/
-node_modules*/
 cdk.out/
+node_modules*/
 
 /coverage*/
 /dist*/

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,12 +3,12 @@
 .serverless/
 .vscode/
 node_modules*/
+cdk.out/
 
 /coverage*/
 /dist*/
 /lib*/
 /tmp*/
-cdk.out*/
 # end managed by skuba
 
 /integration/base/

--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@ node_modules*/
 /dist*/
 /lib*/
 /tmp*/
+cdk.out*/
 # end managed by skuba
 
 /integration/base/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 .serverless/
 .vscode/
 node_modules*/
+cdk.out/
 
 /coverage*/
 /dist*/
@@ -14,7 +15,6 @@ node_modules*/
 /.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
-cdk.out*/
 # end managed by skuba
 
 /integration/base/

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,8 +2,8 @@
 .idea/
 .serverless/
 .vscode/
-node_modules*/
 cdk.out/
+node_modules*/
 
 /coverage*/
 /dist*/

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ node_modules*/
 /.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
+cdk.out*/
 # end managed by skuba
 
 /integration/base/

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -35,6 +35,7 @@ node_modules*/
 /dist*/
 /lib*/
 /tmp*/
+cdk.out*/
 # end managed by skuba
 ",
     "operation": "A",
@@ -96,6 +97,7 @@ node_modules*/
 /.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
+cdk.out*/
 # end managed by skuba
 ",
     "operation": "A",

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -30,12 +30,12 @@ yarn-error.log
 .serverless/
 .vscode/
 node_modules*/
+cdk.out/
 
 /coverage*/
 /dist*/
 /lib*/
 /tmp*/
-cdk.out*/
 # end managed by skuba
 ",
     "operation": "A",
@@ -86,6 +86,7 @@ yarn-error.log
 .serverless/
 .vscode/
 node_modules*/
+cdk.out/
 
 /coverage*/
 /dist*/
@@ -97,7 +98,6 @@ node_modules*/
 /.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
-cdk.out*/
 # end managed by skuba
 ",
     "operation": "A",

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -29,8 +29,8 @@ yarn-error.log
 .idea/
 .serverless/
 .vscode/
-node_modules*/
 cdk.out/
+node_modules*/
 
 /coverage*/
 /dist*/
@@ -85,8 +85,8 @@ yarn-error.log
 .idea/
 .serverless/
 .vscode/
-node_modules*/
 cdk.out/
+node_modules*/
 
 /coverage*/
 /dist*/

--- a/template/base/_.eslintignore
+++ b/template/base/_.eslintignore
@@ -8,4 +8,5 @@ node_modules*/
 /dist*/
 /lib*/
 /tmp*/
+cdk.out*/
 # end managed by skuba

--- a/template/base/_.eslintignore
+++ b/template/base/_.eslintignore
@@ -2,8 +2,8 @@
 .idea/
 .serverless/
 .vscode/
-node_modules*/
 cdk.out/
+node_modules*/
 
 /coverage*/
 /dist*/

--- a/template/base/_.eslintignore
+++ b/template/base/_.eslintignore
@@ -3,10 +3,10 @@
 .serverless/
 .vscode/
 node_modules*/
+cdk.out/
 
 /coverage*/
 /dist*/
 /lib*/
 /tmp*/
-cdk.out*/
 # end managed by skuba

--- a/template/base/_.prettierignore
+++ b/template/base/_.prettierignore
@@ -3,6 +3,7 @@
 .serverless/
 .vscode/
 node_modules*/
+cdk.out/
 
 /coverage*/
 /dist*/
@@ -14,5 +15,4 @@ node_modules*/
 /.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
-cdk.out*/
 # end managed by skuba

--- a/template/base/_.prettierignore
+++ b/template/base/_.prettierignore
@@ -2,8 +2,8 @@
 .idea/
 .serverless/
 .vscode/
-node_modules*/
 cdk.out/
+node_modules*/
 
 /coverage*/
 /dist*/

--- a/template/base/_.prettierignore
+++ b/template/base/_.prettierignore
@@ -14,4 +14,5 @@ node_modules*/
 /.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
+cdk.out*/
 # end managed by skuba


### PR DESCRIPTION
Add ignore cdk.out directory linting rule.

`yarn format` or `yarn lint` will probably trigger node heap out of memory issues otherwise.