### PR TITLE
Remove `why-is-node-running`

### DIFF
--- a/.changeset/light-cherries-refuse.md
+++ b/.changeset/light-cherries-refuse.md
@@ -3,3 +3,13 @@
 ---
 
 GitHub.putIssueComment: Support `userId: 'seek-build-agency'`
+
+The `userId` parameter is an optimisation to skip user lookup. A descriptive constant is now supported on SEEK build agents:
+
+```diff
+await GitHub.putIssueComment({
+  body,
+- userId: 87109344, // https://api.github.com/users/buildagencygitapitoken[bot]
++ userId: 'seek-build-agency',
+});
+```

--- a/.changeset/polite-pants-share.md
+++ b/.changeset/polite-pants-share.md
@@ -2,6 +2,6 @@
 'skuba': patch
 ---
 
-cli: Require `--debug` flag to collect `why-is-node-running` information
+deps: Remove `why-is-node-running`
 
-[`why-is-node-running`](https://www.npmjs.com/package/why-is-node-running) was previously added to the skuba CLI to troubleshoot scenarios where commands were timing out in CI. This is now gated behind the `--debug` flag to minimise disruption of commands such as [`jest --detectOpenHandles`](https://jestjs.io/docs/cli#--detectopenhandles).
+[`why-is-node-running`](https://www.npmjs.com/package/why-is-node-running) was previously added to the skuba CLI to troubleshoot scenarios where commands were timing out in CI. This has now been removed to avoid disruption to commands such as [`jest --detectOpenHandles`](https://jestjs.io/docs/cli#--detectopenhandles).

--- a/.changeset/polite-pants-share.md
+++ b/.changeset/polite-pants-share.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+cli: Require `--debug` flag to collect `why-is-node-running` information
+
+[`why-is-node-running`](https://www.npmjs.com/package/why-is-node-running) was previously added to the skuba CLI to troubleshoot scenarios where commands were timing out in CI. This is now gated behind the `--debug` flag to minimise disruption of commands such as [`jest --detectOpenHandles`](https://jestjs.io/docs/cli#--detectopenhandles).

--- a/.changeset/rare-rats-teach.md
+++ b/.changeset/rare-rats-teach.md
@@ -2,4 +2,6 @@
 'skuba': patch
 ---
 
-deps: Remove `fdir` dependency, which is now unused
+deps: Remove `fdir`
+
+This dependency is no longer used internally.

--- a/.changeset/stupid-planes-fetch.md
+++ b/.changeset/stupid-planes-fetch.md
@@ -2,6 +2,6 @@
 'skuba': patch
 ---
 
-template/\*-rest-api: Gantry v3
+template/\*-rest-api: Comply with latest AWS tagging guidance
 
-Gantry resource templates have been updated to comply with our latest AWS tagging guidance.
+This includes an upgrade to Gantry v3.

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "tsconfig-seek": "2.0.0",
     "typescript": "~5.3.0",
     "validate-npm-package-name": "^5.0.0",
-    "why-is-node-running": "^2.2.2",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,9 +158,6 @@ dependencies:
   validate-npm-package-name:
     specifier: ^5.0.0
     version: 5.0.0
-  why-is-node-running:
-    specifier: ^2.2.2
-    version: 2.2.2
   zod:
     specifier: ^3.22.4
     version: 3.22.4
@@ -8736,10 +8733,6 @@ packages:
       get-intrinsic: 1.2.4
       object-inspect: 1.13.1
 
-  /siginfo@2.0.0:
-    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
-    dev: false
-
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -8949,10 +8942,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       escape-string-regexp: 2.0.0
-
-  /stackback@0.0.2:
-    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-    dev: false
 
   /statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -10083,15 +10072,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-
-  /why-is-node-running@2.2.2:
-    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      siginfo: 2.0.0
-      stackback: 0.0.2
-    dev: false
 
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}

--- a/src/skuba.ts
+++ b/src/skuba.ts
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-import whyIsNodeRunning from 'why-is-node-running';
-
 /**
  * Entry point for the CLI.
  *
@@ -15,7 +13,7 @@ import whyIsNodeRunning from 'why-is-node-running';
 // eslint-disable-next-line import/order -- why-is-node-running must be imported before anything else
 import path from 'path';
 
-import { parseProcessArgs } from './utils/args';
+import { hasDebugFlag, parseProcessArgs } from './utils/args';
 import {
   COMMAND_DIR,
   COMMAND_SET,
@@ -32,6 +30,14 @@ import { hasProp } from './utils/validation';
 const THIRTY_MINUTES = 30 * 60 * 1000;
 
 const skuba = async () => {
+  const debug = hasDebugFlag(process.argv);
+
+  // Only import `why-is-node-running` if we're in debug mode as it has unwanted
+  // side effects like `jest --detectOpenHandles` reporting its open handles.
+  const whyIsNodeRunning = debug
+    ? (await import('why-is-node-running')).default
+    : () => undefined;
+
   const { commandName } = parseProcessArgs(process.argv);
 
   if (COMMAND_SET.has(commandName)) {

--- a/src/skuba.ts
+++ b/src/skuba.ts
@@ -12,7 +12,7 @@
 
 import path from 'path';
 
-import { hasDebugFlag, parseProcessArgs } from './utils/args';
+import { parseProcessArgs } from './utils/args';
 import {
   COMMAND_DIR,
   COMMAND_SET,
@@ -29,14 +29,6 @@ import { hasProp } from './utils/validation';
 const THIRTY_MINUTES = 30 * 60 * 1000;
 
 const skuba = async () => {
-  const debug = hasDebugFlag(process.argv);
-
-  // Only import `why-is-node-running` if we're in debug mode as it has unwanted
-  // side effects like `jest --detectOpenHandles` reporting its open handles.
-  const whyIsNodeRunning = debug
-    ? (await import('why-is-node-running')).default
-    : () => undefined;
-
   const { commandName } = parseProcessArgs(process.argv);
 
   if (COMMAND_SET.has(commandName)) {
@@ -73,7 +65,7 @@ const skuba = async () => {
           log.bold(commandName),
           'timed out. This may indicate a process hanging - please file an issue.',
         );
-        whyIsNodeRunning();
+
         // Need to force exit because promises may be hanging so node won't exit on its own.
         process.exit(1);
       },

--- a/src/skuba.ts
+++ b/src/skuba.ts
@@ -10,7 +10,6 @@
  * ```
  */
 
-// eslint-disable-next-line import/order -- why-is-node-running must be imported before anything else
 import path from 'path';
 
 import { hasDebugFlag, parseProcessArgs } from './utils/args';


### PR DESCRIPTION
This is one idea I had; the other is to remove the dependency entirely.

https://seekchat.slack.com/archives/C03UM9GBGET/p1710315456217509