### PR TITLE
Add cdk.context.json to the base gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
+cdk.context.json
 # end managed by skuba
 
 /integration/format/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .cdk.staging/
 .serverless/
 cdk.out/
+cdk.context.json
 node_modules*/
 
 /coverage*/
@@ -21,7 +22,6 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
-cdk.context.json
 # end managed by skuba
 
 /integration/format/

--- a/packages/eslint-config-skuba/.gitignore
+++ b/packages/eslint-config-skuba/.gitignore
@@ -21,4 +21,5 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
+cdk.context.json
 # end managed by skuba

--- a/packages/eslint-config-skuba/.gitignore
+++ b/packages/eslint-config-skuba/.gitignore
@@ -6,6 +6,7 @@
 .cdk.staging/
 .serverless/
 cdk.out/
+cdk.context.json
 node_modules*/
 
 /coverage*/
@@ -21,5 +22,4 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
-cdk.context.json
 # end managed by skuba

--- a/packages/skuba-dive/.gitignore
+++ b/packages/skuba-dive/.gitignore
@@ -21,4 +21,5 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
+cdk.context.json
 # end managed by skuba

--- a/packages/skuba-dive/.gitignore
+++ b/packages/skuba-dive/.gitignore
@@ -6,6 +6,7 @@
 .cdk.staging/
 .serverless/
 cdk.out/
+cdk.context.json
 node_modules*/
 
 /coverage*/
@@ -21,5 +22,4 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
-cdk.context.json
 # end managed by skuba

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -80,6 +80,7 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
+cdk.context.json
 # end managed by skuba
 ",
     "operation": "A",

--- a/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
+++ b/src/cli/configure/analysis/__snapshots__/project.test.ts.snap
@@ -65,6 +65,7 @@ node_modules*/
 .cdk.staging/
 .serverless/
 cdk.out/
+cdk.context.json
 node_modules*/
 
 /coverage*/
@@ -80,7 +81,6 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
-cdk.context.json
 # end managed by skuba
 ",
     "operation": "A",

--- a/template/base/_.gitignore
+++ b/template/base/_.gitignore
@@ -21,4 +21,5 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
+cdk.context.json
 # end managed by skuba

--- a/template/base/_.gitignore
+++ b/template/base/_.gitignore
@@ -6,6 +6,7 @@
 .cdk.staging/
 .serverless/
 cdk.out/
+cdk.context.json
 node_modules*/
 
 /coverage*/
@@ -21,5 +22,4 @@ node_modules*/
 npm-debug.log
 package-lock.json
 yarn-error.log
-cdk.context.json
 # end managed by skuba


### PR DESCRIPTION
[cdk.context.json](https://docs.aws.amazon.com/cdk/v2/guide/context.html) is usually created when running `cdk` commands locally like:

```sh
cdk deploy
```

This file doesn't need to be checked because it gets generated on demand anyway and isn't required for builds. 