### PR TITLE
Fix Zod Type Validators

### DIFF
--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -69,7 +69,7 @@ export const validateRequestBody = <
 >(
   ctx: Context,
   schema: z.ZodSchema<Output, Def, Input>,
-) =>
+): Output =>
   validate<Output, Def, Input>({
     ctx,
     input: ctx.request.body as unknown,

--- a/template/koa-rest-api/src/framework/validation.ts
+++ b/template/koa-rest-api/src/framework/validation.ts
@@ -36,15 +36,19 @@ const parseInvalidFieldsFromError = ({
     errors.map((err) => [`/${err.path.join('/')}`, err.message]),
   );
 
-export const validate = <T>({
+export const validate = <
+  Output,
+  Def extends z.ZodTypeDef = z.ZodTypeDef,
+  Input = Output,
+>({
   ctx,
   input,
   schema,
 }: {
   ctx: Context;
   input: unknown;
-  schema: z.ZodSchema<T>;
-}) => {
+  schema: z.ZodSchema<Output, Def, Input>;
+}): Output => {
   const parseResult = schema.safeParse(input);
   if (parseResult.success === false) {
     return ctx.throw(
@@ -58,7 +62,16 @@ export const validate = <T>({
   return parseResult.data;
 };
 
-export const validateRequestBody = <T>(
+export const validateRequestBody = <
+  Output,
+  Def extends z.ZodTypeDef = z.ZodTypeDef,
+  Input = Output,
+>(
   ctx: Context,
-  schema: z.ZodSchema<T>,
-): T => validate<T>({ ctx, input: ctx.request.body as unknown, schema });
+  schema: z.ZodSchema<Output, Def, Input>,
+) =>
+  validate<Output, Def, Input>({
+    ctx,
+    input: ctx.request.body as unknown,
+    schema,
+  });

--- a/template/lambda-sqs-worker/src/framework/validation.ts
+++ b/template/lambda-sqs-worker/src/framework/validation.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod';
 
-export const validateJson = <T>(input: string, schema: z.ZodSchema<T>) =>
-  schema.parse(JSON.parse(input));
+export const validateJson = <
+  Output,
+  Def extends z.ZodTypeDef = z.ZodTypeDef,
+  Input = Output,
+>(
+  input: string,
+  schema: z.ZodSchema<Output, Def, Input>,
+): Output => schema.parse(JSON.parse(input));


### PR DESCRIPTION
Resolves https://github.com/seek-oss/skuba/issues/1023

Currently this generic is a little naive and when used it returns the input type of the Zod Type. With basic Zod Types this works as the input type equals the output type but when used in conjunction with zod effects(transform, preprocess) this type becomes incorrect because the input is different to the output.

Before:
<img width="892" alt="image" src="https://user-images.githubusercontent.com/18017094/200527543-04392d1b-56e5-44b0-9e5e-53d616933364.png">

After:
<img width="885" alt="image" src="https://user-images.githubusercontent.com/18017094/200527624-aa77084a-43c6-424a-8527-3297aa7b87ca.png">


Since this isn't released I shouldn't need a changeset right?