### PR TITLE
Jest.mergePreset: Fix compatibility with `NodeNext`

### DIFF
--- a/.changeset/hip-ears-punch.md
+++ b/.changeset/hip-ears-punch.md
@@ -1,0 +1,20 @@
+---
+'skuba': patch
+---
+
+Jest.mergePreset: Fudge `Node16` and `NodeNext` module resolutions
+
+This works around a `ts-jest` issue where test cases fail to run if your `moduleResolution` is set to a modern mode:
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "Node16 | NodeNext"
+  }
+}
+```
+
+```console
+error TS5110: Option 'module' must be set to 'Node16' when option 'moduleResolution' is set to 'Node16'.
+error TS5110: Option 'module' must be set to 'NodeNext' when option 'moduleResolution' is set to 'NodeNext'.
+```

--- a/.changeset/slow-moons-matter.md
+++ b/.changeset/slow-moons-matter.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+pkg: Exclude `jest/*.test.ts` files

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -1,4 +1,5 @@
 const { defaults } = require('ts-jest/presets');
+const { ModuleResolutionKind } = require('typescript');
 
 const { tryParseTsConfig } = require('./tsConfig');
 
@@ -14,6 +15,29 @@ const TS_JEST_PATH = require.resolve(TS_JEST_NAME);
 
 const maybeTsConfig = tryParseTsConfig();
 
+const isolatedModules = maybeTsConfig?.options.isolatedModules ?? true;
+
+const BROKEN_MODULE_RESOLUTIONS = new Set([
+  ModuleResolutionKind.Node16,
+  ModuleResolutionKind.NodeNext,
+]);
+
+/**
+ * Passing through `Node16` or `NodeNext` seems to break `ts-jest`.
+ *
+ * ```
+ * error TS5110: Option 'module' must be set to 'Node16' when option 'moduleResolution' is set to 'Node16'.
+ * error TS5110: Option 'module' must be set to 'NodeNext' when option 'moduleResolution' is set to 'NodeNext'.
+ * ```
+ *
+ * https://github.com/kulshekhar/ts-jest/issues/4198
+ */
+const tsconfig = BROKEN_MODULE_RESOLUTIONS.has(
+  maybeTsConfig?.options.moduleResolution,
+)
+  ? { moduleResolution: 'Node' }
+  : undefined;
+
 // Rewrite `ts-jest` transformations using our resolved `TS_JEST_PATH`.
 module.exports.transform = Object.fromEntries(
   Object.entries(defaults.transform).map(([key, value]) => {
@@ -24,7 +48,8 @@ module.exports.transform = Object.fromEntries(
           ? [
               TS_JEST_PATH,
               {
-                isolatedModules: maybeTsConfig?.options.isolatedModules ?? true,
+                isolatedModules,
+                tsconfig,
               },
             ]
           : value,
@@ -38,10 +63,8 @@ module.exports.transform = Object.fromEntries(
             TS_JEST_PATH,
             {
               ...value[1],
-              isolatedModules:
-                value[1]?.isolatedModules ??
-                maybeTsConfig?.options.isolatedModules ??
-                true,
+              isolatedModules,
+              tsconfig,
             },
           ]
         : value,

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -40,7 +40,7 @@ module.exports.transform = Object.fromEntries(
               ...value[1],
               isolatedModules:
                 value[1]?.isolatedModules ??
-                maybeTsConfig?.isolatedModules ??
+                maybeTsConfig?.options.isolatedModules ??
                 true,
             },
           ]

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -35,7 +35,7 @@ const BROKEN_MODULE_RESOLUTIONS = new Set([
 const tsconfig = BROKEN_MODULE_RESOLUTIONS.has(
   maybeTsConfig?.options.moduleResolution,
 )
-  ? { moduleResolution: 'Node' }
+  ? { tsconfig: { moduleResolution: 'Node' } }
   : undefined;
 
 // Rewrite `ts-jest` transformations using our resolved `TS_JEST_PATH`.
@@ -48,8 +48,8 @@ module.exports.transform = Object.fromEntries(
           ? [
               TS_JEST_PATH,
               {
+                ...tsconfig,
                 isolatedModules,
-                tsconfig,
               },
             ]
           : value,
@@ -63,8 +63,8 @@ module.exports.transform = Object.fromEntries(
             TS_JEST_PATH,
             {
               ...value[1],
+              ...tsconfig,
               isolatedModules,
-              tsconfig,
             },
           ]
         : value,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "files": [
     "config/**/*",
-    "jest/**/*",
+    "jest/**/*.js",
     "lib*/**/*.d.ts",
     "lib*/**/*.js",
     "lib*/**/*.js.map",


### PR DESCRIPTION
https://github.com/seek-oss/skuba/actions/runs/8338828529

Co-authored-by: Michael Taranto <mtaranto@seek.com.au>