### PR TITLE
Add pnpm-lock.yaml to .prettierignore

### DIFF
--- a/.changeset/thirty-bananas-tickle.md
+++ b/.changeset/thirty-bananas-tickle.md
@@ -1,0 +1,5 @@
+---
+'skuba': minor
+---
+
+Add pnpm-lock.yaml to .prettierignore

--- a/template/base/_.prettierignore
+++ b/template/base/_.prettierignore
@@ -4,4 +4,5 @@
 /.gantry/**/*.yml
 gantry*.yaml
 gantry*.yml
+pnpm-lock.yaml
 # end managed by skuba


### PR DESCRIPTION
This has caught a few people out - prettier formats `pnpm-lock.yaml` differently to how `pnpm` commands generate the file as, resulting in formatting errors or churn.