### PR TITLE
Replace Runtypes with Zod in starter templates

### DIFF
--- a/.changeset/neat-parents-jump.md
+++ b/.changeset/neat-parents-jump.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/lambda-sqs-worker-cdk: Replace Runtypes with Zod as default schema validator

--- a/.changeset/pink-gorillas-repair.md
+++ b/.changeset/pink-gorillas-repair.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/lamda-sqs-worker: Replace Runtypes with Zod as default schema validator
+template/lambda-sqs-worker: Replace Runtypes with Zod as default schema validator

--- a/.changeset/pink-gorillas-repair.md
+++ b/.changeset/pink-gorillas-repair.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/lamda-sqs-worker: Replace Runtypes with Zod as default schema validator

--- a/.changeset/thin-kings-teach.md
+++ b/.changeset/thin-kings-teach.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/koa-rest-api: Replace Runtypes with Zod as default schema validator

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -12,11 +12,10 @@
     "koa": "^2.13.4",
     "koa-bodyparser": "^4.3.0",
     "koa-compose": "^4.2.0",
-    "runtypes": "^6.4.1",
-    "runtypes-filter": "^0.6.0",
     "seek-datadog-custom-metrics": "^4.0.0",
     "seek-koala": "^6.0.0",
-    "skuba-dive": "^2.0.0"
+    "skuba-dive": "^2.0.0",
+    "zod": "3.19.1"
   },
   "devDependencies": {
     "@types/chance": "^1.1.3",

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -15,7 +15,7 @@
     "seek-datadog-custom-metrics": "^4.0.0",
     "seek-koala": "^6.0.0",
     "skuba-dive": "^2.0.0",
-    "zod": "3.19.1"
+    "zod": "^3.19.1"
   },
   "devDependencies": {
     "@types/chance": "^1.1.3",

--- a/template/koa-rest-api/src/api/jobs/postJob.test.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.test.ts
@@ -27,11 +27,17 @@ describe('postJobHandler', () => {
       .expect(422)
       .expect(({ text }) =>
         expect(text).toMatchInlineSnapshot(`
-          "Validation failed:
-          {
-            "hirer": "Expected { id: string; }, but was missing"
-          }.
-          Object should match { hirer: { id: string; }; }"
+          "[
+            {
+              "code": "invalid_type",
+              "expected": "object",
+              "received": "undefined",
+              "path": [
+                "hirer"
+              ],
+              "message": "Required"
+            }
+          ]"
         `),
       );
   });

--- a/template/koa-rest-api/src/api/jobs/postJob.test.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.test.ts
@@ -26,19 +26,9 @@ describe('postJobHandler', () => {
       .send(jobInput)
       .expect(422)
       .expect(({ text }) =>
-        expect(text).toMatchInlineSnapshot(`
-          "[
-            {
-              "code": "invalid_type",
-              "expected": "object",
-              "received": "undefined",
-              "path": [
-                "hirer"
-              ],
-              "message": "Required"
-            }
-          ]"
-        `),
+        expect(text).toMatchInlineSnapshot(
+          `"{"message":"Input validation failed","invalidFields":{"/hirer":"Required"}}"`,
+        ),
       );
   });
 });

--- a/template/koa-rest-api/src/api/jobs/postJob.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.ts
@@ -2,11 +2,11 @@ import { logger } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 import { validateRequestBody } from 'src/framework/validation';
 import * as storage from 'src/storage/jobs';
-import { filterJobInput } from 'src/types/jobs';
+import { JobInput } from 'src/types/jobs';
 import { Middleware } from 'src/types/koa';
 
 export const postJobHandler: Middleware = async (ctx) => {
-  const jobInput = validateRequestBody(ctx, filterJobInput);
+  const jobInput = validateRequestBody(ctx, JobInput);
 
   const job = await storage.createJob(jobInput);
 

--- a/template/koa-rest-api/src/api/jobs/postJob.ts
+++ b/template/koa-rest-api/src/api/jobs/postJob.ts
@@ -2,11 +2,11 @@ import { logger } from 'src/framework/logging';
 import { metricsClient } from 'src/framework/metrics';
 import { validateRequestBody } from 'src/framework/validation';
 import * as storage from 'src/storage/jobs';
-import { JobInput } from 'src/types/jobs';
+import { JobInputSchema } from 'src/types/jobs';
 import { Middleware } from 'src/types/koa';
 
 export const postJobHandler: Middleware = async (ctx) => {
-  const jobInput = validateRequestBody(ctx, JobInput);
+  const jobInput = validateRequestBody(ctx, JobInputSchema);
 
   const job = await storage.createJob(jobInput);
 

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -41,10 +41,15 @@ describe('validate', () => {
       .post('/')
       .send({ ...idDescription, id: null })
       .expect(422)
-      .expect(({ text }) =>
-        expect(text).toMatchInlineSnapshot(
-          `"{"message":"Input validation failed","invalidFields":{"/id":"Expected string, received null"}}"`,
-        ),
+      .expect(({ body }) =>
+        expect(body).toMatchInlineSnapshot(`
+          {
+            "invalidFields": {
+              "/id": "Expected string, received null",
+            },
+            "message": "Input validation failed",
+          }
+        `),
       );
   });
 
@@ -53,9 +58,15 @@ describe('validate', () => {
       .post('/')
       .send({})
       .expect(422)
-      .expect(({ text }) =>
-        expect(text).toMatchInlineSnapshot(
-          `"{"message":"Input validation failed","invalidFields":{"/id":"Required","/description":"Required"}}"`,
-        ),
+      .expect(({ body }) =>
+        expect(body).toMatchInlineSnapshot(`
+          {
+            "invalidFields": {
+              "/description": "Required",
+              "/id": "Required",
+            },
+            "message": "Input validation failed",
+          }
+        `),
       ));
 });

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -1,9 +1,5 @@
 import { agentFromMiddleware } from 'src/testing/server';
-import {
-  chance,
-  filterIdDescription,
-  mockIdDescription,
-} from 'src/testing/types';
+import { IdDescription, chance, mockIdDescription } from 'src/testing/types';
 
 import { jsonBodyParser } from './middleware';
 import { validate } from './validation';
@@ -12,7 +8,7 @@ const agent = agentFromMiddleware(jsonBodyParser, (ctx) => {
   const result = validate({
     ctx,
     input: ctx.request.body,
-    filter: filterIdDescription,
+    type: IdDescription,
   });
 
   ctx.body = result;
@@ -43,11 +39,17 @@ describe('validate', () => {
       .expect(422)
       .expect(({ text }) =>
         expect(text).toMatchInlineSnapshot(`
-          "Validation failed:
-          {
-            "id": "Expected string, but was null"
-          }.
-          Object should match { id: string; description: string; }"
+          "[
+            {
+              "code": "invalid_type",
+              "expected": "string",
+              "received": "null",
+              "path": [
+                "id"
+              ],
+              "message": "Expected string, received null"
+            }
+          ]"
         `),
       );
   });
@@ -59,12 +61,26 @@ describe('validate', () => {
       .expect(422)
       .expect(({ text }) =>
         expect(text).toMatchInlineSnapshot(`
-          "Validation failed:
-          {
-            "id": "Expected string, but was missing",
-            "description": "Expected string, but was missing"
-          }.
-          Object should match { id: string; description: string; }"
+          "[
+            {
+              "code": "invalid_type",
+              "expected": "string",
+              "received": "undefined",
+              "path": [
+                "id"
+              ],
+              "message": "Required"
+            },
+            {
+              "code": "invalid_type",
+              "expected": "string",
+              "received": "undefined",
+              "path": [
+                "description"
+              ],
+              "message": "Required"
+            }
+          ]"
         `),
       ));
 });

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -42,19 +42,9 @@ describe('validate', () => {
       .send({ ...idDescription, id: null })
       .expect(422)
       .expect(({ text }) =>
-        expect(text).toMatchInlineSnapshot(`
-          "[
-            {
-              "code": "invalid_type",
-              "expected": "string",
-              "received": "null",
-              "path": [
-                "id"
-              ],
-              "message": "Expected string, received null"
-            }
-          ]"
-        `),
+        expect(text).toMatchInlineSnapshot(
+          `"{"message":"Input validation failed","invalidFields":{"/id":"Expected string, received null"}}"`,
+        ),
       );
   });
 
@@ -64,27 +54,8 @@ describe('validate', () => {
       .send({})
       .expect(422)
       .expect(({ text }) =>
-        expect(text).toMatchInlineSnapshot(`
-          "[
-            {
-              "code": "invalid_type",
-              "expected": "string",
-              "received": "undefined",
-              "path": [
-                "id"
-              ],
-              "message": "Required"
-            },
-            {
-              "code": "invalid_type",
-              "expected": "string",
-              "received": "undefined",
-              "path": [
-                "description"
-              ],
-              "message": "Required"
-            }
-          ]"
-        `),
+        expect(text).toMatchInlineSnapshot(
+          `"{"message":"Input validation failed","invalidFields":{"/id":"Required","/description":"Required"}}"`,
+        ),
       ));
 });

--- a/template/koa-rest-api/src/framework/validation.test.ts
+++ b/template/koa-rest-api/src/framework/validation.test.ts
@@ -1,5 +1,9 @@
 import { agentFromMiddleware } from 'src/testing/server';
-import { IdDescription, chance, mockIdDescription } from 'src/testing/types';
+import {
+  IdDescriptionSchema,
+  chance,
+  mockIdDescription,
+} from 'src/testing/types';
 
 import { jsonBodyParser } from './middleware';
 import { validate } from './validation';
@@ -8,7 +12,7 @@ const agent = agentFromMiddleware(jsonBodyParser, (ctx) => {
   const result = validate({
     ctx,
     input: ctx.request.body,
-    type: IdDescription,
+    schema: IdDescriptionSchema,
   });
 
   ctx.body = result;

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -5,19 +5,21 @@ import { Context } from 'src/types/koa';
 export const validate = <T>({
   ctx,
   input,
-  type,
+  schema,
 }: {
   ctx: Context;
   input: unknown;
-  type: z.ZodSchema<T>;
+  schema: z.ZodSchema<T>;
 }) => {
   try {
-    return type.parse(input);
+    return schema.parse(input);
   } catch (err) {
     // TODO: consider providing structured error messages for your consumers.
     return ctx.throw(422, err instanceof Error ? err.message : String(err));
   }
 };
 
-export const validateRequestBody = <T>(ctx: Context, type: z.ZodSchema<T>): T =>
-  validate<T>({ ctx, input: ctx.request.body as unknown, type });
+export const validateRequestBody = <T>(
+  ctx: Context,
+  schema: z.ZodSchema<T>,
+): T => validate<T>({ ctx, input: ctx.request.body as unknown, schema });

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -1,6 +1,40 @@
+import { ErrorMiddleware } from 'seek-koala';
 import { z } from 'zod';
 
 import { Context } from 'src/types/koa';
+
+/**
+ * Converts a ZodError into an invalidFields object
+ *
+ * example ZodError:
+ *
+ * ```json
+ * {
+ *   "issues":[
+ *     {
+ *       "code":"invalid_type",
+ *       "expected":"string",
+ *       "received":"undefined",
+ *       "path":["advertiserId"],
+ *       "message":"advertiserId is required in the URL"
+ *     }
+ *   ],
+ *   "name":"ZodError"
+ * }
+ * ```
+ * Returns:
+ * ```json
+ * { "/advertiserId": "advertiserId is required in the URL" }
+ * ```
+ */
+const parseInvalidFieldsFromError = (err: z.ZodError): Record<string, string> =>
+  err.errors.reduce(
+    (prevValue, currentValue) => ({
+      ...prevValue,
+      [`/${currentValue.path.join('/')}`]: currentValue.message,
+    }),
+    {},
+  );
 
 export const validate = <T>({
   ctx,
@@ -11,12 +45,17 @@ export const validate = <T>({
   input: unknown;
   schema: z.ZodSchema<T>;
 }) => {
-  try {
-    return schema.parse(input);
-  } catch (err) {
-    // TODO: consider providing structured error messages for your consumers.
-    return ctx.throw(422, err instanceof Error ? err.message : String(err));
+  const parseResult = schema.safeParse(input);
+  if (parseResult.success === false) {
+    return ctx.throw(
+      422,
+      new ErrorMiddleware.JsonResponse('Input validation failed', {
+        message: 'Input validation failed',
+        invalidFields: parseInvalidFieldsFromError(parseResult.error),
+      }),
+    );
   }
+  return parseResult.data;
 };
 
 export const validateRequestBody = <T>(

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -1,23 +1,23 @@
+import { z } from 'zod';
+
 import { Context } from 'src/types/koa';
 
 export const validate = <T>({
   ctx,
   input,
-  filter,
+  type,
 }: {
   ctx: Context;
   input: unknown;
-  filter: (data: unknown) => T;
+  type: z.ZodSchema<T>;
 }) => {
   try {
-    return filter(input);
+    return type.parse(input);
   } catch (err) {
     // TODO: consider providing structured error messages for your consumers.
     return ctx.throw(422, err instanceof Error ? err.message : String(err));
   }
 };
 
-export const validateRequestBody = <T>(
-  ctx: Context,
-  filter: (input: unknown) => T,
-): T => validate({ ctx, input: ctx.request.body as unknown, filter });
+export const validateRequestBody = <T>(ctx: Context, type: z.ZodSchema<T>): T =>
+  validate<T>({ ctx, input: ctx.request.body as unknown, type });

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -29,7 +29,9 @@ import { Context } from 'src/types/koa';
  * { "/advertiserId": "advertiserId is required in the URL" }
  * ```
  */
-const parseInvalidFieldsFromError = (err: z.ZodError): Record<string, string> =>
+const parseInvalidFieldsFromError = ({
+  errors,
+}: z.ZodError): Record<string, string> =>
   Object.fromEntries(
     errors.map((err) => [`/${err.path.join('/')}`, err.message]),
   );

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -4,25 +4,27 @@ import { z } from 'zod';
 import { Context } from 'src/types/koa';
 
 /**
- * Converts a ZodError into an invalidFields object
+ * Converts a `ZodError` into an `invalidFields` object
  *
- * example ZodError:
+ * For example, the `ZodError`:
  *
  * ```json
  * {
- *   "issues":[
+ *   "issues": [
  *     {
- *       "code":"invalid_type",
- *       "expected":"string",
- *       "received":"undefined",
- *       "path":["advertiserId"],
- *       "message":"advertiserId is required in the URL"
+ *       "code": "invalid_type",
+ *       "expected": "string",
+ *       "received": "undefined",
+ *       "path": ["advertiserId"],
+ *       "message": "advertiserId is required in the URL"
  *     }
  *   ],
- *   "name":"ZodError"
+ *   "name": "ZodError"
  * }
  * ```
+ *
  * Returns:
+ *
  * ```json
  * { "/advertiserId": "advertiserId is required in the URL" }
  * ```

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -30,12 +30,8 @@ import { Context } from 'src/types/koa';
  * ```
  */
 const parseInvalidFieldsFromError = (err: z.ZodError): Record<string, string> =>
-  err.errors.reduce(
-    (prevValue, currentValue) => ({
-      ...prevValue,
-      [`/${currentValue.path.join('/')}`]: currentValue.message,
-    }),
-    {},
+  Object.fromEntries(
+    errors.map((err) => [`/${err.path.join('/')}`, err.message]),
   );
 
 export const validate = <T>({

--- a/template/koa-rest-api/src/testing/types.ts
+++ b/template/koa-rest-api/src/testing/types.ts
@@ -1,19 +1,14 @@
-/* eslint-disable new-cap */
-
 import { Chance } from 'chance';
-import * as t from 'runtypes';
-import checkFilter from 'runtypes-filter';
+import { z } from 'zod';
 
 import { JobInput } from 'src/types/jobs';
 
-export type IdDescription = t.Static<typeof IdDescription>;
+export type IdDescription = z.infer<typeof IdDescription>;
 
-const IdDescription = t.Record({
-  id: t.String,
-  description: t.String,
+export const IdDescription = z.object({
+  id: z.string(),
+  description: z.string(),
 });
-
-export const filterIdDescription = checkFilter(IdDescription);
 
 export const chance = new Chance();
 

--- a/template/koa-rest-api/src/testing/types.ts
+++ b/template/koa-rest-api/src/testing/types.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 
 import { JobInput } from 'src/types/jobs';
 
-export type IdDescription = z.infer<typeof IdDescription>;
+export type IdDescription = z.infer<typeof IdDescriptionSchema>;
 
-export const IdDescription = z.object({
+export const IdDescriptionSchema = z.object({
   id: z.string(),
   description: z.string(),
 });

--- a/template/koa-rest-api/src/types/jobs.ts
+++ b/template/koa-rest-api/src/types/jobs.ts
@@ -1,7 +1,4 @@
-/* eslint-disable new-cap */
-
-import * as t from 'runtypes';
-import checkFilter from 'runtypes-filter';
+import { z } from 'zod';
 
 export interface Job {
   id: string;
@@ -11,12 +8,10 @@ export interface Job {
   };
 }
 
-export type JobInput = t.Static<typeof JobInput>;
+export type JobInput = z.infer<typeof JobInput>;
 
-const JobInput = t.Record({
-  hirer: t.Record({
-    id: t.String,
+export const JobInput = z.object({
+  hirer: z.object({
+    id: z.string(),
   }),
 });
-
-export const filterJobInput = checkFilter(JobInput);

--- a/template/koa-rest-api/src/types/jobs.ts
+++ b/template/koa-rest-api/src/types/jobs.ts
@@ -8,9 +8,9 @@ export interface Job {
   };
 }
 
-export type JobInput = z.infer<typeof JobInput>;
+export type JobInput = z.infer<typeof JobInputSchema>;
 
-export const JobInput = z.object({
+export const JobInputSchema = z.object({
   hirer: z.object({
     id: z.string(),
   }),

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -11,14 +11,14 @@ import {
 } from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 
-import { envContextSchema, stageContextSchema } from '../shared/context-types';
+import { EnvContextSchema, StageContextSchema } from '../shared/context-types';
 
 export class AppStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const stage = stageContextSchema.parse(this.node.tryGetContext('stage'));
-    const context = envContextSchema.parse(this.node.tryGetContext(stage));
+    const stage = StageContextSchema.parse(this.node.tryGetContext('stage'));
+    const context = EnvContextSchema.parse(this.node.tryGetContext(stage));
 
     const accountPrincipal = new aws_iam.AccountPrincipal(this.account);
 

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -17,8 +17,8 @@ export class AppStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const stage = stageContext.check(this.node.tryGetContext('stage'));
-    const context = envContext.check(this.node.tryGetContext(stage));
+    const stage = stageContext.parse(this.node.tryGetContext('stage'));
+    const context = envContext.parse(this.node.tryGetContext(stage));
 
     const accountPrincipal = new aws_iam.AccountPrincipal(this.account);
 

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -11,14 +11,14 @@ import {
 } from 'aws-cdk-lib';
 import type { Construct } from 'constructs';
 
-import { envContext, stageContext } from '../shared/context-types';
+import { envContextSchema, stageContextSchema } from '../shared/context-types';
 
 export class AppStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const stage = stageContext.parse(this.node.tryGetContext('stage'));
-    const context = envContext.parse(this.node.tryGetContext(stage));
+    const stage = stageContextSchema.parse(this.node.tryGetContext('stage'));
+    const context = envContextSchema.parse(this.node.tryGetContext(stage));
 
     const accountPrincipal = new aws_iam.AccountPrincipal(this.account);
 

--- a/template/lambda-sqs-worker-cdk/infra/index.ts
+++ b/template/lambda-sqs-worker-cdk/infra/index.ts
@@ -1,12 +1,12 @@
 import { App } from 'aws-cdk-lib';
 
-import { globalContext } from '../shared/context-types';
+import { globalContextSchema } from '../shared/context-types';
 
 import { AppStack } from './appStack';
 
 const app = new App();
 
-const context = globalContext.parse(app.node.tryGetContext('global'));
+const context = globalContextSchema.parse(app.node.tryGetContext('global'));
 
 // eslint-disable-next-line no-new
 new AppStack(app, 'appStack', {

--- a/template/lambda-sqs-worker-cdk/infra/index.ts
+++ b/template/lambda-sqs-worker-cdk/infra/index.ts
@@ -6,7 +6,7 @@ import { AppStack } from './appStack';
 
 const app = new App();
 
-const context = globalContext.check(app.node.tryGetContext('global'));
+const context = globalContext.parse(app.node.tryGetContext('global'));
 
 // eslint-disable-next-line no-new
 new AppStack(app, 'appStack', {

--- a/template/lambda-sqs-worker-cdk/infra/index.ts
+++ b/template/lambda-sqs-worker-cdk/infra/index.ts
@@ -1,12 +1,12 @@
 import { App } from 'aws-cdk-lib';
 
-import { globalContextSchema } from '../shared/context-types';
+import { GlobalContextSchema } from '../shared/context-types';
 
 import { AppStack } from './appStack';
 
 const app = new App();
 
-const context = globalContextSchema.parse(app.node.tryGetContext('global'));
+const context = GlobalContextSchema.parse(app.node.tryGetContext('global'));
 
 // eslint-disable-next-line no-new
 new AppStack(app, 'appStack', {

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@seek/logger": "^5.0.1",
-    "zod": "3.19.1"
+    "zod": "^3.19.1"
   },
   "devDependencies": {
     "@aws-cdk/assert": "^2.24.0",

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@seek/logger": "^5.0.1",
-    "runtypes": "^6.3.2"
+    "zod": "3.19.1"
   },
   "devDependencies": {
     "@aws-cdk/assert": "^2.24.0",

--- a/template/lambda-sqs-worker-cdk/shared/context-types.ts
+++ b/template/lambda-sqs-worker-cdk/shared/context-types.ts
@@ -1,29 +1,21 @@
 import { z } from 'zod';
 
-export const stageContext = z.enum(['dev', 'prod']);
-export type StageContext = z.infer<typeof stageContext>;
+export const stageContextSchema = z.enum(['dev', 'prod']);
+export type StageContext = z.infer<typeof stageContextSchema>;
 
-export const envContext = z
-  .object({
-    workerLambda: z
-      .object({
-        reservedConcurrency: z.number(),
-        environment: z
-          .object({
-            SOMETHING: z.string(),
-          })
-          .transform((val) => Object.freeze(val)),
-      })
-      .transform((val) => Object.freeze(val)),
-  })
-  .transform((val) => Object.freeze(val));
+export const envContextSchema = z.object({
+  workerLambda: z.object({
+    reservedConcurrency: z.number(),
+    environment: z.object({
+      SOMETHING: z.string(),
+    }),
+  }),
+});
 
-export type EnvContext = z.infer<typeof envContext>;
+export type EnvContext = z.infer<typeof envContextSchema>;
 
-export const globalContext = z
-  .object({
-    appName: z.string(),
-  })
-  .transform((val) => Object.freeze(val));
+export const globalContextSchema = z.object({
+  appName: z.string(),
+});
 
-export type GlobalContext = z.infer<typeof globalContext>;
+export type GlobalContext = z.infer<typeof globalContextSchema>;

--- a/template/lambda-sqs-worker-cdk/shared/context-types.ts
+++ b/template/lambda-sqs-worker-cdk/shared/context-types.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 
-export const stageContextSchema = z.enum(['dev', 'prod']);
-export type StageContext = z.infer<typeof stageContextSchema>;
+export const StageContextSchema = z.enum(['dev', 'prod']);
+export type StageContext = z.infer<typeof StageContextSchema>;
 
-export const envContextSchema = z.object({
+export const EnvContextSchema = z.object({
   workerLambda: z.object({
     reservedConcurrency: z.number(),
     environment: z.object({
@@ -12,10 +12,10 @@ export const envContextSchema = z.object({
   }),
 });
 
-export type EnvContext = z.infer<typeof envContextSchema>;
+export type EnvContext = z.infer<typeof EnvContextSchema>;
 
-export const globalContextSchema = z.object({
+export const GlobalContextSchema = z.object({
   appName: z.string(),
 });
 
-export type GlobalContext = z.infer<typeof globalContextSchema>;
+export type GlobalContext = z.infer<typeof GlobalContextSchema>;

--- a/template/lambda-sqs-worker-cdk/shared/context-types.ts
+++ b/template/lambda-sqs-worker-cdk/shared/context-types.ts
@@ -1,30 +1,29 @@
-/* eslint-disable new-cap */
-import * as t from 'runtypes';
+import { z } from 'zod';
 
-export const stageContext = t.Union(t.Literal('dev'), t.Literal('prod'));
-export type StageContext = t.Static<typeof stageContext>;
+export const stageContext = z.enum(['dev', 'prod']);
+export type StageContext = z.infer<typeof stageContext>;
 
-export const envContext = t
-  .Record({
-    workerLambda: t
-      .Record({
-        reservedConcurrency: t.Number,
-        environment: t
-          .Record({
-            SOMETHING: t.String,
+export const envContext = z
+  .object({
+    workerLambda: z
+      .object({
+        reservedConcurrency: z.number(),
+        environment: z
+          .object({
+            SOMETHING: z.string(),
           })
-          .asReadonly(),
+          .transform((val) => Object.freeze(val)),
       })
-      .asReadonly(),
+      .transform((val) => Object.freeze(val)),
   })
-  .asReadonly();
+  .transform((val) => Object.freeze(val));
 
-export type EnvContext = t.Static<typeof envContext>;
+export type EnvContext = z.infer<typeof envContext>;
 
-export const globalContext = t
-  .Record({
-    appName: t.String,
+export const globalContext = z
+  .object({
+    appName: z.string(),
   })
-  .asReadonly();
+  .transform((val) => Object.freeze(val));
 
-export type GlobalContext = t.Static<typeof globalContext>;
+export type GlobalContext = z.infer<typeof globalContext>;

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -4,8 +4,7 @@
     "aws-sdk": "^2.1011.0",
     "datadog-lambda-js": "^6.83.0",
     "skuba-dive": "^2.0.0",
-    "runtypes": "^6.4.1",
-    "runtypes-filter": "^0.6.0"
+    "zod": "3.19.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.84",

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -4,7 +4,7 @@
     "aws-sdk": "^2.1011.0",
     "datadog-lambda-js": "^6.83.0",
     "skuba-dive": "^2.0.0",
-    "zod": "3.19.1"
+    "zod": "^3.19.1"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.84",

--- a/template/lambda-sqs-worker/src/app.ts
+++ b/template/lambda-sqs-worker/src/app.ts
@@ -8,7 +8,7 @@ import { metricsClient } from 'src/framework/metrics';
 import { validateJson } from 'src/framework/validation';
 import { scoreJobPublishedEvent, scoringService } from 'src/services/jobScorer';
 import { sendPipelineEvent } from 'src/services/pipelineEventSender';
-import { filterJobPublishedEvent } from 'src/types/pipelineEvents';
+import { JobPublishedEvent } from 'src/types/pipelineEvents';
 
 /**
  * Tests connectivity to ensure appropriate access and network configuration.
@@ -40,7 +40,7 @@ export const handler = createHandler<SQSEvent>(async (event) => {
   // the event and eventually send it to your dead-letter queue. If you don't
   // trust your source to provide consistently well-formed input, consider
   // catching and handling this error in code.
-  const publishedJob = validateJson(record.body, filterJobPublishedEvent);
+  const publishedJob = validateJson(record.body, JobPublishedEvent);
 
   const scoredJob = await scoreJobPublishedEvent(publishedJob);
 

--- a/template/lambda-sqs-worker/src/app.ts
+++ b/template/lambda-sqs-worker/src/app.ts
@@ -8,7 +8,7 @@ import { metricsClient } from 'src/framework/metrics';
 import { validateJson } from 'src/framework/validation';
 import { scoreJobPublishedEvent, scoringService } from 'src/services/jobScorer';
 import { sendPipelineEvent } from 'src/services/pipelineEventSender';
-import { JobPublishedEvent } from 'src/types/pipelineEvents';
+import { JobPublishedEventSchema } from 'src/types/pipelineEvents';
 
 /**
  * Tests connectivity to ensure appropriate access and network configuration.
@@ -40,7 +40,7 @@ export const handler = createHandler<SQSEvent>(async (event) => {
   // the event and eventually send it to your dead-letter queue. If you don't
   // trust your source to provide consistently well-formed input, consider
   // catching and handling this error in code.
-  const publishedJob = validateJson(record.body, JobPublishedEvent);
+  const publishedJob = validateJson(record.body, JobPublishedEventSchema);
 
   const scoredJob = await scoreJobPublishedEvent(publishedJob);
 

--- a/template/lambda-sqs-worker/src/framework/validation.test.ts
+++ b/template/lambda-sqs-worker/src/framework/validation.test.ts
@@ -1,4 +1,8 @@
-import { IdDescription, chance, mockIdDescription } from 'src/testing/types';
+import {
+  IdDescriptionSchema,
+  chance,
+  mockIdDescription,
+} from 'src/testing/types';
 
 import { validateJson } from './validation';
 
@@ -8,19 +12,23 @@ describe('validateJson', () => {
   it('permits valid input', () => {
     const input = JSON.stringify(idDescription);
 
-    expect(validateJson(input, IdDescription)).toStrictEqual(idDescription);
+    expect(validateJson(input, IdDescriptionSchema)).toStrictEqual(
+      idDescription,
+    );
   });
 
   it('filters additional properties', () => {
     const input = JSON.stringify({ ...idDescription, hacker: chance.name() });
 
-    expect(validateJson(input, IdDescription)).toStrictEqual(idDescription);
+    expect(validateJson(input, IdDescriptionSchema)).toStrictEqual(
+      idDescription,
+    );
   });
 
   it('blocks mistyped prop', () => {
     const input = JSON.stringify({ ...idDescription, id: null });
 
-    expect(() => validateJson(input, IdDescription))
+    expect(() => validateJson(input, IdDescriptionSchema))
       .toThrowErrorMatchingInlineSnapshot(`
       "[
         {
@@ -39,7 +47,7 @@ describe('validateJson', () => {
   it('blocks missing prop', () => {
     const input = '{}';
 
-    expect(() => validateJson(input, IdDescription))
+    expect(() => validateJson(input, IdDescriptionSchema))
       .toThrowErrorMatchingInlineSnapshot(`
       "[
         {
@@ -68,7 +76,7 @@ describe('validateJson', () => {
     const input = '}';
 
     expect(() =>
-      validateJson(input, IdDescription),
+      validateJson(input, IdDescriptionSchema),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Unexpected token } in JSON at position 0"`,
     );

--- a/template/lambda-sqs-worker/src/framework/validation.test.ts
+++ b/template/lambda-sqs-worker/src/framework/validation.test.ts
@@ -1,8 +1,4 @@
-import {
-  chance,
-  filterIdDescription,
-  mockIdDescription,
-} from 'src/testing/types';
+import { IdDescription, chance, mockIdDescription } from 'src/testing/types';
 
 import { validateJson } from './validation';
 
@@ -12,43 +8,59 @@ describe('validateJson', () => {
   it('permits valid input', () => {
     const input = JSON.stringify(idDescription);
 
-    expect(validateJson(input, filterIdDescription)).toStrictEqual(
-      idDescription,
-    );
+    expect(validateJson(input, IdDescription)).toStrictEqual(idDescription);
   });
 
   it('filters additional properties', () => {
     const input = JSON.stringify({ ...idDescription, hacker: chance.name() });
 
-    expect(validateJson(input, filterIdDescription)).toStrictEqual(
-      idDescription,
-    );
+    expect(validateJson(input, IdDescription)).toStrictEqual(idDescription);
   });
 
   it('blocks mistyped prop', () => {
     const input = JSON.stringify({ ...idDescription, id: null });
 
-    expect(() => validateJson(input, filterIdDescription))
+    expect(() => validateJson(input, IdDescription))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Validation failed:
-      {
-        "id": "Expected string, but was null"
-      }.
-      Object should match { id: string; description: string; }"
+      "[
+        {
+          "code": "invalid_type",
+          "expected": "string",
+          "received": "null",
+          "path": [
+            "id"
+          ],
+          "message": "Expected string, received null"
+        }
+      ]"
     `);
   });
 
   it('blocks missing prop', () => {
     const input = '{}';
 
-    expect(() => validateJson(input, filterIdDescription))
+    expect(() => validateJson(input, IdDescription))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Validation failed:
-      {
-        "id": "Expected string, but was missing",
-        "description": "Expected string, but was missing"
-      }.
-      Object should match { id: string; description: string; }"
+      "[
+        {
+          "code": "invalid_type",
+          "expected": "string",
+          "received": "undefined",
+          "path": [
+            "id"
+          ],
+          "message": "Required"
+        },
+        {
+          "code": "invalid_type",
+          "expected": "string",
+          "received": "undefined",
+          "path": [
+            "description"
+          ],
+          "message": "Required"
+        }
+      ]"
     `);
   });
 
@@ -56,7 +68,7 @@ describe('validateJson', () => {
     const input = '}';
 
     expect(() =>
-      validateJson(input, filterIdDescription),
+      validateJson(input, IdDescription),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Unexpected token } in JSON at position 0"`,
     );

--- a/template/lambda-sqs-worker/src/framework/validation.ts
+++ b/template/lambda-sqs-worker/src/framework/validation.ts
@@ -1,4 +1,4 @@
 import { z } from 'zod';
 
-export const validateJson = <T>(input: string, type: z.ZodSchema<T>) =>
-  type.parse(JSON.parse(input));
+export const validateJson = <T>(input: string, schema: z.ZodSchema<T>) =>
+  schema.parse(JSON.parse(input));

--- a/template/lambda-sqs-worker/src/framework/validation.ts
+++ b/template/lambda-sqs-worker/src/framework/validation.ts
@@ -1,2 +1,4 @@
-export const validateJson = <T>(input: string, filter: (data: unknown) => T) =>
-  filter(JSON.parse(input));
+import { z } from 'zod';
+
+export const validateJson = <T>(input: string, type: z.ZodSchema<T>) =>
+  type.parse(JSON.parse(input));

--- a/template/lambda-sqs-worker/src/services/jobScorer.ts
+++ b/template/lambda-sqs-worker/src/services/jobScorer.ts
@@ -2,11 +2,7 @@ import {
   jobPublishedEventToScorerInput,
   jobScorerOutputToScoredEvent,
 } from 'src/mapping/jobScorer';
-import {
-  JobScorerInput,
-  JobScorerOutput,
-  filterJobScorerOutput,
-} from 'src/types/jobScorer';
+import { JobScorerInput, JobScorerOutput } from 'src/types/jobScorer';
 import { JobPublishedEvent, JobScoredEvent } from 'src/types/pipelineEvents';
 
 /* istanbul ignore next: simulation of an external service */
@@ -39,7 +35,7 @@ const scoreJob = async ({
 }: JobScorerInput): Promise<JobScorerOutput> => {
   const score = await scoringService.request(details);
 
-  return filterJobScorerOutput({
+  return JobScorerOutput.parse({
     id,
     score,
   });

--- a/template/lambda-sqs-worker/src/services/jobScorer.ts
+++ b/template/lambda-sqs-worker/src/services/jobScorer.ts
@@ -2,7 +2,11 @@ import {
   jobPublishedEventToScorerInput,
   jobScorerOutputToScoredEvent,
 } from 'src/mapping/jobScorer';
-import { JobScorerInput, JobScorerOutput } from 'src/types/jobScorer';
+import {
+  JobScorerInput,
+  JobScorerOutput,
+  JobScorerOutputSchema,
+} from 'src/types/jobScorer';
 import { JobPublishedEvent, JobScoredEvent } from 'src/types/pipelineEvents';
 
 /* istanbul ignore next: simulation of an external service */
@@ -35,7 +39,7 @@ const scoreJob = async ({
 }: JobScorerInput): Promise<JobScorerOutput> => {
   const score = await scoringService.request(details);
 
-  return JobScorerOutput.parse({
+  return JobScorerOutputSchema.parse({
     id,
     score,
   });

--- a/template/lambda-sqs-worker/src/testing/types.ts
+++ b/template/lambda-sqs-worker/src/testing/types.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 
 import { JobPublishedEvent } from 'src/types/pipelineEvents';
 
-export type IdDescription = z.infer<typeof IdDescription>;
+export type IdDescription = z.infer<typeof IdDescriptionSchema>;
 
-export const IdDescription = z.object({
+export const IdDescriptionSchema = z.object({
   id: z.string(),
   description: z.string(),
 });

--- a/template/lambda-sqs-worker/src/testing/types.ts
+++ b/template/lambda-sqs-worker/src/testing/types.ts
@@ -1,19 +1,14 @@
-/* eslint-disable new-cap */
-
 import { Chance } from 'chance';
-import * as t from 'runtypes';
-import checkFilter from 'runtypes-filter';
+import { z } from 'zod';
 
 import { JobPublishedEvent } from 'src/types/pipelineEvents';
 
-export type IdDescription = t.Static<typeof IdDescription>;
+export type IdDescription = z.infer<typeof IdDescription>;
 
-const IdDescription = t.Record({
-  id: t.String,
-  description: t.String,
+export const IdDescription = z.object({
+  id: z.string(),
+  description: z.string(),
 });
-
-export const filterIdDescription = checkFilter(IdDescription);
 
 export const chance = new Chance();
 

--- a/template/lambda-sqs-worker/src/types/jobScorer.ts
+++ b/template/lambda-sqs-worker/src/types/jobScorer.ts
@@ -1,22 +1,15 @@
-/* eslint-disable new-cap */
+import { z } from 'zod';
 
-import * as t from 'runtypes';
-import checkFilter from 'runtypes-filter';
+export type JobScorerInput = z.infer<typeof JobScorerInput>;
 
-export type JobScorerInput = t.Static<typeof JobScorerInput>;
-
-const JobScorerInput = t.Record({
-  id: t.String,
-  details: t.String,
+const JobScorerInput = z.object({
+  id: z.string(),
+  details: z.string(),
 });
 
-export const filterJobScorerInput = checkFilter(JobScorerInput);
+export type JobScorerOutput = z.infer<typeof JobScorerOutput>;
 
-export type JobScorerOutput = t.Static<typeof JobScorerOutput>;
-
-const JobScorerOutput = t.Record({
-  id: t.String,
-  score: t.Number,
+export const JobScorerOutput = z.object({
+  id: z.string(),
+  score: z.number(),
 });
-
-export const filterJobScorerOutput = checkFilter(JobScorerOutput);

--- a/template/lambda-sqs-worker/src/types/jobScorer.ts
+++ b/template/lambda-sqs-worker/src/types/jobScorer.ts
@@ -1,15 +1,15 @@
 import { z } from 'zod';
 
-export type JobScorerInput = z.infer<typeof JobScorerInput>;
+export type JobScorerInput = z.infer<typeof JobScorerInputSchema>;
 
-const JobScorerInput = z.object({
+const JobScorerInputSchema = z.object({
   id: z.string(),
   details: z.string(),
 });
 
-export type JobScorerOutput = z.infer<typeof JobScorerOutput>;
+export type JobScorerOutput = z.infer<typeof JobScorerOutputSchema>;
 
-export const JobScorerOutput = z.object({
+export const JobScorerOutputSchema = z.object({
   id: z.string(),
   score: z.number(),
 });

--- a/template/lambda-sqs-worker/src/types/pipelineEvents.ts
+++ b/template/lambda-sqs-worker/src/types/pipelineEvents.ts
@@ -1,28 +1,21 @@
-/* eslint-disable new-cap */
+import { z } from 'zod';
 
-import * as t from 'runtypes';
-import checkFilter from 'runtypes-filter';
+export type JobPublishedEvent = z.infer<typeof JobPublishedEvent>;
 
-export type JobPublishedEvent = t.Static<typeof JobPublishedEvent>;
-
-const JobPublishedEvent = t.Record({
-  data: t.Record({
-    details: t.String,
+export const JobPublishedEvent = z.object({
+  data: z.object({
+    details: z.string(),
   }),
-  entityId: t.String,
-  eventType: t.Literal('JobPublished'),
+  entityId: z.string(),
+  eventType: z.literal('JobPublished'),
 });
 
-export const filterJobPublishedEvent = checkFilter(JobPublishedEvent);
+export type JobScoredEvent = z.infer<typeof JobScoredEvent>;
 
-export type JobScoredEvent = t.Static<typeof JobScoredEvent>;
-
-const JobScoredEvent = t.Record({
-  data: t.Record({
-    score: t.Number,
+export const JobScoredEvent = z.object({
+  data: z.object({
+    score: z.number(),
   }),
-  entityId: t.String,
-  eventType: t.Literal('JobScored'),
+  entityId: z.string(),
+  eventType: z.literal('JobScored'),
 });
-
-export const filterJobScoredEvent = checkFilter(JobScoredEvent);

--- a/template/lambda-sqs-worker/src/types/pipelineEvents.ts
+++ b/template/lambda-sqs-worker/src/types/pipelineEvents.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-export type JobPublishedEvent = z.infer<typeof JobPublishedEvent>;
+export type JobPublishedEvent = z.infer<typeof JobPublishedEventSchema>;
 
-export const JobPublishedEvent = z.object({
+export const JobPublishedEventSchema = z.object({
   data: z.object({
     details: z.string(),
   }),
@@ -10,9 +10,9 @@ export const JobPublishedEvent = z.object({
   eventType: z.literal('JobPublished'),
 });
 
-export type JobScoredEvent = z.infer<typeof JobScoredEvent>;
+export type JobScoredEvent = z.infer<typeof JobScoredEventSchema>;
 
-export const JobScoredEvent = z.object({
+export const JobScoredEventSchema = z.object({
   data: z.object({
     score: z.number(),
   }),


### PR DESCRIPTION
### Proposed Changes

Closes #983.

### High level summary of change

Replace Runtypes with Zod in templates:
- koa-rest-api
- lambda-sqs-worker
- lambda-sqs-worker-cdk

