### PR TITLE
Enumerate patch directories only

### DIFF
--- a/src/cli/configure/upgrade/index.test.ts
+++ b/src/cli/configure/upgrade/index.test.ts
@@ -81,9 +81,12 @@ describe('upgradeSkuba in format mode', () => {
     jest.mocked(getSkubaVersion).mockResolvedValue('2.0.0');
 
     // readdir has overloads and the mocked version doesn't match the string version
-    jest
-      .mocked(readdir)
-      .mockResolvedValue(['0.9.0', '1.0.0', '2.0.0'] as never);
+    jest.mocked(readdir).mockResolvedValue([
+      { isDirectory: () => true, name: '0.9.0' },
+      { isDirectory: () => true, name: '1.0.0' },
+      { isDirectory: () => true, name: '2.0.0' },
+      { isDirectory: () => false, name: 'index.d.ts' },
+    ] as never);
 
     await expect(upgradeSkuba('format', log)).resolves.toEqual({
       ok: true,
@@ -118,7 +121,9 @@ describe('upgradeSkuba in format mode', () => {
     jest.mocked(getSkubaVersion).mockResolvedValue('2.0.0');
 
     // readdir has overloads and the mocked version doesn't match the string version
-    jest.mocked(readdir).mockResolvedValue(['2.0.0'] as never);
+    jest
+      .mocked(readdir)
+      .mockResolvedValue([{ isDirectory: () => true, name: '2.0.0' }] as never);
 
     await expect(upgradeSkuba('format', log)).resolves.toEqual({
       ok: true,
@@ -161,7 +166,9 @@ describe('upgradeSkuba in format mode', () => {
     jest.mocked(getSkubaVersion).mockResolvedValue('2.0.0');
 
     // readdir has overloads and the mocked version doesn't match the string version
-    jest.mocked(readdir).mockResolvedValue(['2.0.0'] as never);
+    jest
+      .mocked(readdir)
+      .mockResolvedValue([{ isDirectory: () => true, name: '2.0.0' }] as never);
 
     await expect(upgradeSkuba('format', log)).resolves.toEqual({
       ok: true,
@@ -232,9 +239,11 @@ describe('upgradeSkuba in lint mode', () => {
     jest.mocked(getSkubaVersion).mockResolvedValue('2.0.0');
 
     // readdir has overloads and the mocked version doesn't match the string version
-    jest
-      .mocked(readdir)
-      .mockResolvedValue(['0.9.0', '1.0.0', '2.0.0'] as never);
+    jest.mocked(readdir).mockResolvedValue([
+      { isDirectory: () => true, name: '0.9.0' },
+      { isDirectory: () => true, name: '1.0.0' },
+      { isDirectory: () => true, name: '2.0.0' },
+    ] as never);
 
     await expect(upgradeSkuba('lint', log)).resolves.toEqual({
       ok: false,
@@ -265,7 +274,9 @@ describe('upgradeSkuba in lint mode', () => {
 
     jest.mocked(getSkubaVersion).mockResolvedValue('2.0.0');
 
-    jest.mocked(readdir).mockResolvedValue(['0.9.0'] as never);
+    jest
+      .mocked(readdir)
+      .mockResolvedValue([{ isDirectory: () => true, name: '0.9.0' }] as never);
 
     await expect(upgradeSkuba('lint', log)).resolves.toEqual({
       ok: true,


### PR DESCRIPTION
Apparently `index.d.ts` is not a valid semver :D

```
skuba    │ Failed to run skuba lints.
skuba    │ TypeError: Invalid Version: index.d.ts
    at new SemVer (/Users/rling/Code/github.com/seek-oss/skuba/node_modules/.pnpm/semver@7.5.4/node_modules/semver/classes/semver.js:38:13)
    at compare (/Users/rling/Code/github.com/seek-oss/skuba/node_modules/.pnpm/semver@7.5.4/node_modules/semver/functions/compare.js:3:3)
    at gte (/Users/rling/Code/github.com/seek-oss/skuba/node_modules/.pnpm/semver@7.5.4/node_modules/semver/functions/gte.js:2:30)
    at /Users/rling/Code/github.com/seek-oss/skuba/lib/cli/configure/upgrade/index.js:46:38
    at Array.filter (<anonymous>)
    at getPatches (/Users/rling/Code/github.com/seek-oss/skuba/lib/cli/configure/upgrade/index.js:44:13)
    at async upgradeSkuba (/Users/rling/Code/github.com/seek-oss/skuba/lib/cli/configure/upgrade/index.js:78:19)
    at async Promise.all (index 0)
    at async lintConcurrently (/Users/rling/Code/github.com/seek-oss/skuba/lib/cli/lint/internal.js:59:10)
    at async internalLint (/Users/rling/Code/github.com/seek-oss/skuba/lib/cli/lint/internal.js:76:21)
```