### PR TITLE
Don't pass explicit list of extensions and let ESLint infer them from the config

### DIFF
--- a/integration/base/fixable/a/a/a.mjs
+++ b/integration/base/fixable/a/a/a.mjs
@@ -1,0 +1,7 @@
+// Imports out-of-order
+import path from 'path';
+import fs from 'fs';
+
+export const main = async () => {
+  await fs.promises.access(path.join('.', 'a.mjs'));
+};

--- a/integration/base/fixable/a/a/a.mts
+++ b/integration/base/fixable/a/a/a.mts
@@ -1,0 +1,7 @@
+// Imports out-of-order
+import path from 'path';
+import fs from 'fs';
+
+export const main = async () => {
+  await fs.promises.access(path.join('.', 'a.mts'));
+};

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "enquirer": "^2.3.6",
     "esbuild": "~0.17.0",
     "eslint": "^8.11.0",
-    "eslint-config-skuba": "1.4.1",
+    "eslint-config-skuba": "1.4.2",
     "execa": "^5.0.0",
     "fdir": "^6.0.0",
     "fs-extra": "^11.0.0",

--- a/src/cli/__snapshots__/format.int.test.ts.snap
+++ b/src/cli/__snapshots__/format.int.test.ts.snap
@@ -3,10 +3,10 @@
 exports[`fixable 1`] = `
 "
 ESLint
-Processed 2 files in <random>s.
+Processed 4 files in <random>s.
 
 Prettier
-Processed 6 files in <random>s.
+Processed 8 files in <random>s.
 Formatted 4 files:
 b.md
 c.json
@@ -118,7 +118,7 @@ Processed 2 files in <random>s.
   8:3  error  Unexpected console statement  no-console
 
 <random>/d.js
-  1:0  error  Parsing error: Declaration or statement expected
+  1:0  error  Parsing error: Unexpected token (1:0)
 
 ✖ 2 problems (2 errors, 0 warnings)
 

--- a/src/cli/__snapshots__/lint.int.test.ts.snap
+++ b/src/cli/__snapshots__/lint.int.test.ts.snap
@@ -2,15 +2,21 @@
 
 exports[`fixable 1`] = `
 "
-ESLint   │ Processed 2 files in <random>s.
+ESLint   │ Processed 4 files in <random>s.
 ESLint   │ 
+<random>/a/a/a.mjs
+  3:1  error  \`fs\` import should occur before import of \`path\`  import/order
+
+<random>/a/a/a.mts
+  3:1  error  \`fs\` import should occur before import of \`path\`  import/order
+
 <random>/a/a/a.ts
   3:1  error  \`fs\` import should occur before import of \`path\`  import/order
 
-✖ 1 problem (1 error, 0 warnings)
-  1 error and 0 warnings potentially fixable with the \`--fix\` option.
+✖ 3 problems (3 errors, 0 warnings)
+  3 errors and 0 warnings potentially fixable with the \`--fix\` option.
 
-Prettier │ Processed 6 files in <random>s.
+Prettier │ Processed 8 files in <random>s.
 Prettier │ Flagged 4 files:
 Prettier │ b.md
 Prettier │ c.json
@@ -37,11 +43,17 @@ Options: {
 **ESLint**
 
 \`\`\`term
+<random>/a/a/a.mjs
+  3:1  error  \`fs\` import should occur before import of \`path\`  import/order
+
+<random>/a/a/a.mts
+  3:1  error  \`fs\` import should occur before import of \`path\`  import/order
+
 <random>/a/a/a.ts
   3:1  error  \`fs\` import should occur before import of \`path\`  import/order
 
-✖ 1 problem (1 error, 0 warnings)
-  1 error and 0 warnings potentially fixable with the \`--fix\` option.
+✖ 3 problems (3 errors, 0 warnings)
+  3 errors and 0 warnings potentially fixable with the \`--fix\` option.
 \`\`\`
 
 **Prettier**
@@ -143,7 +155,7 @@ ESLint   │
   8:3  error  Unexpected console statement                      no-console
 
 <random>/d.js
-  1:0  error  Parsing error: Declaration or statement expected
+  1:0  error  Parsing error: Unexpected token (1:0)
 
 ✖ 3 problems (3 errors, 0 warnings)
   1 error and 0 warnings potentially fixable with the \`--fix\` option.
@@ -182,7 +194,7 @@ Options: {
   8:3  error  Unexpected console statement                      no-console
 
 <random>/d.js
-  1:0  error  Parsing error: Declaration or statement expected
+  1:0  error  Parsing error: Unexpected token (1:0)
 
 ✖ 3 problems (3 errors, 0 warnings)
   1 error and 0 warnings potentially fixable with the \`--fix\` option.

--- a/src/cli/adapter/eslint.ts
+++ b/src/cli/adapter/eslint.ts
@@ -36,18 +36,6 @@ export const runESLint = async (
 
   const engine = new ESLint({
     cache: true,
-    extensions: [
-      'cjs',
-      'cts',
-      'js',
-      'jsx',
-      'mjs',
-      'mts',
-      'ts',
-      'tsx',
-      'yaml',
-      'yml',
-    ],
     fix: mode === 'format',
     reportUnusedDisableDirectives: 'error',
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3666,10 +3666,10 @@ eslint-config-seek@^10.2.0:
     eslint-plugin-react-hooks "^4.6.0"
     find-root "^1.1.0"
 
-eslint-config-skuba@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-skuba/-/eslint-config-skuba-1.4.1.tgz#ce504944f7ae5da00676118e1f74e2e9cb6e03c2"
-  integrity sha512-wGmy0Q/hLSrpFjYh+vqDfw5AgpGWVd8lmavcoE+DUktO8LjphR5Fyhg7CM5twd5RXxiQUSKh51sJsQ95IbEpxg==
+eslint-config-skuba@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-skuba/-/eslint-config-skuba-1.4.2.tgz#d774dee270daf789f0ded4f7be47ce1087ee8128"
+  integrity sha512-pa27gBE4nBst42VyykKGTALykWhNFvLtiAr6X78s88E3qYdjT4QOoBra+j/u5VuQFQhqVQ7elV/I0XnzDfVbwA==
   dependencies:
     "@types/eslint" "^8.4.1"
     "@typescript-eslint/eslint-plugin" "^5.55.0"


### PR DESCRIPTION
As of v7, ESLint is a bit more friendly:

> ESLint will now lint files with extensions other than `.js` if they are explicitly defined in `overrides[].files` - no need to use the `--ext` flag!

So I added a few new files to verify that it still works without providing a list of extensions. You'll notice a few integration tests failing with this message:

```
<random>/a/a/a.mjs
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/a/a/a.mjs` using `parserOptions.project`: /users/rmate/work/skuba/integration/lint/fixable-bd1e312d13bfc2883c3abec50ef3784eb5e55fe52034b08ce2df4892971d4ce6/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```

That's because the [ESLint config](https://github.com/seek-oss/eslint-config-skuba/blob/master/index.js#L22) needs to be changed as well. And arguably, this is (more) correct since `typescript-eslint` shouldn't be parsing `.{js,mjs,cjs,jsx}` files.

```diff
diff --git a/index.js b/index.js
index 88db565..f74d054 100644
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
       extends: [
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
       ],
-      files: [`*.{${allExtensions.join(',')}}`],
+      files: [`*.{${tsExtensions.join(',')}}`],
       parserOptions: {
         project: './tsconfig.json',
       },

```

If you make the change locally you'll see the tests passing. If you're happy with the changes in this PR I can create a PR in `eslint-config-skuba` with the above diff.