### PR TITLE
Fix lambda CDK snapshot churn

### DIFF
--- a/.changeset/rare-eggs-tell.md
+++ b/.changeset/rare-eggs-tell.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/lambda-sqs-worker-cdk: Update tests to use a stable bundling.assetHash to avoid irrelevant snapshot changes on lockfile/source code/other changes

--- a/.changeset/rare-eggs-tell.md
+++ b/.changeset/rare-eggs-tell.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/lambda-sqs-worker-cdk: Update tests to use a stable bundling.assetHash to avoid irrelevant snapshot changes on lockfile/source code/other changes
+template/lambda-sqs-worker-cdk: Update tests to use a stable identifier for the AWS::Lambda in snapshots, to avoid irrelevant snapshot changes on unrelated source code changes

--- a/.changeset/rare-eggs-tell.md
+++ b/.changeset/rare-eggs-tell.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/lambda-sqs-worker-cdk: Update tests to use a stable identifier for the AWS::Lambda in snapshots, to avoid irrelevant snapshot changes on unrelated source code changes
+template/lambda-sqs-worker-cdk: Update tests to use a stable identifier for the `AWS::Lambda::Version` logical IDs in snapshots. This avoid snapshot changes on unrelated source code changes.

--- a/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
+++ b/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
@@ -481,7 +481,7 @@ exports[`returns expected CloudFormation stack for dev 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "workerCurrentVersionFA5B4BF441e66128e5ed7959d9ba938428a73330",
+            "workerCurrentVersionxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             "Version",
           ],
         },
@@ -540,7 +540,7 @@ exports[`returns expected CloudFormation stack for dev 1`] = `
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "workerCurrentVersionFA5B4BF441e66128e5ed7959d9ba938428a73330": {
+    "workerCurrentVersionxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": {
       "Properties": {
         "FunctionName": {
           "Ref": "worker28EA3E30",
@@ -1523,7 +1523,7 @@ exports[`returns expected CloudFormation stack for prod 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "workerCurrentVersionFA5B4BF4604e806aad8a7f8068cc002718ea2bdc",
+            "workerCurrentVersionxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
             "Version",
           ],
         },
@@ -1582,7 +1582,7 @@ exports[`returns expected CloudFormation stack for prod 1`] = `
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "workerCurrentVersionFA5B4BF4604e806aad8a7f8068cc002718ea2bdc": {
+    "workerCurrentVersionxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": {
       "Properties": {
         "FunctionName": {
           "Ref": "worker28EA3E30",

--- a/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
+++ b/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
@@ -481,7 +481,7 @@ exports[`returns expected CloudFormation stack for dev 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "workerCurrentVersionFA5B4BF4c6e1b764a3a99fdb70911ac06ee9afd5",
+            "workerCurrentVersionFA5B4BF441e66128e5ed7959d9ba938428a73330",
             "Version",
           ],
         },
@@ -540,7 +540,7 @@ exports[`returns expected CloudFormation stack for dev 1`] = `
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "workerCurrentVersionFA5B4BF4c6e1b764a3a99fdb70911ac06ee9afd5": {
+    "workerCurrentVersionFA5B4BF441e66128e5ed7959d9ba938428a73330": {
       "Properties": {
         "FunctionName": {
           "Ref": "worker28EA3E30",
@@ -1523,7 +1523,7 @@ exports[`returns expected CloudFormation stack for prod 1`] = `
         },
         "FunctionVersion": {
           "Fn::GetAtt": [
-            "workerCurrentVersionFA5B4BF40f2ad063ab6223cdd6c6489f9188cf94",
+            "workerCurrentVersionFA5B4BF4604e806aad8a7f8068cc002718ea2bdc",
             "Version",
           ],
         },
@@ -1582,7 +1582,7 @@ exports[`returns expected CloudFormation stack for prod 1`] = `
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
-    "workerCurrentVersionFA5B4BF40f2ad063ab6223cdd6c6489f9188cf94": {
+    "workerCurrentVersionFA5B4BF4604e806aad8a7f8068cc002718ea2bdc": {
       "Properties": {
         "FunctionName": {
           "Ref": "worker28EA3E30",

--- a/template/lambda-sqs-worker-cdk/infra/appStack.test.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.test.ts
@@ -31,6 +31,15 @@ jest.useFakeTimers({
   now: new Date(currentDate),
 });
 
+class AppStackWithStableHash extends AppStack {
+  get defaultWorkerBundlingConfig() {
+    return {
+      ...super.defaultWorkerBundlingConfig,
+      assetHash: 'mocked',
+    };
+  }
+}
+
 it.each(contexts)(
   'returns expected CloudFormation stack for $stage',
   (context) => {
@@ -40,7 +49,7 @@ it.each(contexts)(
 
     const app = new App({ context });
 
-    const stack = new AppStack(app, 'appStack');
+    const stack = new AppStackWithStableHash(app, 'appStack');
 
     const template = Template.fromStack(stack);
 

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -68,6 +68,13 @@ export class AppStack extends Stack {
       awsSdkConnectionReuse: false,
     };
 
+    const defaultWorkerBundlingConfig: aws_lambda_nodejs.BundlingOptions = {
+      sourceMap: true,
+      target: 'node20',
+      // aws-sdk-v3 is set as an external module by default, but we want it to be bundled with the function
+      externalModules: [],
+    };
+
     const defaultWorkerEnvironment: Record<string, string> = {
       NODE_ENV: 'production',
       // https://nodejs.org/api/cli.html#cli_node_options_options
@@ -78,7 +85,7 @@ export class AppStack extends Stack {
       ...defaultWorkerConfig,
       entry: './src/app.ts',
       timeout: Duration.seconds(30),
-      bundling: this.defaultWorkerBundlingConfig,
+      bundling: defaultWorkerBundlingConfig,
       functionName: '<%- serviceName %>',
       environment: {
         ...defaultWorkerEnvironment,
@@ -108,7 +115,7 @@ export class AppStack extends Stack {
         ...defaultWorkerConfig,
         entry: './src/preHook.ts',
         timeout: Duration.seconds(120),
-        bundling: this.defaultWorkerBundlingConfig,
+        bundling: defaultWorkerBundlingConfig,
         functionName: '<%- serviceName %>-pre-hook',
         environment: {
           ...defaultWorkerEnvironment,
@@ -127,7 +134,7 @@ export class AppStack extends Stack {
         ...defaultWorkerConfig,
         entry: './src/postHook.ts',
         timeout: Duration.seconds(30),
-        bundling: this.defaultWorkerBundlingConfig,
+        bundling: defaultWorkerBundlingConfig,
         functionName: '<%- serviceName %>-post-hook',
         environment: {
           ...defaultWorkerEnvironment,
@@ -176,14 +183,5 @@ export class AppStack extends Stack {
     deploymentGroup.addPreHook(preHook);
 
     deploymentGroup.addPostHook(postHook);
-  }
-
-  get defaultWorkerBundlingConfig(): aws_lambda_nodejs.BundlingOptions {
-    return {
-      sourceMap: true,
-      target: 'node20',
-      // aws-sdk-v3 is set as an external module by default, but we want it to be bundled with the function
-      externalModules: [],
-    };
   }
 }

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -68,13 +68,6 @@ export class AppStack extends Stack {
       awsSdkConnectionReuse: false,
     };
 
-    const defaultWorkerBundlingConfig: aws_lambda_nodejs.BundlingOptions = {
-      sourceMap: true,
-      target: 'node20',
-      // aws-sdk-v3 is set as an external module by default, but we want it to be bundled with the function
-      externalModules: [],
-    };
-
     const defaultWorkerEnvironment: Record<string, string> = {
       NODE_ENV: 'production',
       // https://nodejs.org/api/cli.html#cli_node_options_options
@@ -85,7 +78,7 @@ export class AppStack extends Stack {
       ...defaultWorkerConfig,
       entry: './src/app.ts',
       timeout: Duration.seconds(30),
-      bundling: defaultWorkerBundlingConfig,
+      bundling: this.defaultWorkerBundlingConfig,
       functionName: '<%- serviceName %>',
       environment: {
         ...defaultWorkerEnvironment,
@@ -115,7 +108,7 @@ export class AppStack extends Stack {
         ...defaultWorkerConfig,
         entry: './src/preHook.ts',
         timeout: Duration.seconds(120),
-        bundling: defaultWorkerBundlingConfig,
+        bundling: this.defaultWorkerBundlingConfig,
         functionName: '<%- serviceName %>-pre-hook',
         environment: {
           ...defaultWorkerEnvironment,
@@ -134,7 +127,7 @@ export class AppStack extends Stack {
         ...defaultWorkerConfig,
         entry: './src/postHook.ts',
         timeout: Duration.seconds(30),
-        bundling: defaultWorkerBundlingConfig,
+        bundling: this.defaultWorkerBundlingConfig,
         functionName: '<%- serviceName %>-post-hook',
         environment: {
           ...defaultWorkerEnvironment,
@@ -183,5 +176,14 @@ export class AppStack extends Stack {
     deploymentGroup.addPreHook(preHook);
 
     deploymentGroup.addPostHook(postHook);
+  }
+
+  get defaultWorkerBundlingConfig(): aws_lambda_nodejs.BundlingOptions {
+    return {
+      sourceMap: true,
+      target: 'node20',
+      // aws-sdk-v3 is set as an external module by default, but we want it to be bundled with the function
+      externalModules: [],
+    };
   }
 }


### PR DESCRIPTION
This was pissing me off. The logical ids depend on the code, lock files, etc (e.g. in master get the snapshot passing then change Hello World! to Hello World!! and it'll fail). 

Low value in asserting on specific hash of all the content, so use a stable identifier. 