### PR TITLE
Add BUILDPLATFORM fallbacks everywhere

### DIFF
--- a/template/express-rest-api/Dockerfile.dev-deps
+++ b/template/express-rest-api/Dockerfile.dev-deps
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=${BUILDPLATFORM} node:18-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM:-arm64} node:18-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/greeter/Dockerfile
+++ b/template/greeter/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=${BUILDPLATFORM} node:18-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM:-arm64} node:18-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/koa-rest-api/Dockerfile.dev-deps
+++ b/template/koa-rest-api/Dockerfile.dev-deps
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=${BUILDPLATFORM} node:18-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM:-arm64} node:18-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=${BUILDPLATFORM} node:16-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM:-arm64} node:16-alpine AS dev-deps
 
 WORKDIR /workdir
 

--- a/template/lambda-sqs-worker/Dockerfile
+++ b/template/lambda-sqs-worker/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
 
-FROM --platform=${BUILDPLATFORM} node:16-alpine AS dev-deps
+FROM --platform=${BUILDPLATFORM:-arm64} node:16-alpine AS dev-deps
 
 WORKDIR /workdir
 


### PR DESCRIPTION
This seems safer given I seem to have observed some presumably old versions of Docker Compose not supplying this value.