### PR TITLE
Revert "Ignore `Dockerfile-incunabulum` from Git"

### DIFF
--- a/.changeset/big-files-wave.md
+++ b/.changeset/big-files-wave.md
@@ -1,7 +1,0 @@
----
-'skuba': patch
----
-
-lint, template: Ignore `Dockerfile-incunabulum` from Git
-
-This automation file is added to the working directory by our [npm packaging pipeline](https://github.com/SEEK-Jobs/gutenberg) and should not be committed in a [GitHub autofix](https://seek-oss.github.io/skuba/docs/deep-dives/github.html#github-autofixes).

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -76,7 +76,6 @@ node_modules*/
 .npmrc
 *.tgz
 *.tsbuildinfo
-Dockerfile-incunabulum
 npm-debug.log
 package-lock.json
 yarn-error.log

--- a/template/base/_.gitignore
+++ b/template/base/_.gitignore
@@ -17,7 +17,6 @@ node_modules*/
 .npmrc
 *.tgz
 *.tsbuildinfo
-Dockerfile-incunabulum
 npm-debug.log
 package-lock.json
 yarn-error.log


### PR DESCRIPTION
Reverts #1072 given #1074 achieves the same result without having to change consumer `.gitignore`s.