### PR TITLE
Set the keep alive timeout to 31 seconds

### DIFF
--- a/.changeset/fair-shrimps-count.md
+++ b/.changeset/fair-shrimps-count.md
@@ -2,11 +2,11 @@
 'skuba': patch
 ---
 
-template/\*-rest-api: Set `keepAliveTimeout` to 31 seconds to prevent 502 errors
+template/\*-rest-api: Set `keepAliveTimeout` to 31 seconds to prevent HTTP 502s
 
-The default Node.js server keep alive timeout is set to 5 seconds. However, the Gantry default ALB idle timeout is 30 seconds. This would lead to the occasional issues where the sidecar would throw `proxyStatus` 502 errors. AWS recommends setting an application timeout larger than the ALB idle timeout.
+The default Node.js server keep-alive timeout is set to 5 seconds. However, the Gantry default ALB idle timeout is 30 seconds. This would lead to the occasional issues where the sidecar would throw `proxyStatus=502` errors. AWS recommends setting an application timeout larger than the ALB idle timeout.
 
-A more detailed explanation can be found in the below links
+A more detailed explanation can be found in the below links:
 
-https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
-https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout
+1. <https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout>
+2. <https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout>

--- a/.changeset/fair-shrimps-count.md
+++ b/.changeset/fair-shrimps-count.md
@@ -1,0 +1,12 @@
+---
+'skuba': patch
+---
+
+template/\*-rest-api: Set `keepAliveTimeout` to 30.5 seconds to prevent 502 errors
+
+The default Node.js server keep alive timeout is set to 5 seconds. However, the Gantry default ALB idle timeout is 30 seconds. This would lead to the occasional issues where the sidecar would throw `proxyStatus` 502 errors. AWS recommends setting an application timeout larger than the ALB idle timeout.
+
+A more detailed explanation can be found in the below links
+
+https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
+https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout

--- a/.changeset/fair-shrimps-count.md
+++ b/.changeset/fair-shrimps-count.md
@@ -2,7 +2,7 @@
 'skuba': patch
 ---
 
-template/\*-rest-api: Set `keepAliveTimeout` to 30.5 seconds to prevent 502 errors
+template/\*-rest-api: Set `keepAliveTimeout` to 31 seconds to prevent 502 errors
 
 The default Node.js server keep alive timeout is set to 5 seconds. However, the Gantry default ALB idle timeout is 30 seconds. This would lead to the occasional issues where the sidecar would throw `proxyStatus` 502 errors. AWS recommends setting an application timeout larger than the ALB idle timeout.
 

--- a/template/express-rest-api/src/listen.ts
+++ b/template/express-rest-api/src/listen.ts
@@ -15,7 +15,7 @@ const listener = app.listen(config.port, () => {
   }
 });
 
-// Gantry ALB Default Idle timeout is 30 seconds
+// Gantry ALB default idle timeout is 30 seconds
 // https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout
 // Node default is 5 seconds
 // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout

--- a/template/express-rest-api/src/listen.ts
+++ b/template/express-rest-api/src/listen.ts
@@ -14,3 +14,10 @@ const listener = app.listen(config.port, () => {
     rootLogger.debug(`listening on port ${address.port}`);
   }
 });
+
+// Gantry ALB Default Idle timeout is 30 seconds
+// https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout
+// Node default is 5 seconds
+// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
+// AWS recommends setting an application timeout larger than the load balancer
+listener.keepAliveTimeout = 30500;

--- a/template/express-rest-api/src/listen.ts
+++ b/template/express-rest-api/src/listen.ts
@@ -20,4 +20,4 @@ const listener = app.listen(config.port, () => {
 // Node default is 5 seconds
 // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
 // AWS recommends setting an application timeout larger than the load balancer
-listener.keepAliveTimeout = 30500;
+listener.keepAliveTimeout = 31000;

--- a/template/koa-rest-api/src/listen.ts
+++ b/template/koa-rest-api/src/listen.ts
@@ -16,7 +16,7 @@ const listener = app.listen(config.port, () => {
   }
 });
 
-// Gantry ALB Default Idle timeout is 30 seconds
+// Gantry ALB default idle timeout is 30 seconds
 // https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout
 // Node default is 5 seconds
 // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout

--- a/template/koa-rest-api/src/listen.ts
+++ b/template/koa-rest-api/src/listen.ts
@@ -15,3 +15,10 @@ const listener = app.listen(config.port, () => {
     logger.debug(`listening on port ${address.port}`);
   }
 });
+
+// Gantry ALB Default Idle timeout is 30 seconds
+// https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout
+// Node default is 5 seconds
+// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
+// AWS recommends setting an application timeout larger than the load balancer
+listener.keepAliveTimeout = 30500;

--- a/template/koa-rest-api/src/listen.ts
+++ b/template/koa-rest-api/src/listen.ts
@@ -21,4 +21,4 @@ const listener = app.listen(config.port, () => {
 // Node default is 5 seconds
 // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
 // AWS recommends setting an application timeout larger than the load balancer
-listener.keepAliveTimeout = 30500;
+listener.keepAliveTimeout = 31000;


### PR DESCRIPTION
The default Node.js server keep alive timeout is set to 5 seconds. However, the Gantry default ALB idle timeout is 30 seconds. This would lead to the occasional issues where the sidecar would throw `proxyStatus` 502 errors while trying to talk to your node application as it would believe that the socket is still open. AWS recommends setting an application timeout larger than the ALB idle timeout.

A more detailed explanation can be found in the below links

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout
https://nodejs.org/docs/latest-v18.x/api/http.html#serverkeepalivetimeout

So far it has completely removed all 502 errors from the products-api and hirer graphql api