### PR TITLE
Add cdk.context.json to the base gitignore

### DIFF
--- a/template/base/_.gitignore
+++ b/template/base/_.gitignore
@@ -21,4 +21,5 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
+cdk.context.json
 # end managed by skuba


### PR DESCRIPTION
[cdk.context.json](https://docs.aws.amazon.com/cdk/v2/guide/context.html) is usually created when running `cdk` commands locally like:

```sh
cdk deploy
```

This file doesn't need to be checked because it gets generated on demand anyway and isn't required for builds. 