### PR TITLE
Fix pnpm guide

### DIFF
--- a/docs/deep-dives/pnpm.md
+++ b/docs/deep-dives/pnpm.md
@@ -263,7 +263,6 @@ This migration guide assumes that your project was scaffolded with a **skuba** t
       WORKDIR /workdir
     
       COPY --from=build /workdir/lib lib
-    - COPY --from=build /workdir/packages packages
     - COPY --from=deps /workdir/node_modules node_modules
     + COPY --from=build /workdir/node_modules node_modules
     


### PR DESCRIPTION
Turns out this is required. Oops. We removed it in another repo due to a different change