### PR TITLE
Add http server support

### DIFF
--- a/.changeset/nasty-dryers-end.md
+++ b/.changeset/nasty-dryers-end.md
@@ -1,5 +1,5 @@
 ---
-"skuba": minor
+'skuba': minor
 ---
 
 start: Add `http.Server` support

--- a/.changeset/nasty-dryers-end.md
+++ b/.changeset/nasty-dryers-end.md
@@ -1,0 +1,7 @@
+---
+"skuba": minor
+---
+
+start: Add `http.Server` support
+
+`skuba start` can now be used to create a live-reloading server for `http.Server` instances. See the [`skuba start` documentation](https://seek-oss.github.io/skuba/docs/cli/run.html#skuba-start) for more information.

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -152,7 +152,7 @@ const app = express();
 export default Object.assign(app, { port });
 ```
 
-As should a [Http Server]:
+As should a [HTTP Server]:
 
 ```typescript
 const app = http.createServer();

--- a/docs/cli/run.md
+++ b/docs/cli/run.md
@@ -152,6 +152,14 @@ const app = express();
 export default Object.assign(app, { port });
 ```
 
+As should a [Http Server]:
+
+```typescript
+const app = http.createServer();
+
+export default Object.assign(app, { port });
+```
+
 ### Debugging options
 
 The `--inspect` and `--inspect-brk` [Node.js options] are supported for debugging sessions.
@@ -204,5 +212,6 @@ Execution should pause on the breakpoint until we hit `F5` or the `▶️` butto
 [`tsconfig-paths`]: https://github.com/dividab/tsconfig-paths
 [express]: https://expressjs.com/
 [fastify]: https://www.fastify.io/
+[http server]: https://nodejs.org/docs/latest-v18.x/api/http.html#class-httpserver
 [koa]: https://koajs.com/
 [node.js options]: https://nodejs.org/en/docs/guides/debugging-getting-started/#command-line-options

--- a/src/wrapper/main.test.ts
+++ b/src/wrapper/main.test.ts
@@ -104,6 +104,24 @@ test('koaRequestListener', async () => {
   ]);
 });
 
+test('httpServerRequestListener', async () => {
+  // Without `.ts`
+  await initWrapper('httpServerRequestListener');
+
+  expect(startServer.mock.calls).toEqual([[expect.any(nodeHttp.Server), 8080]]);
+
+  return Promise.all([
+    agent
+      .get('/httpServer')
+      .expect(200)
+      .expect(({ text }) =>
+        expect(text).toMatchInlineSnapshot(`"Http Server!"`),
+      ),
+
+    agent.get('/express').expect(404),
+  ]);
+});
+
 test('fastifyRequestListener', async () => {
   // Without `.ts`
   await initWrapper('fastifyRequestListener');

--- a/src/wrapper/requestListener.ts
+++ b/src/wrapper/requestListener.ts
@@ -60,6 +60,11 @@ export const runRequestListener = async ({
 
   const port = isIpPort(config.port) ? config.port : availablePort;
 
+  // http.Server support
+  if (typeof config !== 'function' && config instanceof http.Server) {
+    return startServer(config, port);
+  }
+
   // Fastify workaround
   if (
     typeof config !== 'function' &&

--- a/src/wrapper/testing/httpServerRequestListener.ts
+++ b/src/wrapper/testing/httpServerRequestListener.ts
@@ -1,0 +1,19 @@
+import http from 'http';
+
+import Koa from 'koa';
+
+const app = new Koa().use((ctx) => {
+  if (ctx.request.path === '/httpServer') {
+    ctx.body = 'Http Server!';
+  }
+});
+
+// FIXME: https://github.com/koajs/koa/issues/1755
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+const httpServer = http.createServer(app.callback());
+
+Object.assign(httpServer, {
+  port: 65536,
+});
+
+export default httpServer;


### PR DESCRIPTION
Apollo Server 4 changed how you interact with koa and as a result you now have to export a httpServer instance.

eg. `export = httpServer`

https://github.com/apollo-server-integrations/apollo-server-integration-koa

![image](https://user-images.githubusercontent.com/18017094/235827652-8f33eae7-7a4a-48e1-9a34-6bd3bf195b74.png)

This adds support for exporting a `httpServer` instance.