### PR TITLE
template: Change some lambda worker info logs to debug to reduce unneeded production logging

### DIFF
--- a/.changeset/cyan-knives-drop.md
+++ b/.changeset/cyan-knives-drop.md
@@ -1,0 +1,13 @@
+---
+'skuba': patch
+---
+
+template: Change some lambda worker info logs to debug
+
+The "Function succeeded" log message was changed from `info` to `debug`
+to reduce the amount of unnecessary logs in production.  
+The message will still be logged in dev environments but at a `debug`
+level.
+
+The "Function succeeded" log message was retained as it is part of unit-testing
+the handler.

--- a/template/lambda-sqs-worker/src/app.test.ts
+++ b/template/lambda-sqs-worker/src/app.test.ts
@@ -47,7 +47,7 @@ describe('handler', () => {
 
     expect(logger.error).not.toHaveBeenCalled();
 
-    expect(logger.info.mock.calls).toEqual([
+    expect(logger.debug.mock.calls).toEqual([
       [{ count: 1 }, 'Received jobs'],
       [{ snsMessageId: expect.any(String) }, 'Scored job'],
       ['Function succeeded'],

--- a/template/lambda-sqs-worker/src/app.ts
+++ b/template/lambda-sqs-worker/src/app.ts
@@ -20,7 +20,7 @@ const smokeTest = async () => {
 export const handler = createHandler<SQSEvent>(async (event) => {
   // Treat an empty object as our smoke test event.
   if (!Object.keys(event).length) {
-    logger.info('Received smoke test request');
+    logger.debug('Received smoke test request');
     return smokeTest();
   }
 
@@ -30,7 +30,7 @@ export const handler = createHandler<SQSEvent>(async (event) => {
     throw Error(`Received ${count} records`);
   }
 
-  logger.info({ count }, 'Received jobs');
+  logger.debug({ count }, 'Received jobs');
 
   metricsClient.distribution('job.received', event.Records.length);
 
@@ -46,7 +46,7 @@ export const handler = createHandler<SQSEvent>(async (event) => {
 
   const snsMessageId = await sendPipelineEvent(scoredJob);
 
-  logger.info({ snsMessageId }, 'Scored job');
+  logger.debug({ snsMessageId }, 'Scored job');
 
   metricsClient.distribution('job.scored', 1);
 });

--- a/template/lambda-sqs-worker/src/framework/handler.test.ts
+++ b/template/lambda-sqs-worker/src/framework/handler.test.ts
@@ -18,7 +18,7 @@ describe('createHandler', () => {
     const handler = createHandler((event) => {
       expect(event).toBe(input);
 
-      logger.info('Handler invoked');
+      logger.debug('Handler invoked');
 
       return Promise.resolve(output);
     });
@@ -27,7 +27,7 @@ describe('createHandler', () => {
 
     expect(logger.error).not.toHaveBeenCalled();
 
-    expect(logger.info.mock.calls).toEqual([
+    expect(logger.debug.mock.calls).toEqual([
       ['Handler invoked'],
       ['Function succeeded'],
     ]);
@@ -42,7 +42,7 @@ describe('createHandler', () => {
 
     expect(logger.error).toHaveBeenCalledWith({ err }, 'Function failed');
 
-    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
   });
 
   it('handles sync error', async () => {
@@ -56,6 +56,6 @@ describe('createHandler', () => {
 
     expect(logger.error).toHaveBeenCalledWith({ err }, 'Function failed');
 
-    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.debug).not.toHaveBeenCalled();
   });
 });

--- a/template/lambda-sqs-worker/src/framework/handler.ts
+++ b/template/lambda-sqs-worker/src/framework/handler.ts
@@ -31,7 +31,7 @@ export const createHandler = <Event, Output = unknown>(
       try {
         const output = await fn(event);
 
-        logger.info('Function succeeded');
+        logger.debug('Function succeeded');
 
         return output;
       } catch (err) {

--- a/template/lambda-sqs-worker/src/testing/logging.ts
+++ b/template/lambda-sqs-worker/src/testing/logging.ts
@@ -3,14 +3,17 @@ import * as logging from 'src/framework/logging';
 export const logger = {
   error: jest.fn(),
   info: jest.fn(),
+  debug: jest.fn(),
 
   clear: () => {
     logger.error.mockClear();
     logger.info.mockClear();
+    logger.debug.mockClear();
   },
 
   spy: () => {
     jest.spyOn(logging.logger, 'error').mockImplementation(logger.error);
     jest.spyOn(logging.logger, 'info').mockImplementation(logger.info);
+    jest.spyOn(logging.logger, 'debug').mockImplementation(logger.debug);
   },
 };


### PR DESCRIPTION
The "Function succeeded" log message was changed from `info` to `debug`
to reduce the amount of unnecessary logs in production.  
The message will still be logged in dev environments but at a `debug`
level.

The "Function succeeded" log message was retained as it is part of unit-testing
the handler.