### PR TITLE
Bundle `eslint-plugin-yml`

### DIFF
--- a/.changeset/forty-spies-tie.md
+++ b/.changeset/forty-spies-tie.md
@@ -1,0 +1,23 @@
+---
+'skuba': minor
+---
+
+format, lint: Bundle `eslint-plugin-yml`
+
+[eslint-plugin-yml](https://github.com/ota-meshi/eslint-plugin-yml) is now supported on `skuba format` and `skuba lint`. While the default configuration should be unobtrusive, you can opt in to stricter rules in your `.eslintrc.js`:
+
+```diff
+module.exports = {
+  extends: ['skuba'],
++ overrides: [
++   {
++     files: ['my/strict/config.yaml'],
++     rules: {
++       'yml/sort-keys': 'error',
++     },
++   },
++ ],
+};
+```
+
+YAML files with non-standard syntax may fail ESLint parsing with this change. Gantry resource files should be excluded by default due to their custom templating syntax, and you can list additional exclusions in your `.eslintignore`.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "enquirer": "^2.3.6",
     "esbuild": "~0.17.0",
     "eslint": "^8.11.0",
-    "eslint-config-skuba": "1.2.1",
+    "eslint-config-skuba": "1.2.2-beta.3",
     "execa": "^5.0.0",
     "fdir": "^6.0.0",
     "fs-extra": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "enquirer": "^2.3.6",
     "esbuild": "~0.17.0",
     "eslint": "^8.11.0",
-    "eslint-config-skuba": "1.2.2-beta.3",
+    "eslint-config-skuba": "1.3.0",
     "execa": "^5.0.0",
     "fdir": "^6.0.0",
     "fs-extra": "^11.0.0",

--- a/src/cli/adapter/eslint.ts
+++ b/src/cli/adapter/eslint.ts
@@ -36,7 +36,7 @@ export const runESLint = async (
 
   const engine = new ESLint({
     cache: true,
-    extensions: ['js', 'ts', 'tsx'],
+    extensions: ['js', 'ts', 'tsx', 'yaml', 'yml'],
     fix: mode === 'format',
     reportUnusedDisableDirectives: 'error',
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3693,10 +3693,10 @@ eslint-config-seek@^10.0.0:
     eslint-plugin-react-hooks "^4.6.0"
     find-root "^1.1.0"
 
-eslint-config-skuba@1.2.2-beta.3:
-  version "1.2.2-beta.3"
-  resolved "https://registry.yarnpkg.com/eslint-config-skuba/-/eslint-config-skuba-1.2.2-beta.3.tgz#37b444b035761ed68d4785d1eac95afca231e523"
-  integrity sha512-MX17P1BJO4vkXSJVAWMk05tpWIjXgpuhDvaavmqsqHKX2Cf640Z9yOG+JGbtup95pI5ZP9nGaZAUjsQ5IG8Ycg==
+eslint-config-skuba@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-skuba/-/eslint-config-skuba-1.3.0.tgz#8eba4a2024031962076d335c1b4e72ddca67075e"
+  integrity sha512-HDq3Nc9n0xOtaFqBYXJU4WPQVz040yClOzZ+Sgp6llln2viYsBXumxkifJWEfXowTRBGC5aepNBDgW+NOZbwkg==
   dependencies:
     "@types/eslint" "^8.4.1"
     "@typescript-eslint/eslint-plugin" "^5.45.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3693,10 +3693,10 @@ eslint-config-seek@^10.0.0:
     eslint-plugin-react-hooks "^4.6.0"
     find-root "^1.1.0"
 
-eslint-config-skuba@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-skuba/-/eslint-config-skuba-1.2.1.tgz#730e8ae41192b93efa120d8172544297e355b0c0"
-  integrity sha512-cF920uWhZqsQCWRTABXh4kCxZciQMdqLyqUIeYamTCaiJrOQYmRqNJvdCA4fQoeWjAJ9FEltwMZtcN6eMGhoKw==
+eslint-config-skuba@1.2.2-beta.3:
+  version "1.2.2-beta.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-skuba/-/eslint-config-skuba-1.2.2-beta.3.tgz#37b444b035761ed68d4785d1eac95afca231e523"
+  integrity sha512-MX17P1BJO4vkXSJVAWMk05tpWIjXgpuhDvaavmqsqHKX2Cf640Z9yOG+JGbtup95pI5ZP9nGaZAUjsQ5IG8Ycg==
   dependencies:
     "@types/eslint" "^8.4.1"
     "@typescript-eslint/eslint-plugin" "^5.45.0"
@@ -3704,6 +3704,7 @@ eslint-config-skuba@1.2.1:
     eslint-config-seek "^10.0.0"
     eslint-plugin-jest "^27.0.0"
     eslint-plugin-tsdoc "^0.2.14"
+    eslint-plugin-yml "^1.5.0"
 
 eslint-import-resolver-node@^0.3.7:
   version "0.3.7"
@@ -3803,6 +3804,16 @@ eslint-plugin-tsdoc@^0.2.14:
     "@microsoft/tsdoc" "0.14.2"
     "@microsoft/tsdoc-config" "0.16.2"
 
+eslint-plugin-yml@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-yml/-/eslint-plugin-yml-1.5.0.tgz#e7eb4ae96701ec0f7f9689f9dc84a49f41833240"
+  integrity sha512-iygN054g+ZrnYmtOXMnT+sx9iDNXt89/m0+506cQHeG0+5jJN8hY5iOPQLd3yfd50AfK/mSasajBWruf1SoHpQ==
+  dependencies:
+    debug "^4.3.2"
+    lodash "^4.17.21"
+    natural-compare "^1.4.0"
+    yaml-eslint-parser "^1.1.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -3831,7 +3842,7 @@ eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint-visitor-keys@^3.3.0:
+eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
@@ -9856,6 +9867,15 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml-eslint-parser@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/yaml-eslint-parser/-/yaml-eslint-parser-1.1.0.tgz#62703e2f4afbe5a17d3fe297882740bf89504e78"
+  integrity sha512-b464Q1fYiX1oYx2kE8k4mEp6S9Prk+tfDsY/IPxQ0FCjEuj3AKko5Skf3/yQJeYTTDyjDE+aWIJemnv29HvEWQ==
+  dependencies:
+    eslint-visitor-keys "^3.0.0"
+    lodash "^4.17.21"
+    yaml "^2.0.0"
 
 yaml@^1.10.0:
   version "1.10.2"


### PR DESCRIPTION
The motivation for this is that I would like to optionally configure YAML sorting in a shared configuration repository.

Refs:

- seek-oss/eslint-config-skuba#173
- seek-oss/eslint-config-skuba#174