### PR TITLE
Add pnpm command to update snapshot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,16 @@ pnpm test:template greeter
 rm -fr ../tmp-greeter
 ```
 
+Snapshots in `templates` can be updated with the following command but note that manual clean up is necessary afterwards
+
+```shell
+# greeter being name of template
+pnpm test:template:updateSnapshot greeter
+
+# clean up temporary sibling directory
+rm -fr ../tmp-greeter
+```
+
 ### Running locally
 
 If you want to try out the **skuba** CLI on itself,

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:ci": "pnpm --silent skuba test --runInBand",
     "test:int": "pnpm --silent skuba test --selectProjects integration --runInBand",
     "test:template": "scripts/test-template.sh",
+    "test:template:updateSnapshot": "scripts/test-template.sh -u",
     "test:watch": "pnpm --silent skuba test --runInBand --watch"
   },
   "remarkConfig": {

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -2,7 +2,17 @@
 
 set -e
 
+update_snapshot=false
+
+# Process optional flag
+if [ "$1" == "-u" ]; then
+  update_snapshot=true
+  shift
+fi
+
 template="${1}"
+
+echo "--- testing template ${update_snapshot}, ${template}"
 if [ -z "$template" ]; then
   echo "Usage: pnpm test:template <template_name>"
   exit 1
@@ -81,5 +91,12 @@ pnpm lint
 echo "--- pnpm format ${template}"
 pnpm format
 
-echo "--- pnpm test ${template}"
-pnpm test
+if [ "$update_snapshot" = true ]; then
+  echo "--- pnpm test --updateSnapshot ${template}"
+  pnpm test -- --updateSnapshot
+  cd ../../skuba || exit 1
+  bash ./scripts/update-template-snapshot.sh ${skuba_temp_directory} ${template}
+else 
+  echo "--- pnpm test ${template}"
+  pnpm test 
+fi

--- a/scripts/update-template-snapshot.sh
+++ b/scripts/update-template-snapshot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# To be used in conjunction with `test-template.sh`. 
+# This script copies all snapshot directories from the tmp directory to the template directory.
+
+set -e
+
+tmp_dir="$1"
+template="$2"
+
+# Loops through tmp directory created in test-template.sh, ignoring node_modules and only looks at __snapshots__ directories.
+find ../${tmp_dir}/tmp-${template} -path '*/node_modules' -prune -o -type d -name '__snapshots__' -print | while read -r src_dir; do
+  dest_dir=$(echo "$src_dir" | sed "s|../${tmp_dir}/tmp-${template}|template/${template}|")
+  cp -r $src_dir/ $dest_dir/
+done
+
+echo "All snapshot directories have been copied successfully."


### PR DESCRIPTION
## Overview
Add a new `pnpm test:template:updateSnapshot` script

## What it does
It leverages existing `update-template.sh` and adds a `-u` option to update snapshot. It will update existing snapshots when running tests in `tmp-${template}` dir and copy the snapshots to `skuba/template` dir

## Why
To make it easier to avoid #1646 because I missed it in #1644

## Further thoughts
I initially thought to make `pnpm test:template` `--updateSnapshot` by default but I am unsure of the existing approach. Assuming that snapshots in template are meant as safeguard for template user and not skuba developers, it might be easier to just have a `husky pre-commit` hook to `--updateSnapshot` by default when modifying templates.