### PR TITLE
Remove fdir dependency

### DIFF
--- a/.changeset/rare-rats-teach.md
+++ b/.changeset/rare-rats-teach.md
@@ -1,5 +1,5 @@
 ---
-"skuba": patch
+'skuba': patch
 ---
 
 deps: Remove `fdir` dependency, which is now unused

--- a/.changeset/rare-rats-teach.md
+++ b/.changeset/rare-rats-teach.md
@@ -1,0 +1,5 @@
+---
+"skuba": patch
+---
+
+deps: Remove `fdir` dependency, which is now unused

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "eslint-config-skuba": "3.1.0",
     "execa": "^5.0.0",
     "fast-glob": "^3.3.2",
-    "fdir": "^6.0.0",
     "fs-extra": "^11.0.0",
     "function-arguments": "^1.0.9",
     "get-port": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,9 +62,6 @@ dependencies:
   fast-glob:
     specifier: ^3.3.2
     version: 3.3.2
-  fdir:
-    specifier: ^6.0.0
-    version: 6.1.1(picomatch@4.0.1)
   fs-extra:
     specifier: ^11.0.0
     version: 11.2.0
@@ -4484,17 +4481,6 @@ packages:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
     dependencies:
       bser: 2.1.1
-
-  /fdir@6.1.1(picomatch@4.0.1):
-    resolution: {integrity: sha512-QfKBVg453Dyn3mr0Q0O+Tkr1r79lOTAKSi9f/Ot4+qVEwxWhav2Z+SudrG9vQjM2aYRMQQZ2/Q1zdA8ACM1pDg==}
-    peerDependencies:
-      picomatch: 3.x
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-    dependencies:
-      picomatch: 4.0.1
-    dev: false
 
   /figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}

--- a/src/utils/dir.ts
+++ b/src/utils/dir.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 
-import { fdir as FDir } from 'fdir';
 import fs from 'fs-extra';
 import ignore from 'ignore';
 import picomatch from 'picomatch';
@@ -42,22 +41,11 @@ export const crawlDirectory = async (
     ignoreFilenames.map((ignoreFilename) => path.join(root, ignoreFilename)),
   );
 
-  const output = await new FDir()
-    .crawlWithOptions(root, {
-      exclude: (dirname) => ['.git', 'node_modules'].includes(dirname),
-      filters: [
-        (pathname) => {
-          const relativePathname = path.relative(root, pathname);
-
-          return ignoreFileFilter(relativePathname);
-        },
-      ],
-      includeBasePath: true,
-    })
-    .withPromise();
-
-  // Patch over non-specific `fdir` typings.
-  const absoluteFilenames = output as string[];
+  const absoluteFilenames = await crawl(root, {
+    includeDirName: (dirname) => !['.git', 'node_modules'].includes(dirname),
+    includeFilePath: (pathname) =>
+      ignoreFileFilter(path.relative(root, pathname)),
+  });
 
   const relativeFilepaths = absoluteFilenames.map((filepath) =>
     path.relative(root, filepath),
@@ -91,3 +79,43 @@ export const createInclusionFilter = async (ignoreFilepaths: string[]) => {
 
   return ignore().add('.git').add(managers).createFilter();
 };
+
+/**
+ * Recursively crawl a directory and return all file paths that match the
+ * filters. `paths` is mutated and returned.
+ */
+async function crawl(
+  directoryPath: string,
+  filters: {
+    includeDirName: (dirName: string) => boolean;
+    includeFilePath: (path: string) => boolean;
+  },
+  paths: string[] = [],
+) {
+  try {
+    const entries = await fs.promises.readdir(directoryPath, {
+      withFileTypes: true,
+    });
+
+    await Promise.all(
+      entries.map(async (entry) => {
+        const fullPath = path.join(directoryPath, entry.name);
+
+        if (
+          (entry.isFile() || entry.isSymbolicLink()) &&
+          filters.includeFilePath(fullPath)
+        ) {
+          paths.push(fullPath);
+        }
+
+        if (entry.isDirectory() && filters.includeDirName(entry.name)) {
+          await crawl(fullPath, filters, paths);
+        }
+      }),
+    );
+  } catch {
+    // Ignore errors, because of e.g. permission issues reading directories
+  }
+
+  return paths;
+}


### PR DESCRIPTION
We're getting some peer dependency issues between fdir and picomatch, IMO best to just kill it as we only use it one spot for a narrow scope / fairly simple use case (but also, how is directory crawling not built in?)