### PR TITLE
Sort `package.json` based on the well-known package.json keys

### DIFF
--- a/.changeset/twenty-pigs-sparkle.md
+++ b/.changeset/twenty-pigs-sparkle.md
@@ -1,0 +1,5 @@
+---
+'skuba': minor
+---
+
+**configure, init:** Format `package.json` with [sort-package-json](https://github.com/keithamus/sort-package-json)

--- a/.changeset/twenty-pigs-sparkle.md
+++ b/.changeset/twenty-pigs-sparkle.md
@@ -2,4 +2,4 @@
 'skuba': minor
 ---
 
-**configure, init:** Format `package.json` with [sort-package-json](https://github.com/keithamus/sort-package-json)
+configure, init: Format `package.json` with [sort-package-json](https://github.com/keithamus/sort-package-json)

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "semantic-release": "^19.0.0",
     "serialize-error": "^8.0.1",
     "simple-git": "^3.5.0",
+    "sort-package-json": "^1.57.0",
     "strip-ansi": "^6.0.1",
     "ts-dedent": "^2.2.0",
     "ts-jest": "^28.0.2",

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -139,8 +139,8 @@ export default Jest.mergePreset({
   },
   "package.json": Object {
     "data": "{
-  \\"license\\": \\"UNLICENSED\\",
   \\"private\\": true,
+  \\"license\\": \\"UNLICENSED\\",
   \\"scripts\\": {
     \\"build\\": \\"skuba build\\",
     \\"format\\": \\"skuba format\\",

--- a/src/cli/configure/ensureTemplateCompletion.ts
+++ b/src/cli/configure/ensureTemplateCompletion.ts
@@ -11,7 +11,7 @@ import { ensureTemplateConfigDeletion } from '../../utils/template';
 import { hasStringProp } from '../../utils/validation';
 import { getTemplateConfig, runForm } from '../init/getConfig';
 
-import { formatObject } from './processing/json';
+import { formatPackage } from './processing/package';
 
 interface Props {
   destinationRoot: string;
@@ -41,7 +41,7 @@ export const ensureTemplateCompletion = async ({
     name: 'customAnswers',
   });
 
-  const updatedPackageJson = formatObject(manifest.packageJson);
+  const updatedPackageJson = formatPackage(manifest.packageJson);
   const packageJsonFilepath = path.join(destinationRoot, 'package.json');
   await fs.promises.writeFile(packageJsonFilepath, updatedPackageJson);
 

--- a/src/cli/configure/processing/package.test.ts
+++ b/src/cli/configure/processing/package.test.ts
@@ -87,18 +87,18 @@ describe('withPackage', () => {
       })(
         JSON.stringify({
           description: 'My Package',
-          name: 'my-package',
           readme: 'https://github.com/my-org/my-package#readme',
           version: '0.1.0',
+          name: 'my-package',
         }),
       ),
     ).toMatchInlineSnapshot(`
       "{
-        \\"$name\\": \\"unit-test\\",
-        \\"description\\": \\"My Package\\",
         \\"name\\": \\"my-package\\",
-        \\"readme\\": \\"https://github.com/my-org/my-package#readme\\",
-        \\"version\\": \\"0.1.0\\"
+        \\"version\\": \\"0.1.0\\",
+        \\"description\\": \\"My Package\\",
+        \\"$name\\": \\"unit-test\\",
+        \\"readme\\": \\"https://github.com/my-org/my-package#readme\\"
       }
       "
     `));
@@ -116,7 +116,6 @@ describe('withPackage', () => {
             b: '2',
             a: '1',
           },
-          files: ['b', 'a'],
           scripts: {
             prebuild: 'rm -rf system32',
             build: 'npm install freebsd',
@@ -125,10 +124,19 @@ describe('withPackage', () => {
             version: '1.0.0',
             type: 'application',
           },
+          files: ['b', 'a'],
         }),
       ),
     ).toMatchInlineSnapshot(`
       "{
+        \\"files\\": [
+          \\"b\\",
+          \\"a\\"
+        ],
+        \\"scripts\\": {
+          \\"prebuild\\": \\"rm -rf system32\\",
+          \\"build\\": \\"npm install freebsd\\"
+        },
         \\"dependencies\\": {
           \\"a\\": \\"1\\",
           \\"b\\": \\"2\\"
@@ -138,17 +146,9 @@ describe('withPackage', () => {
           \\"d\\": \\"4\\",
           \\"e\\": \\"5\\"
         },
-        \\"files\\": [
-          \\"b\\",
-          \\"a\\"
-        ],
-        \\"scripts\\": {
-          \\"prebuild\\": \\"rm -rf system32\\",
-          \\"build\\": \\"npm install freebsd\\"
-        },
         \\"skuba\\": {
-          \\"type\\": \\"application\\",
-          \\"version\\": \\"1.0.0\\"
+          \\"version\\": \\"1.0.0\\",
+          \\"type\\": \\"application\\"
         }
       }
       "

--- a/src/cli/configure/processing/package.test.ts
+++ b/src/cli/configure/processing/package.test.ts
@@ -111,6 +111,9 @@ describe('withPackage', () => {
             c: '3',
             e: '5',
             d: '4',
+            '@types/koa__router': '^8.0.8',
+            '@types/koa-bodyparser': '^5.0.2',
+            '@types/koa': '^2.13.4',
           },
           dependencies: {
             b: '2',
@@ -146,6 +149,9 @@ describe('withPackage', () => {
           \\"b\\": \\"2\\"
         },
         \\"devDependencies\\": {
+          \\"@types/koa\\": \\"^2.13.4\\",
+          \\"@types/koa-bodyparser\\": \\"^5.0.2\\",
+          \\"@types/koa__router\\": \\"^8.0.8\\",
           \\"c\\": \\"3\\",
           \\"d\\": \\"4\\",
           \\"e\\": \\"5\\"

--- a/src/cli/configure/processing/package.test.ts
+++ b/src/cli/configure/processing/package.test.ts
@@ -117,6 +117,8 @@ describe('withPackage', () => {
             a: '1',
           },
           scripts: {
+            lint: 'echo Linting',
+            prelint: 'echo Prepare for lint-off',
             prebuild: 'rm -rf system32',
             build: 'npm install freebsd',
           },
@@ -135,7 +137,9 @@ describe('withPackage', () => {
         ],
         \\"scripts\\": {
           \\"prebuild\\": \\"rm -rf system32\\",
-          \\"build\\": \\"npm install freebsd\\"
+          \\"build\\": \\"npm install freebsd\\",
+          \\"prelint\\": \\"echo Prepare for lint-off\\",
+          \\"lint\\": \\"echo Linting\\"
         },
         \\"dependencies\\": {
           \\"a\\": \\"1\\",

--- a/src/cli/configure/processing/package.ts
+++ b/src/cli/configure/processing/package.ts
@@ -9,10 +9,7 @@ import { formatPrettier } from './prettier';
 export const formatPackage = (rawData: PackageJson) => {
   normalizeData(rawData);
 
-  // we don't want to sort scripts, so make a copy to overwrite the sorted scripts
-  const scripts = rawData.scripts && { ...rawData.scripts };
   const data = sortPackageJson(rawData);
-  data.scripts = scripts;
 
   // normalize-package-data fields that aren't useful for applications
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,6 +1521,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/glob@^7.1.1":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.5.tgz#21ffba0d98da4350db64891f92a9e5db3cdb4e15"
@@ -1660,6 +1668,11 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
+
+"@types/minimatch@*":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.0.tgz#c3018161691376002f8a22ebb87f341e0dba3219"
+  integrity sha512-0RJHq5FqDWo17kdHe+SMDJLfxmLaqHbWnqZ6gNKzDvStUlrmx/eKIY17+ifLS1yybo7X86aUshQMlittDOVNnw==
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -3008,7 +3021,7 @@ detect-indent@^6.0.0:
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
   integrity sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==
 
-detect-newline@^3.0.0:
+detect-newline@3.1.0, detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
@@ -3598,7 +3611,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.9:
+fast-glob@^3.0.3, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -3948,6 +3961,11 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+git-hooks-list@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/git-hooks-list/-/git-hooks-list-1.0.3.tgz#be5baaf78203ce342f2f844a9d2b03dba1b45156"
+  integrity sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==
+
 git-log-parser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/git-log-parser/-/git-log-parser-1.2.0.tgz#2e6a4c1b13fc00028207ba795a7ac31667b9fd4a"
@@ -4015,6 +4033,20 @@ globals@^13.15.0:
   integrity sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==
   dependencies:
     type-fest "^0.20.2"
+
+globby@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.0.tgz#abfcd0630037ae174a88590132c2f6804e291072"
+  integrity sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
 
 globby@^11.0.0, globby@^11.0.1, globby@^11.1.0:
   version "11.1.0"
@@ -4262,7 +4294,7 @@ ignore-walk@^5.0.1:
   dependencies:
     minimatch "^5.0.1"
 
-ignore@^5.0.0, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.0.0, ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -4524,6 +4556,11 @@ is-path-inside@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-plain-obj@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
+  integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
 is-plain-obj@^1.1.0:
   version "1.1.0"
@@ -5717,7 +5754,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0, merge2@^1.4.1:
+merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -7791,6 +7828,23 @@ socks@^2.6.2:
   dependencies:
     ip "^2.0.0"
     smart-buffer "^4.2.0"
+
+sort-object-keys@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.3.tgz#bff833fe85cab147b34742e45863453c1e190b45"
+  integrity sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==
+
+sort-package-json@^1.57.0:
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.57.0.tgz#e95fb44af8ede0bb6147e3f39258102d4bb23fc4"
+  integrity sha512-FYsjYn2dHTRb41wqnv+uEqCUvBpK3jZcTp9rbz2qDTmel7Pmdtf+i2rLaaPMRZeSVM60V3Se31GyWFpmKs4Q5Q==
+  dependencies:
+    detect-indent "^6.0.0"
+    detect-newline "3.1.0"
+    git-hooks-list "1.0.3"
+    globby "10.0.0"
+    is-plain-obj "2.1.0"
+    sort-object-keys "^1.1.3"
 
 source-map-support@0.5.13:
   version "0.5.13"


### PR DESCRIPTION
This uses [sort-package-json](https://github.com/keithamus/sort-package-json).

> ### How does it sort?
>
> It sorts using [`sort-object-keys`](http://github.com/keithamus/sort-object-keys). It sorts using the well-known keys of a package.json. For the full list check the [default rules](./defaultRules.md). It sorts sub-keys too - sometimes by a well-known order, other times alphabetically. The initial order was derived from the [package.json docs](https://docs.npmjs.com/files/package.json) with a few extras added for good measure.

Re: #107, sorting the `scripts` key [can also be enabled](https://github.com/keithamus/sort-package-json/blob/master/defaultRules.md#scripts). It says only the scripts in that list are sorted, but I tested with non-standard ones and it still worked — see latest commit 0cd952110ec9b7845116aedfd4c74d8ed1050ac4.

> Keys are sorted alphabetically except for [pre/post scripts](https://docs.npmjs.com/cli/v6/using-npm/scripts#pre--post-scripts). Those are placed before and after their corresponding base npm script.

Also fixes #926.
