### PR TITLE
lint: Avoid committing `.npmrc` changes

### DIFF
--- a/.changeset/chilled-spiders-drive.md
+++ b/.changeset/chilled-spiders-drive.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+lint: Avoid committing `.npmrc` changes
+
+`skuba lint` can automatically commit codegen changes if you have [GitHub autofixes](https://seek-oss.github.io/skuba/docs/deep-dives/github.html#github-autofixes) enabled on your project. Previously we made sure to exclude a new `.npmrc` file from the commit, but we now exclude changes to an existing `.npmrc` too.

--- a/src/cli/lint/autofix.test.ts
+++ b/src/cli/lint/autofix.test.ts
@@ -496,6 +496,21 @@ describe('autofix', () => {
       `);
     });
 
+    it('skips an .npmrc modification only', async () => {
+      jest.spyOn(Git, 'getChangedFiles').mockResolvedValue([
+        {
+          path: '.npmrc',
+          state: 'modified',
+        },
+      ]);
+
+      await expect(
+        autofix({ ...params, eslint: false, prettier: false }),
+      ).resolves.toBeUndefined();
+
+      expectNoAutofix();
+    });
+
     it('handles codegen changes only', async () => {
       jest.spyOn(Git, 'getChangedFiles').mockResolvedValue([
         {

--- a/src/cli/lint/autofix.ts
+++ b/src/cli/lint/autofix.ts
@@ -40,6 +40,12 @@ export const AUTOFIX_IGNORE_FILES: Git.ChangedFile[] = [
     state: 'added',
   },
   {
+    // This file may already exist in version control, but we shouldn't commit
+    // further changes as the CI environment may have appended an npm token.
+    path: '.npmrc',
+    state: 'modified',
+  },
+  {
     path: 'Dockerfile-incunabulum',
     state: 'added',
   },


### PR DESCRIPTION
I thought that excluding the `added` state would be enough 🤦.