### PR TITLE
RFC: Mount `package.json` for Corepack

### DIFF
--- a/docs/deep-dives/pnpm.md
+++ b/docs/deep-dives/pnpm.md
@@ -210,7 +210,9 @@ This migration guide assumes that your project was scaffolded with a **skuba** t
     ```diff
       FROM --platform=arm64 node:20-alpine AS dev-deps
     
-    + RUN corepack enable pnpm
+    + RUN --mount=type=bind,source=package.json,target=package.json \
+    + corepack enable pnpm
+    
     + RUN pnpm config set store-dir /root/.pnpm-store
     
       WORKDIR /workdir
@@ -279,7 +281,7 @@ This migration guide assumes that your project was scaffolded with a **skuba** t
     Your build pipeline may have previously output an ephemeral `.npmrc` with an auth token on the build agent.
     This needs to be output elsewhere to avoid overwriting the new pnpm configuration stored in `.npmrc`.
 
-    Swap out caching on `package.json` and `yarn.lock` for `.npmrc` and `pnpm-lock.yaml` at the same time.
+    Swap out caching on `yarn.lock` for `.npmrc` and `pnpm-lock.yaml` at the same time.
 
     ```diff
       seek-oss/private-npm#v1.2.0:
@@ -290,9 +292,9 @@ This migration guide assumes that your project was scaffolded with a **skuba** t
     ```diff
      seek-oss/docker-ecr-cache#v2.1.0:
        cache-on:
-    -    - package.json
-    -    - yarn.lock
     +    - .npmrc
+         - package.json
+    -    - yarn.lock
     +    - pnpm-lock.yaml
        dockerfile: Dockerfile.dev-deps
     -  secrets: id=npm,src=.npmrc

--- a/template/express-rest-api/.buildkite/pipeline.yml
+++ b/template/express-rest-api/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ configs:
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
         cache-on:
           - .npmrc
+          - package.json
           - pnpm-lock.yaml
         dockerfile: Dockerfile.dev-deps
         secrets: id=npm,src=tmp/.npmrc

--- a/template/express-rest-api/Dockerfile.dev-deps
+++ b/template/express-rest-api/Dockerfile.dev-deps
@@ -2,7 +2,9 @@
 
 FROM --platform=<%- platformName %> node:20-alpine AS dev-deps
 
-RUN corepack enable pnpm
+RUN --mount=type=bind,source=package.json,target=package.json \
+    corepack enable pnpm
+
 RUN pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir

--- a/template/greeter/.buildkite/pipeline.yml
+++ b/template/greeter/.buildkite/pipeline.yml
@@ -1,6 +1,8 @@
 agents:
   queue: <%- prodBuildkiteQueueName %>
 
+# Allow conditional unblock + dodgy CI stuffs
+
 configs:
   plugins:
     - &aws-sm
@@ -12,6 +14,7 @@ configs:
       seek-oss/docker-ecr-cache#v2.1.1:
         cache-on:
           - .npmrc
+          - package.json
           - pnpm-lock.yaml
         secrets: id=npm,src=tmp/.npmrc
 

--- a/template/greeter/Dockerfile
+++ b/template/greeter/Dockerfile
@@ -2,7 +2,9 @@
 
 FROM --platform=<%- platformName %> node:20-alpine AS dev-deps
 
-RUN corepack enable pnpm
+RUN --mount=type=bind,source=package.json,target=package.json \
+    corepack enable pnpm
+
 RUN pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir

--- a/template/koa-rest-api/.buildkite/pipeline.yml
+++ b/template/koa-rest-api/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ configs:
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
         cache-on:
           - .npmrc
+          - package.json
           - pnpm-lock.yaml
         dockerfile: Dockerfile.dev-deps
         secrets: id=npm,src=tmp/.npmrc

--- a/template/koa-rest-api/Dockerfile.dev-deps
+++ b/template/koa-rest-api/Dockerfile.dev-deps
@@ -2,7 +2,9 @@
 
 FROM --platform=<%- platformName %> node:20-alpine AS dev-deps
 
-RUN corepack enable pnpm
+RUN --mount=type=bind,source=package.json,target=package.json \
+    corepack enable pnpm
+
 RUN pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir

--- a/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker-cdk/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ configs:
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
         cache-on:
           - .npmrc
+          - package.json
           - pnpm-lock.yaml
         secrets: id=npm,src=tmp/.npmrc
 

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -5,7 +5,9 @@ FROM --platform=<%- platformName %> node:20-alpine AS dev-deps
 # Needed for cdk
 RUN apk add --no-cache bash
 
-RUN corepack enable pnpm
+RUN --mount=type=bind,source=package.json,target=package.json \
+    corepack enable pnpm
+
 RUN pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir

--- a/template/lambda-sqs-worker/.buildkite/pipeline.yml
+++ b/template/lambda-sqs-worker/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ configs:
       seek-oss/docker-ecr-cache#v2.1.1: &docker-ecr-cache-defaults
         cache-on:
           - .npmrc
+          - package.json
           - pnpm-lock.yaml
         secrets: id=npm,src=tmp/.npmrc
 

--- a/template/lambda-sqs-worker/Dockerfile
+++ b/template/lambda-sqs-worker/Dockerfile
@@ -2,7 +2,9 @@
 
 FROM --platform=<%- platformName %> node:20-alpine AS dev-deps
 
-RUN corepack enable pnpm
+RUN --mount=type=bind,source=package.json,target=package.json \
+    corepack enable pnpm
+
 RUN pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir


### PR DESCRIPTION
Our Dockerfiles currently run `corepack enable pnpm` without any versioning information:

https://github.com/seek-oss/skuba/blob/bc2c69d3b85a6aba738c5d63d01f810a69b1a248/template/greeter/Dockerfile#L5

This may use a different version than is specified in package.json:

https://github.com/seek-oss/skuba/blob/bc2c69d3b85a6aba738c5d63d01f810a69b1a248/template/greeter/package.json

This can result in a subsequent `pnpm install --offline` to hang in CI on the following prompt:

```console
Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz.

Do you want to continue? [Y/n]
```