### PR TITLE
Support AMD64 Docker builds via `BUILDPLATFORM`

### DIFF
--- a/.changeset/thick-ducks-relax.md
+++ b/.changeset/thick-ducks-relax.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+template: Support AMD64 Docker builds via `BUILDPLATFORM`
+
+See the [Docker documentation](https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images) for more information. Note that this does not allow you to build on AMD64 hardware then deploy to ARM64 hardware and vice versa. It is provided for convenience if you need to revert to an AMD64 workflow and/or build and run an image on local AMD64 hardware.

--- a/docs/deep-dives/arm64.md
+++ b/docs/deep-dives/arm64.md
@@ -50,11 +50,12 @@ See [Builds at SEEK] and the [Gantry ARM reference] for more information.
 If you are not ready to build and run your projects on ARM64 hardware,
 you can downgrade a templated project to be compatible with AMD64 hardware.
 
-Remove the `--platform` flag from your Dockerfile(s):
+Replace hardcoded `--platform` values in your Dockerfile(s),
+then ensure that you run your builds on AMD64 hardware:
 
 ```diff
 - FROM --platform=arm64 gcr.io/distroless/nodejs:16 AS runtime
-+ FROM gcr.io/distroless/nodejs:16 AS runtime
++ FROM --platform=${BUILDPLATFORM} gcr.io/distroless/nodejs:16 AS runtime
 ```
 
 For a [Gantry] service, modify the `cpuArchitecture` property in your `gantry.build.yml` and `gantry.apply.yml` resource files:

--- a/template/express-rest-api/Dockerfile
+++ b/template/express-rest-api/Dockerfile
@@ -17,7 +17,7 @@ RUN yarn build
 
 ###
 
-FROM --platform=arm64 gcr.io/distroless/nodejs:16 AS runtime
+FROM --platform=${BUILDPLATFORM} gcr.io/distroless/nodejs:16 AS runtime
 
 WORKDIR /workdir
 

--- a/template/express-rest-api/Dockerfile.dev-deps
+++ b/template/express-rest-api/Dockerfile.dev-deps
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=arm64 node:16-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM} node:16-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/greeter/Dockerfile
+++ b/template/greeter/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=arm64 node:16-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM} node:16-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -17,7 +17,7 @@ RUN yarn build
 
 ###
 
-FROM --platform=arm64 gcr.io/distroless/nodejs:16 AS runtime
+FROM --platform=${BUILDPLATFORM} gcr.io/distroless/nodejs:16 AS runtime
 
 WORKDIR /workdir
 

--- a/template/koa-rest-api/Dockerfile.dev-deps
+++ b/template/koa-rest-api/Dockerfile.dev-deps
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=arm64 node:16-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM} node:16-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=arm64 node:16-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM} node:16-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/lambda-sqs-worker/Dockerfile
+++ b/template/lambda-sqs-worker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=arm64 node:16-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM} node:16-alpine AS dev-deps
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Thoughts welcome.

While we don't make it easy to build our templated Dockerfiles locally (at least until we can land #968), but we currently punish x86 holdouts by requiring them to emulate ARM. This should still default to ARM on the ARM64 build agents and deployment targets that we prescribe but allows for flexibility via the `BUILDPLATFORM` Docker built-in.

https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images