### PR TITLE
Disable noUnusedLocals and noUnusedParameters in tsconfig

### DIFF
--- a/.changeset/forty-hornets-argue.md
+++ b/.changeset/forty-hornets-argue.md
@@ -1,0 +1,8 @@
+---
+'skuba': patch
+---
+
+tsconfig: Make noUnusedLocals and noUnusedParameters false
+
+Skuba is already using Seek's ESLint config which has a [rule](https://eslint.org/docs/latest/rules/no-unused-vars) which works for both function and types.
+We do not need both tools to do the same thing. ESLint has better support for ignoring files if needed.

--- a/.changeset/forty-hornets-argue.md
+++ b/.changeset/forty-hornets-argue.md
@@ -2,7 +2,6 @@
 'skuba': patch
 ---
 
-tsconfig: Make noUnusedLocals and noUnusedParameters false
+tsconfig: Turn off [`noUnusedLocals`](https://www.typescriptlang.org/tsconfig#noUnusedLocals) and [`noUnusedParameters`](https://www.typescriptlang.org/tsconfig#noUnusedParameters)
 
-Skuba is already using Seek's ESLint config which has a [rule](https://eslint.org/docs/latest/rules/no-unused-vars) which works for both function and types.
-We do not need both tools to do the same thing. ESLint has better support for ignoring files if needed.
+[SEEK's ESLint config](https://github.com/seek-oss/eslint-config-seek) has a [rule](https://eslint.org/docs/latest/rules/no-unused-vars) which works for both function and types. We do not need both tools to do the same thing and ESLint has better support for ignoring files if needed.

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -3,7 +3,9 @@
     "incremental": true,
     "isolatedModules": true,
     "moduleResolution": "node",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
   },
   "extends": "tsconfig-seek"
 }


### PR DESCRIPTION
Make `noUnusedLocals` and `noUnusedParameters` false.

These two values are set as `true` in SEEK's tsconfig.

Skuba is already using Seek's ESLint config which has a [rule](https://eslint.org/docs/latest/rules/no-unused-vars) which works for both function and types.

We do not need both tools to do the same thing. ESLint has better support for ignoring files  if needed.