### PR TITLE
RFC: Don't silently write on lint

### DIFF
--- a/src/cli/configure/refreshIgnoreFiles.ts
+++ b/src/cli/configure/refreshIgnoreFiles.ts
@@ -16,7 +16,11 @@ export const REFRESHABLE_IGNORE_FILES = [
   '.prettierignore',
 ];
 
-export const refreshIgnoreFiles = async () => {
+interface RefreshOptions {
+  linting: boolean;
+}
+
+export const refreshIgnoreFiles = async ({ linting }: RefreshOptions) => {
   const manifest = await getDestinationManifest();
 
   const destinationRoot = path.dirname(manifest.path);
@@ -35,15 +39,35 @@ export const refreshIgnoreFiles = async () => {
 
     const filepath = path.join(destinationRoot, filename);
 
+    if (linting) {
+      return { ok: data === inputFile, filename };
+    }
+
     await fs.promises.writeFile(filepath, data);
+    return { ok: true, filename };
   };
 
-  await Promise.all(REFRESHABLE_IGNORE_FILES.map(refreshIgnoreFile));
+  const results = await Promise.all(
+    REFRESHABLE_IGNORE_FILES.map(refreshIgnoreFile),
+  );
+
+  if (results.some((result) => !result.ok)) {
+    const notOk = results
+      .filter((result) => !result.ok)
+      .map((r) => r.filename)
+      .join(',');
+
+    log.newline();
+    log.err(
+      `Some ignore files (${notOk}) were not up-to-date. Run \`skuba format\` to refresh them.`,
+    );
+    process.exitCode = 1;
+  }
 };
 
-export const tryRefreshIgnoreFiles = async () => {
+export const tryRefreshIgnoreFiles = async (options: RefreshOptions) => {
   try {
-    await refreshIgnoreFiles();
+    await refreshIgnoreFiles(options);
   } catch (err) {
     log.warn('Failed to refresh ignore files.');
     log.subtle(inspect(err));

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -9,7 +9,10 @@ import { tryRefreshIgnoreFiles } from './configure/refreshIgnoreFiles';
 import { upgradeSkuba } from './configure/upgrade';
 
 export const format = async (args = process.argv.slice(2)): Promise<void> => {
-  await Promise.all([tryRefreshIgnoreFiles(), upgradeSkuba()]);
+  await Promise.all([
+    tryRefreshIgnoreFiles({ linting: false }),
+    upgradeSkuba(),
+  ]);
 
   const debug = hasDebugFlag(args);
   const logger = createLogger(debug);

--- a/src/cli/lint/index.ts
+++ b/src/cli/lint/index.ts
@@ -13,7 +13,7 @@ export const lint = async (
   tscOutputStream: Writable | undefined = undefined,
   workerThreads = true,
 ) => {
-  await Promise.all([tryRefreshIgnoreFiles(), upgradeSkuba()]);
+  await Promise.all([tryRefreshIgnoreFiles({ linting: true }), upgradeSkuba()]);
 
   const opts: Input = {
     debug: hasDebugFlag(args),


### PR DESCRIPTION
Currently, if .gitignore/other ignore files need to be fixed by `format`, you can get away with never having them fixed because lint never fails. I've seen cases where they're not pushed with autofix (unsure if always or just if no write perms?)

There's way more work to do here (same goes for skuba upgrade), autofix would be nice, but hoping to get feedback on direction before committing 

Fairly important to get right before pnpm / managing npmrc 