### PR TITLE
Exclude internal files from autofix commits

### DIFF
--- a/.changeset/red-llamas-explain.md
+++ b/.changeset/red-llamas-explain.md
@@ -1,0 +1,10 @@
+---
+'skuba': patch
+---
+
+lint: Exclude internal files from autofix commits
+
+`skuba lint` now avoids committing the following internal files in a [GitHub autofix](https://seek-oss.github.io/skuba/docs/deep-dives/github.html#github-autofixes):
+
+- `.npmrc`
+- `Dockerfile-incunabulum`

--- a/src/api/git/commitAllChanges.ts
+++ b/src/api/git/commitAllChanges.ts
@@ -3,6 +3,7 @@ import git from 'isomorphic-git';
 
 import { commit } from './commit';
 import type { Identity } from './commit';
+import type { ChangedFile } from './getChangedFiles';
 import { getChangedFiles } from './getChangedFiles';
 
 interface CommitAllParameters {
@@ -10,6 +11,13 @@ interface CommitAllParameters {
   message: string;
   author?: Identity;
   committer?: Identity;
+
+  /**
+   * File changes to exclude from the commit.
+   *
+   * Defaults to `[]` (no exclusions).
+   */
+  ignore?: ChangedFile[];
 }
 
 /**
@@ -18,10 +26,12 @@ interface CommitAllParameters {
 export const commitAllChanges = async ({
   dir,
   message,
+
   author,
   committer,
+  ignore,
 }: CommitAllParameters): Promise<string | undefined> => {
-  const changedFiles = await getChangedFiles({ dir });
+  const changedFiles = await getChangedFiles({ dir, ignore });
 
   if (!changedFiles.length) {
     return;

--- a/src/api/git/getChangedFiles.ts
+++ b/src/api/git/getChangedFiles.ts
@@ -18,6 +18,13 @@ export interface ChangedFile {
 }
 interface ChangedFilesParameters {
   dir: string;
+
+  /**
+   * File changes to exclude from the result.
+   *
+   * Defaults to `[]` (no exclusions).
+   */
+  ignore?: ChangedFile[];
 }
 
 const mapState = (
@@ -40,6 +47,8 @@ const mapState = (
  */
 export const getChangedFiles = async ({
   dir,
+
+  ignore = [],
 }: ChangedFilesParameters): Promise<ChangedFile[]> => {
   const allFiles = await git.statusMatrix({ fs, dir });
   return allFiles
@@ -49,5 +58,11 @@ export const getChangedFiles = async ({
         row[WORKDIR] !== UNMODIFIED ||
         row[STAGE] !== UNMODIFIED,
     )
-    .map((row) => ({ path: row[FILEPATH], state: mapState(row) }));
+    .map((row) => ({ path: row[FILEPATH], state: mapState(row) }))
+    .filter(
+      (changedFile) =>
+        !ignore.some(
+          (i) => i.path === changedFile.path && i.state === changedFile.state,
+        ),
+    );
 };

--- a/src/api/git/index.ts
+++ b/src/api/git/index.ts
@@ -1,6 +1,7 @@
 export { commit } from './commit';
 export { commitAllChanges } from './commitAllChanges';
 export { currentBranch } from './currentBranch';
+export type { ChangedFile } from './getChangedFiles';
 export { getChangedFiles } from './getChangedFiles';
 export { getHeadCommitId, getHeadCommitMessage } from './log';
 export { getOwnerAndRepo } from './remote';

--- a/src/cli/lint/autofix.test.ts
+++ b/src/cli/lint/autofix.test.ts
@@ -5,7 +5,7 @@ import * as GitHub from '../../api/github';
 import { runESLint } from '../../cli/adapter/eslint';
 import { runPrettier } from '../../cli/adapter/prettier';
 
-import { autofix } from './autofix';
+import { AUTOFIX_IGNORE_FILES, autofix } from './autofix';
 
 jest.mock('simple-git');
 jest.mock('../../api/git');
@@ -155,6 +155,13 @@ describe('autofix', () => {
 
       expectAutofixCommit();
 
+      expect(Git.commitAllChanges).toHaveBeenNthCalledWith(1, {
+        dir: expect.any(String),
+        message: 'Run `skuba format`',
+
+        ignore: AUTOFIX_IGNORE_FILES,
+      });
+
       expect(push).toHaveBeenNthCalledWith(1);
 
       expect(stdout()).toMatchInlineSnapshot(`
@@ -197,6 +204,14 @@ describe('autofix', () => {
       ).resolves.toBeUndefined();
 
       expectAutofixCommit({ eslint: false });
+
+      expect(Git.commitAllChanges).toHaveBeenNthCalledWith(1, {
+        dir: expect.any(String),
+        message: 'Run `skuba format`',
+
+        ignore: AUTOFIX_IGNORE_FILES,
+      });
+
       expect(push).toHaveBeenNthCalledWith(1);
 
       // We should only run Prettier
@@ -357,9 +372,11 @@ describe('autofix', () => {
 
       expectAutofixCommit();
       expect(GitHub.uploadAllFileChanges).toHaveBeenNthCalledWith(1, {
-        dir: expect.any(String),
         branch: 'dev',
+        dir: expect.any(String),
         messageHeadline: 'Run `skuba format`',
+
+        ignore: AUTOFIX_IGNORE_FILES,
       });
 
       // We should run both ESLint and Prettier
@@ -382,9 +399,11 @@ describe('autofix', () => {
 
       expectAutofixCommit({ eslint: false });
       expect(GitHub.uploadAllFileChanges).toHaveBeenNthCalledWith(1, {
-        dir: expect.any(String),
         branch: 'dev',
+        dir: expect.any(String),
         messageHeadline: 'Run `skuba format`',
+
+        ignore: AUTOFIX_IGNORE_FILES,
       });
 
       // We should only run Prettier

--- a/src/cli/lint/autofix.ts
+++ b/src/cli/lint/autofix.ts
@@ -14,6 +14,17 @@ import type { Input } from './types';
 
 const AUTOFIX_COMMIT_MESSAGE = 'Run `skuba format`';
 
+const AUTOFIX_IGNORE_FILES: Git.ChangedFile[] = [
+  {
+    path: '.npmrc',
+    state: 'added',
+  },
+  {
+    path: 'Dockerfile-incunabulum',
+    state: 'added',
+  },
+];
+
 const shouldPush = async ({
   currentBranch,
   dir,
@@ -100,6 +111,8 @@ export const autofix = async (params: AutofixParameters): Promise<void> => {
       const ref = await Git.commitAllChanges({
         dir,
         message: AUTOFIX_COMMIT_MESSAGE,
+
+        ignore: AUTOFIX_IGNORE_FILES,
       });
 
       if (!ref) {
@@ -122,9 +135,11 @@ export const autofix = async (params: AutofixParameters): Promise<void> => {
 
     const ref = await throwOnTimeout(
       GitHub.uploadAllFileChanges({
-        dir,
         branch: currentBranch,
+        dir,
         messageHeadline: AUTOFIX_COMMIT_MESSAGE,
+
+        ignore: AUTOFIX_IGNORE_FILES,
       }),
       { s: 30 },
     );

--- a/src/cli/lint/autofix.ts
+++ b/src/cli/lint/autofix.ts
@@ -14,7 +14,7 @@ import type { Input } from './types';
 
 const AUTOFIX_COMMIT_MESSAGE = 'Run `skuba format`';
 
-const AUTOFIX_IGNORE_FILES: Git.ChangedFile[] = [
+export const AUTOFIX_IGNORE_FILES: Git.ChangedFile[] = [
   {
     path: '.npmrc',
     state: 'added',


### PR DESCRIPTION
Follows on from #1072 and additionally prevents `.npmrc` mishaps.