### PR TITLE
add .npmrc mounts

### DIFF
--- a/template/express-rest-api/.buildkite/pipeline.yml
+++ b/template/express-rest-api/.buildkite/pipeline.yml
@@ -10,7 +10,9 @@ configs:
 
     - &docker-ecr-cache
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
-        cache-on: pnpm-lock.yaml
+        cache-on:
+          - .npmrc
+          - pnpm-lock.yaml
         dockerfile: Dockerfile.dev-deps
         secrets: id=npm,src=tmp/.npmrc
 

--- a/template/express-rest-api/Dockerfile.dev-deps
+++ b/template/express-rest-api/Dockerfile.dev-deps
@@ -8,5 +8,6 @@ RUN pnpm config set store-dir /root/.pnpm-store
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+    --mount=type=bind,source=.npmrc,target=.npmrc \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/greeter/.buildkite/pipeline.yml
+++ b/template/greeter/.buildkite/pipeline.yml
@@ -10,7 +10,9 @@ configs:
 
     - &docker-ecr-cache
       seek-oss/docker-ecr-cache#v2.1.1:
-        cache-on: pnpm-lock.yaml
+        cache-on:
+          - .npmrc
+          - pnpm-lock.yaml
         secrets: id=npm,src=tmp/.npmrc
 
     - &private-npm

--- a/template/greeter/Dockerfile
+++ b/template/greeter/Dockerfile
@@ -8,5 +8,6 @@ RUN pnpm config set store-dir /root/.pnpm-store
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+    --mount=type=bind,source=.npmrc,target=.npmrc \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/koa-rest-api/.buildkite/pipeline.yml
+++ b/template/koa-rest-api/.buildkite/pipeline.yml
@@ -10,7 +10,9 @@ configs:
 
     - &docker-ecr-cache
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
-        cache-on: pnpm-lock.yaml
+        cache-on:
+          - .npmrc
+          - pnpm-lock.yaml
         dockerfile: Dockerfile.dev-deps
         secrets: id=npm,src=tmp/.npmrc
 

--- a/template/koa-rest-api/Dockerfile.dev-deps
+++ b/template/koa-rest-api/Dockerfile.dev-deps
@@ -8,5 +8,6 @@ RUN pnpm config set store-dir /root/.pnpm-store
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+    --mount=type=bind,source=.npmrc,target=.npmrc \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -10,7 +10,9 @@ configs:
 
     - &docker-ecr-cache
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
-        cache-on: pnpm-lock.yaml
+        cache-on:
+          - .npmrc
+          - pnpm-lock.yaml
         secrets: id=npm,src=tmp/.npmrc
 
     - &private-npm

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -11,5 +11,6 @@ RUN pnpm config set store-dir /root/.pnpm-store
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+    --mount=type=bind,source=.npmrc,target=.npmrc \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/lambda-sqs-worker/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker/.buildkite/pipeline.yml
@@ -10,7 +10,9 @@ configs:
 
     - &docker-ecr-cache
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
-        cache-on: pnpm-lock.yaml
+        cache-on:
+          - .npmrc
+          - pnpm-lock.yaml
         secrets: id=npm,src=tmp/.npmrc
 
     - &private-npm

--- a/template/lambda-sqs-worker/Dockerfile
+++ b/template/lambda-sqs-worker/Dockerfile
@@ -8,5 +8,6 @@ RUN pnpm config set store-dir /root/.pnpm-store
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
+    --mount=type=bind,source=.npmrc,target=.npmrc \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch


### PR DESCRIPTION
Looks like `pnpm fetch` reads the `.npmrc` for settings and outputs a `publicHoistPattern` in `node_modules/.modules.yaml`

<img width="747" alt="image" src="https://github.com/seek-oss/skuba/assets/18017094/2d31aa92-48fa-4751-91e8-8e9117a4cebc">

As a result, when we go to run `pnpm install --offline` it fails silently and asks if we would like to destroy `node_modules`

<img width="1023" alt="image" src="https://github.com/seek-oss/skuba/assets/18017094/152ef5d7-6556-4f43-8030-a91431c000c2">

This results in `skuba` not being properly hoisted.