### PR TITLE
Use environment value

### DIFF
--- a/.changeset/purple-readers-collect.md
+++ b/.changeset/purple-readers-collect.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+template/\*-rest-api: Replace `'{{.Environment}}'` with a custom `environment` Gantry value.

--- a/.changeset/purple-readers-collect.md
+++ b/.changeset/purple-readers-collect.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 template/\*-rest-api: Replace `'{{.Environment}}'` with a custom `environment` Gantry value.

--- a/template/express-rest-api/.gantry/common.yml
+++ b/template/express-rest-api/.gantry/common.yml
@@ -13,7 +13,7 @@ tags:
   # seek:data:consumers: internal
   # https://rfc.skinfra.xyz/RFC019-AWS-Tagging-Standard.html#seekdatatypes
   # seek:data:types:restricted: job-ads
-  seek:env:label: '{{.Environment}}'
+  seek:env:label: '{{values "environment"}}'
   seek:env:production: '{{values "isProduction"}}'
   seek:owner:team: '<%- teamName %>'
   seek:source:sha: '{{.CommitSHA}}'

--- a/template/express-rest-api/.gantry/dev.yml
+++ b/template/express-rest-api/.gantry/dev.yml
@@ -1,3 +1,4 @@
+environment: dev
 env:
   SOME_ENVIRONMENT_VARIABLE: dev-value
 

--- a/template/express-rest-api/.gantry/prod.yml
+++ b/template/express-rest-api/.gantry/prod.yml
@@ -1,3 +1,4 @@
+environment: prod
 env:
   SOME_ENVIRONMENT_VARIABLE: prod-value
 

--- a/template/express-rest-api/gantry.apply.yml
+++ b/template/express-rest-api/gantry.apply.yml
@@ -10,7 +10,7 @@ env:
   # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
   AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
 
-  ENVIRONMENT: '{{.Environment}}'
+  ENVIRONMENT: '{{values "environment"}}'
   SERVICE: '{{values "service"}}'
 
   {{range $key, $value := .Values.env}}

--- a/template/koa-rest-api/.gantry/common.yml
+++ b/template/koa-rest-api/.gantry/common.yml
@@ -13,7 +13,7 @@ tags:
   # seek:data:consumers: internal
   # https://rfc.skinfra.xyz/RFC019-AWS-Tagging-Standard.html#seekdatatypes
   # seek:data:types:restricted: job-ads
-  seek:env:label: '{{.Environment}}'
+  seek:env:label: '{{values "environment"}}'
   seek:env:production: '{{values "isProduction"}}'
   seek:owner:team: '<%- teamName %>'
   seek:source:sha: '{{.CommitSHA}}'

--- a/template/koa-rest-api/.gantry/dev.yml
+++ b/template/koa-rest-api/.gantry/dev.yml
@@ -1,3 +1,4 @@
+environment: dev
 env:
   SOME_ENVIRONMENT_VARIABLE: dev-value
 

--- a/template/koa-rest-api/.gantry/prod.yml
+++ b/template/koa-rest-api/.gantry/prod.yml
@@ -1,3 +1,4 @@
+environment: prod
 env:
   SOME_ENVIRONMENT_VARIABLE: prod-value
 

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -10,7 +10,7 @@ env:
   # https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/node-reusing-connections.html
   AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1'
 
-  ENVIRONMENT: '{{.Environment}}'
+  ENVIRONMENT: '{{values "environment"}}'
   OPENTELEMETRY_ENABLED: '{{.Values.openTelemetry.enabled | default false}}'
   SERVICE: '{{values "service"}}'
 


### PR DESCRIPTION
Set an environment value instead of relying on `'{{.Environment}}'` which is actually the gantry environment name. This was fairly problematic for us when moving Gantry environments given the classroom tells you to create an environment which isn't just "dev" or "prod"

https://backstage.myseek.xyz/docs/default/component/gantry/v1/classroom/step-07/