### PR TITLE
fix supertest app.test.ts example

### DIFF
--- a/.changeset/calm-tips-wait.md
+++ b/.changeset/calm-tips-wait.md
@@ -1,0 +1,12 @@
+---
+'skuba': patch
+---
+
+template/koa-rest-api: Fix `app.test.ts` assertions
+
+Previously, [custom `.expect((res) => {})` assertions](https://github.com/ladjs/supertest#expectfunctionres-) were incorrectly defined to return false rather than throw an error. The template has been updated to avoid this syntax, but the most straightforward diff to demonstrate the fix is as follows:
+
+```diff
+- await agent.get('/').expect(({ status }) => status !== 404);
++ await agent.get('/').expect(({ status }) => expect(status).not.toBe(404));
+```

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -3,6 +3,10 @@
 set -e
 
 template="${1}"
+if [ -z "$template" ]; then
+  echo "Usage: yarn test:template <template_name>"
+  exit 1
+fi
 
 directory="tmp-${template}"
 

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -17,10 +17,18 @@ describe('app', () => {
       }
     }));
 
+  /**
+   * Test assertion with logic
+   */
   it('has a reachable nested route', () =>
     agent.get('/jobs').expect(({ status }) => {
-      if (status === 404) {
-        throw new Error('Unreachable nested route');
+      switch (status) {
+        case 200:
+          return;
+        case 404:
+          throw new Error('Unreachable jobs route');
+        default:
+          throw new Error(`Unexpected status: ${status}`);
       }
     }));
 

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -10,12 +10,10 @@ describe('app', () => {
 
   it('has a happy health check', () => agent.get('/health').expect(200, ''));
 
-  it('has a reachable smoke test', () =>
-    agent.get('/smoke').expect(({ status }) => {
-      if (status === 404) {
-        throw new Error('Unreachable smoke test');
-      }
-    }));
+  it('has a reachable smoke test', async () => {
+    const response = await agent.get('/smoke');
+    expect(response.status).not.toBe(404);
+  });
 
   /**
    * Test assertion with logic

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -15,20 +15,10 @@ describe('app', () => {
     expect(response.status).not.toBe(404);
   });
 
-  /**
-   * Test assertion with logic
-   */
-  it('has a reachable nested route', () =>
-    agent.get('/jobs').expect(({ status }) => {
-      switch (status) {
-        case 200:
-          return;
-        case 404:
-          throw new Error('Unreachable jobs route');
-        default:
-          throw new Error(`Unexpected status: ${status}`);
-      }
-    }));
+  it('has a reachable nested route', async () => {
+    const response = await agent.get('/jobs');
+    expect(response.status).not.toBe(404);
+  });
 
   it('has OPTIONS for a nested route', () =>
     agent.options('/jobs').expect(200).expect('allow', /HEAD/));

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -11,10 +11,18 @@ describe('app', () => {
   it('has a happy health check', () => agent.get('/health').expect(200, ''));
 
   it('has a reachable smoke test', () =>
-    agent.get('/smoke').expect(({ status }) => status !== 404));
+    agent.get('/smoke').expect(({ status }) => {
+      if (status === 404) {
+        throw new Error('Unreachable smoke test');
+      }
+    }));
 
   it('has a reachable nested route', () =>
-    agent.get('/jobs').expect(({ status }) => status !== 404));
+    agent.get('/jobs').expect(({ status }) => {
+      if (status === 404) {
+        throw new Error('Unreachable nested route');
+      }
+    }));
 
   it('has OPTIONS for a nested route', () =>
     agent.options('/jobs').expect(200).expect('allow', /HEAD/));


### PR DESCRIPTION
### Why

The below unit tests do not fail when endpoint returns 404
We either use `expect` function or throw when check fails  https://github.com/ladjs/supertest#expectfunctionres-

### What
Modify unit test
Add usage message when argument is not received