### PR TITLE
template/koa-rest-api: Remove `not.toBe(404)`s

### DIFF
--- a/.changeset/long-dots-jump.md
+++ b/.changeset/long-dots-jump.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/koa-rest-api: Clean up `src/app.test.ts`

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -11,8 +11,10 @@ describe('app', () => {
   it('has a happy health check', () => agent.get('/health').expect(200, ''));
 
   it('has a reachable smoke test', () =>
-    agent.options('/smoke').expect(200, '').expect('Allow', /GET/));
+    agent.options('/smoke').expect(200, '').expect('Allow', 'HEAD, GET'));
 
   it('has a reachable nested route', () =>
     agent.options('/jobs').expect(200, '').expect('Allow', /POST/));
+
+  it('handles an unknown route', () => agent.options('/admin.php').expect(404));
 });

--- a/template/koa-rest-api/src/app.test.ts
+++ b/template/koa-rest-api/src/app.test.ts
@@ -10,16 +10,9 @@ describe('app', () => {
 
   it('has a happy health check', () => agent.get('/health').expect(200, ''));
 
-  it('has a reachable smoke test', async () => {
-    const response = await agent.get('/smoke');
-    expect(response.status).not.toBe(404);
-  });
+  it('has a reachable smoke test', () =>
+    agent.options('/smoke').expect(200, '').expect('Allow', /GET/));
 
-  it('has a reachable nested route', async () => {
-    const response = await agent.get('/jobs');
-    expect(response.status).not.toBe(404);
-  });
-
-  it('has OPTIONS for a nested route', () =>
-    agent.options('/jobs').expect(200).expect('allow', /HEAD/));
+  it('has a reachable nested route', () =>
+    agent.options('/jobs').expect(200, '').expect('Allow', /POST/));
 });


### PR DESCRIPTION
These are super dodgy because they often go unloved as an API evolves and end up sending real outbound requests to upstreams when you run the test suite. Typically the upstreams don't respond with a 404 so the tests still pass, but it's gross.