### PR TITLE
Bump Eslint Version

### DIFF
--- a/.changeset/clean-candles-design.md
+++ b/.changeset/clean-candles-design.md
@@ -1,0 +1,5 @@
+---
+"skuba": minor
+---
+
+deps: eslint 8.56.0

--- a/.changeset/clean-candles-design.md
+++ b/.changeset/clean-candles-design.md
@@ -4,4 +4,4 @@
 
 deps: eslint 8.56.0
 
-This upgrade is required as part of the eslint-config-seek 13 update
+This upgrade is required for [eslint-config-seek 13](https://github.com/seek-oss/eslint-config-seek/releases/tag/v13.0.0).

--- a/.changeset/clean-candles-design.md
+++ b/.changeset/clean-candles-design.md
@@ -1,5 +1,7 @@
 ---
-'skuba': minor
+'skuba': patch
 ---
 
 deps: eslint 8.56.0
+
+This upgrade is required as part of the eslint-config-seek 13 update

--- a/.changeset/clean-candles-design.md
+++ b/.changeset/clean-candles-design.md
@@ -1,5 +1,5 @@
 ---
-"skuba": minor
+'skuba': minor
 ---
 
 deps: eslint 8.56.0

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "ejs": "^3.1.6",
     "enquirer": "^2.3.6",
     "esbuild": "~0.20.0",
-    "eslint": "^8.11.0",
+    "eslint": "^8.56.0",
     "eslint-config-skuba": "workspace:*",
     "execa": "^5.0.0",
     "fast-glob": "^3.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         specifier: ~0.20.0
         version: 0.20.2
       eslint:
-        specifier: ^8.11.0
+        specifier: ^8.56.0
         version: 8.57.0
       eslint-config-skuba:
         specifier: workspace:*


### PR DESCRIPTION
Forgot to bump this in the eslint-config-skuba upgrade

<img width="562" alt="image" src="https://github.com/seek-oss/skuba/assets/18017094/b60ad223-6887-4250-8a9d-384102e9b28c">
