### PR TITLE
Declare dd-trace dependency

### DIFF
--- a/.changeset/eighty-bikes-grow.md
+++ b/.changeset/eighty-bikes-grow.md
@@ -1,0 +1,38 @@
+---
+'skuba': patch
+---
+
+template/lambda-sqs-worker: Declare `dd-trace` dependency
+
+This resolves a `Runtime.ImportModuleError` that occurs if this transitive dependency is not installed:
+
+```console
+Runtime.ImportModuleError
+Error: Cannot find module 'dd-trace'
+```
+
+Alternatively, you can [configure the Datadog Serverless plugin](https://docs.datadoghq.com/serverless/libraries_integrations/plugin/#configuration-parameters) to bundle these dependencies via [Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html):
+
+```diff
+serverless.yml
+
+custom:
+  datadog:
+-   addLayers: false
++   addLayers: true
+```
+
+```diff
+package.json
+
+{
+  "dependencies": {
+-   "datadog-lambda-js: "x.y.z",
+-   "dd-trace: "x.y.z"
+  },
+  "devDependencies": {
++   "datadog-lambda-js: "x.y.z",
++   "dd-trace: "x.y.z"
+  }
+}
+```

--- a/template/lambda-sqs-worker/package.json
+++ b/template/lambda-sqs-worker/package.json
@@ -17,6 +17,7 @@
     "@seek/logger": "^5.0.1",
     "aws-sdk": "^2.1011.0",
     "datadog-lambda-js": "^6.83.0",
+    "dd-trace": "^3.8.0",
     "skuba-dive": "^2.0.0",
     "zod": "^3.19.1"
   },


### PR DESCRIPTION
Wasn't sure if we wanted to default to layers, so this at least documents the two options.