### PR TITLE
init: Fix `skuba.template.js` validation

### DIFF
--- a/.changeset/old-berries-train.md
+++ b/.changeset/old-berries-train.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+init: Fix `skuba.template.js` validation
+
+This resolves an "Invalid function return type" error on `skuba init`.

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -77,7 +77,9 @@ export const templateConfigSchema = z.object({
       name: z.string(),
       message: z.string(),
       initial: z.string(),
-      validate: z.function(z.tuple([z.string()]), z.boolean()).optional(),
+      validate: z
+        .function(z.tuple([z.string()]), z.union([z.boolean(), z.string()]))
+        .optional(),
     }),
   ),
   entryPoint: z.string().optional(),

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -78,7 +78,9 @@ export const templateConfigSchema = z.object({
       message: z.string(),
       initial: z.string(),
       validate: z
-        .function(z.tuple([z.string()]), z.union([z.boolean(), z.string()]))
+        .function()
+        .args(z.string())
+        .returns(z.union([z.boolean(), z.string()]))
         .optional(),
     }),
   ),


### PR DESCRIPTION
This resolves an "Invalid function return type" error on `skuba init`.