### PR TITLE
Handle TypeScript deprecations

### DIFF
--- a/src/cli/configure/processing/typescript.ts
+++ b/src/cli/configure/processing/typescript.ts
@@ -38,7 +38,6 @@ const createExportDefaultObjectLiteralExpression = (
   factory.createExportAssignment(
     undefined,
     undefined,
-    undefined,
     callExpression === undefined
       ? factory.createObjectLiteralExpression(props, true)
       : factory.createCallExpression(callExpression, undefined, [
@@ -73,7 +72,6 @@ const createImportFromExpression = (
         );
 
   return factory.createImportDeclaration(
-    undefined,
     undefined,
     importClause,
     factory.createStringLiteral(moduleName),
@@ -122,7 +120,6 @@ const expressionAsDefaultExport = (
 
       // Anything else
       return context.factory.createExportAssignment(
-        undefined,
         undefined,
         undefined,
         expression,


### PR DESCRIPTION
https://github.com/seek-oss/skuba/actions/runs/3801200255/jobs/6465414295#step:7:176

```
DeprecationWarning: 'createExportAssignment' has been deprecated since v4.8.0. Decorators are no longer supported for this function. Callers should switch to an overload that does not accept a 'decorators' parameter.
```

https://github.com/seek-oss/skuba/actions/runs/3801200255/jobs/6465414295#step:7:211

```
DeprecationWarning: 'createImportDeclaration' has been deprecated since v4.8.0. Decorators are no longer supported for this function. Callers should switch to an overload that does not accept a 'decorators' parameter.
```