### PR TITLE
Use `fs-extra` more consistently

### DIFF
--- a/src/cli/configure/upgrade/patches/7.3.1/addEmptyExports.test.ts
+++ b/src/cli/configure/upgrade/patches/7.3.1/addEmptyExports.test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs-extra';
 
 import * as packageAnalysis from '../../../analysis/package';
 import * as projectAnalysis from '../../../analysis/project';

--- a/src/cli/configure/upgrade/patches/7.3.1/patchServerListener.test.ts
+++ b/src/cli/configure/upgrade/patches/7.3.1/patchServerListener.test.ts
@@ -1,6 +1,6 @@
+import fs from 'fs';
 import { inspect } from 'util';
 
-import fs from 'fs-extra';
 import memfs, { vol } from 'memfs';
 
 import { tryPatchServerListener } from './patchServerListener';

--- a/src/cli/configure/upgrade/patches/7.3.1/patchServerListener.test.ts
+++ b/src/cli/configure/upgrade/patches/7.3.1/patchServerListener.test.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
 import { inspect } from 'util';
 
+import fs from 'fs-extra';
 import memfs, { vol } from 'memfs';
 
 import { tryPatchServerListener } from './patchServerListener';

--- a/src/cli/lint.int.test.ts
+++ b/src/cli/lint.int.test.ts
@@ -1,10 +1,9 @@
 import crypto from 'crypto';
-import fs from 'fs';
 import path from 'path';
 import stream from 'stream';
 import { inspect } from 'util';
 
-import { copy } from 'fs-extra';
+import fs, { copy } from 'fs-extra';
 import git from 'isomorphic-git';
 
 import { Buildkite } from '..';


### PR DESCRIPTION
These are just internal tests, but they are harmless to tweak and this may make it more obvious that we are intentionally choosing `fs-extra`.

https://github.com/seek-oss/skuba/pull/1274#discussion_r1424901691