### PR TITLE
RFC: Do not modify config files if version is outdated

### DIFF
--- a/.changeset/smart-drinks-design.md
+++ b/.changeset/smart-drinks-design.md
@@ -1,0 +1,17 @@
+---
+'skuba': patch
+---
+
+format, lint: Do not modify config files if version is outdated
+
+Starting from this version, `skuba format` will not modify config files if it detects that it is older than the version that last wrote to the project `package.json`:
+
+```json
+{
+  "skuba": {
+    "version": "1.0.0"
+  }
+}
+```
+
+This is intended to address the scenario where you have an older version of skuba installed locally, run `skuba format`, and inadvertently revert config files to a prior state.

--- a/src/cli/lint/internalLints/refreshConfigFiles.ts
+++ b/src/cli/lint/internalLints/refreshConfigFiles.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { inspect } from 'util';
 
 import { writeFile } from 'fs-extra';
+import { gt } from 'semver';
 import stripAnsi from 'strip-ansi';
 
 import { Git } from '../../..';
@@ -12,6 +13,7 @@ import {
   detectPackageManager,
 } from '../../../utils/packageManager';
 import { readBaseTemplateFile } from '../../../utils/template';
+import { getSkubaVersion, manifestSkubaVersion } from '../../../utils/version';
 import { getDestinationManifest } from '../../configure/analysis/package';
 import { createDestinationFileReader } from '../../configure/analysis/project';
 import { mergeWithConfigFile } from '../../configure/processing/configFile';
@@ -74,11 +76,27 @@ export const REFRESHABLE_CONFIG_FILES: RefreshableConfigFile[] = [
 export const refreshConfigFiles = async (
   mode: 'format' | 'lint',
   logger: Logger,
-) => {
-  const [manifest, gitRoot] = await Promise.all([
+): Promise<InternalLintResult> => {
+  const [currentVersion, manifest, gitRoot] = await Promise.all([
+    getSkubaVersion(),
     getDestinationManifest(),
     Git.findRoot({ dir: process.cwd() }),
   ]);
+
+  const manifestVersion = manifestSkubaVersion(manifest);
+
+  process.stdout.write(
+    `${JSON.stringify({ currentVersion, manifestVersion })}\n`,
+  );
+
+  // The local version that we're running is older than the version that last
+  // wrote to the manifest; avoid reverting config files back to a prior state.
+  if (gt(manifestVersion, currentVersion)) {
+    return {
+      ok: true,
+      fixable: false,
+    };
+  }
 
   const destinationRoot = path.dirname(manifest.path);
 

--- a/src/cli/lint/internalLints/upgrade/index.ts
+++ b/src/cli/lint/internalLints/upgrade/index.ts
@@ -10,7 +10,10 @@ import {
   type PackageManagerConfig,
   detectPackageManager,
 } from '../../../../utils/packageManager';
-import { getSkubaVersion } from '../../../../utils/version';
+import {
+  getSkubaVersion,
+  manifestSkubaVersion,
+} from '../../../../utils/version';
 import { formatPackage } from '../../../configure/processing/package';
 import type { SkubaPackageJson } from '../../../init/writePackageJson';
 import type { InternalLintResult } from '../../internal';
@@ -84,10 +87,7 @@ export const upgradeSkuba = async (
     throw new Error('Could not find a package json for this project');
   }
 
-  manifest.packageJson.skuba ??= { version: '1.0.0' };
-
-  const manifestVersion = (manifest.packageJson.skuba as SkubaPackageJson)
-    .version;
+  const manifestVersion = manifestSkubaVersion(manifest);
 
   // We are up to date, skip patches
   if (gte(manifestVersion, currentVersion)) {
@@ -160,7 +160,8 @@ export const upgradeSkuba = async (
     }
   }
 
-  (manifest.packageJson.skuba as SkubaPackageJson).version = currentVersion;
+  ((manifest.packageJson.skuba ??= {}) as SkubaPackageJson).version =
+    currentVersion;
 
   const updatedPackageJson = await formatPackage(manifest.packageJson);
 

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,5 +1,8 @@
 import searchNpm from 'libnpmsearch';
+import type readPkgUp from 'read-pkg-up';
 import validatePackageName from 'validate-npm-package-name';
+
+import type { SkubaPackageJson } from '../cli/init/writePackageJson';
 
 import { getSkubaManifest } from './manifest';
 import { withTimeout } from './wait';
@@ -32,6 +35,14 @@ const latestSkubaVersion = async (): Promise<string | null> => {
   } catch {
     return null;
   }
+};
+
+export const manifestSkubaVersion = (
+  manifest: readPkgUp.NormalizedReadResult,
+) => {
+  const skuba = manifest.packageJson.skuba as SkubaPackageJson | undefined;
+
+  return skuba?.version ?? '1.0.0';
 };
 
 export const getSkubaVersion = async (): Promise<string> => {


### PR DESCRIPTION
I noticed some recent commits where config file changes were going back and forth. However, after writing this I'm not sure that it is actually worth it, given e.g. a Prettier change between versions would similarly cause such churn if local dependencies are outdated. Thoughts?