### PR TITLE
Update distroless nodejs image

### DIFF
--- a/.changeset/silly-swans-serve.md
+++ b/.changeset/silly-swans-serve.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/\*-rest-api: Switch distroless image from nodejs:18 to nodejs18-debian11

--- a/.changeset/silly-swans-serve.md
+++ b/.changeset/silly-swans-serve.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/\*-rest-api: Switch distroless image from nodejs:18 to nodejs18-debian11
+template/\*-rest-api: Switch distroless image from `nodejs:18` to `nodejs18-debian11`

--- a/.changeset/wild-plums-join.md
+++ b/.changeset/wild-plums-join.md
@@ -2,6 +2,6 @@
 'skuba': minor
 ---
 
-format/lint: Switch distroless image from nodejs to nodejs-debian11
+format, lint: Switch distroless image from `nodejs` to `nodejs-debian11`
 
-skuba format and skuba lint will now automatically switch your gcr.io/distroless/nodejs:18 image to gcr.io/distroless/nodejs18-debian11. This is now the [recommended](https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md) base image for Node.js.
+`skuba format` and `skuba lint` will now automatically switch your `gcr.io/distroless/nodejs:18` image to `gcr.io/distroless/nodejs18-debian11`. This is now the [recommended](https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md) base image for Node.js.

--- a/.changeset/wild-plums-join.md
+++ b/.changeset/wild-plums-join.md
@@ -1,0 +1,7 @@
+---
+'skuba': minor
+---
+
+format/lint: Switch distroless image from nodejs to nodejs-debian11
+
+skuba format and skuba lint will now automatically switch your gcr.io/distroless/nodejs:18 image to gcr.io/distroless/nodejs18-debian11. This is now the [recommended](https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md) base image for Node.js.

--- a/docs/deep-dives/arm64.md
+++ b/docs/deep-dives/arm64.md
@@ -54,11 +54,11 @@ Replace the relevant `--platform` values in your Dockerfile(s),
 then ensure that you run your builds on AMD64 hardware:
 
 ```diff
-- FROM --platform=arm64 gcr.io/distroless/nodejs:18 AS runtime
-+ FROM --platform=${BUILDPLATFORM:-amd64} gcr.io/distroless/nodejs:18 AS runtime
+- FROM --platform=arm64 gcr.io/distroless/nodejs18-debian11 AS runtime
++ FROM --platform=${BUILDPLATFORM:-amd64} gcr.io/distroless/nodejs18-debian11 AS runtime
 
-- FROM --platform=${BUILDPLATFORM:-arm64} gcr.io/distroless/nodejs:18 AS runtime
-+ FROM --platform=${BUILDPLATFORM:-amd64} gcr.io/distroless/nodejs:18 AS runtime
+- FROM --platform=${BUILDPLATFORM:-arm64} gcr.io/distroless/nodejs18-debian11 AS runtime
++ FROM --platform=${BUILDPLATFORM:-amd64} gcr.io/distroless/nodejs18-debian11 AS runtime
 ```
 
 For a [Gantry] service, modify the `cpuArchitecture` property in your `gantry.build.yml` and `gantry.apply.yml` resource files:

--- a/src/cli/configure/patchDockerfile.test.ts
+++ b/src/cli/configure/patchDockerfile.test.ts
@@ -1,0 +1,44 @@
+import memfs, { vol } from 'memfs';
+
+import { tryPatchDockerfile } from './patchDockerfile';
+
+jest.mock('fs-extra', () => memfs);
+
+const volToJson = () => vol.toJSON(process.cwd(), undefined, true);
+
+beforeEach(jest.clearAllMocks);
+beforeEach(() => vol.reset());
+
+const dockerfile = `
+ARG BASE_IMAGE
+ARG BASE_TAG
+
+FROM --platform=\${BUILDPLATFORM:-<%- platformName %>} gcr.io/distroless/nodejs:18 AS runtime
+
+WORKDIR /workdir
+`;
+
+it('patches an existing Dockerfile', async () => {
+  vol.fromJSON({ Dockerfile: dockerfile });
+
+  await expect(tryPatchDockerfile()).resolves.toBeUndefined();
+
+  expect(volToJson()).toMatchInlineSnapshot(`
+{
+  "Dockerfile": "
+ARG BASE_IMAGE
+ARG BASE_TAG
+
+FROM --platform=\${BUILDPLATFORM:-<%- platformName %>} gcr.io/distroless/nodejs18-debian11 AS runtime
+
+WORKDIR /workdir
+",
+}
+`);
+});
+
+it('ignores when a Dockerfile is missing', async () => {
+  vol.fromJSON({});
+
+  await expect(tryPatchDockerfile()).resolves.toBeUndefined();
+});

--- a/src/cli/configure/patchDockerfile.ts
+++ b/src/cli/configure/patchDockerfile.ts
@@ -1,0 +1,38 @@
+import { inspect } from 'util';
+
+import fs from 'fs-extra';
+
+import { log } from '../../utils/logging';
+
+import { createDestinationFileReader } from './analysis/project';
+
+const DOCKERFILE_FILENAME = 'Dockerfile';
+
+const VERSION_REGEX = /gcr.io\/distroless\/nodejs:(16|18|20)/g;
+const VERSION_DEBIAN_REPLACE = 'gcr.io/distroless/nodejs$1-debian11';
+
+const patchDockerfile = async (dir: string) => {
+  const readFile = createDestinationFileReader(dir);
+
+  const maybeDockerfile = await readFile(DOCKERFILE_FILENAME);
+
+  if (!maybeDockerfile) {
+    return;
+  }
+
+  const patched = maybeDockerfile.replaceAll(
+    VERSION_REGEX,
+    VERSION_DEBIAN_REPLACE,
+  );
+
+  await fs.promises.writeFile(DOCKERFILE_FILENAME, patched);
+};
+
+export const tryPatchDockerfile = async (dir = process.cwd()) => {
+  try {
+    await patchDockerfile(dir);
+  } catch (err) {
+    log.warn('Failed to patch Dockerfile.');
+    log.subtle(inspect(err));
+  }
+};

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -6,6 +6,7 @@ import { createLogger, log } from '../utils/logging';
 import { runESLint } from './adapter/eslint';
 import { runPrettier } from './adapter/prettier';
 import { tryAddEmptyExports } from './configure/addEmptyExports';
+import { tryPatchDockerfile } from './configure/patchDockerfile';
 import { tryPatchRenovateConfig } from './configure/patchRenovateConfig';
 import { tryPatchServerListener } from './configure/patchServerListener';
 import { tryRefreshIgnoreFiles } from './configure/refreshIgnoreFiles';
@@ -14,6 +15,7 @@ export const format = async (args = process.argv.slice(2)): Promise<void> => {
   await Promise.all([
     tryAddEmptyExports(),
     tryPatchRenovateConfig(),
+    tryPatchDockerfile(),
     tryPatchServerListener(),
     tryRefreshIgnoreFiles(),
   ]);

--- a/template/express-rest-api/Dockerfile
+++ b/template/express-rest-api/Dockerfile
@@ -17,7 +17,7 @@ RUN yarn build
 
 ###
 
-FROM --platform=${BUILDPLATFORM:-<%- platformName %>} gcr.io/distroless/nodejs:18 AS runtime
+FROM --platform=${BUILDPLATFORM:-<%- platformName %>} gcr.io/distroless/nodejs18-debian11 AS runtime
 
 WORKDIR /workdir
 

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -17,7 +17,7 @@ RUN yarn build
 
 ###
 
-FROM --platform=${BUILDPLATFORM:-<%- platformName %>} gcr.io/distroless/nodejs:18 AS runtime
+FROM --platform=${BUILDPLATFORM:-<%- platformName %>} gcr.io/distroless/nodejs18-debian11 AS runtime
 
 WORKDIR /workdir
 


### PR DESCRIPTION
The current image has these vulnerabilities flagged in ECR but the new `-debian11` image is free from them.

![image](https://github.com/seek-oss/skuba/assets/18017094/173c31b4-a2e6-4be8-884e-829857f65dad)

For whatever reason, this image isn't using the latest deps/libs? I haven't quite looked at why but the documentation now recommends `gcr.io/distroless/nodejs18-debian11` by default

https://github.com/GoogleContainerTools/distroless/blob/main/nodejs/README.md