### PR TITLE
Update module and moduleResolution

### DIFF
--- a/docs/cli/build.md
+++ b/docs/cli/build.md
@@ -66,7 +66,7 @@ With esbuild, you can supply the following options:
 
 ## skuba build-package
 
-Compiles your project for compatibility with CommonJS and ES2015 modules.
+Compiles your project for compatibility with CommonJS and ES2022 modules.
 
 This is useful for building isomorphic npm packages.
 
@@ -75,8 +75,8 @@ skuba build-package
 
 # commonjs │ TSFILE: ...
 # commonjs │ tsc exited with code 0
-# es2015   │ TSFILE: ...
-# es2015   │ tsc exited with code 0
+# esm      │ TSFILE: ...
+# esm      │ tsc exited with code 0
 # types    │ TSFILE: ...
 # types    │ tsc exited with code 0
 ```

--- a/packages/skuba-dive/tsconfig.json
+++ b/packages/skuba-dive/tsconfig.json
@@ -3,8 +3,8 @@
     "declaration": true,
     "incremental": true,
     "lib": ["ES2020"],
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "outDir": "lib",
     "removeComments": false,
     "target": "ES2020"

--- a/src/cli/build/assets.int.test.ts
+++ b/src/cli/build/assets.int.test.ts
@@ -76,8 +76,8 @@ describe('copyAssetsConcurrently', () => {
         prefixColor: 'green',
       },
       {
-        outDir: 'lib-es2015',
-        name: 'es2015',
+        outDir: 'lib-esm',
+        name: 'esm',
         prefixColor: 'yellow',
       },
     ]);
@@ -88,10 +88,10 @@ describe('copyAssetsConcurrently', () => {
         "lib-commonjs/.vocab/translations.json": "",
         "lib-commonjs/other.vocab/th.translations.json": "",
         "lib-commonjs/other.vocab/translations.json": "",
-        "lib-es2015/.vocab/th.translations.json": "",
-        "lib-es2015/.vocab/translations.json": "",
-        "lib-es2015/other.vocab/th.translations.json": "",
-        "lib-es2015/other.vocab/translations.json": "",
+        "lib-esm/.vocab/th.translations.json": "",
+        "lib-esm/.vocab/translations.json": "",
+        "lib-esm/other.vocab/th.translations.json": "",
+        "lib-esm/other.vocab/translations.json": "",
       }
     `);
     expect(getStdOut()).toMatchInlineSnapshot(`
@@ -99,10 +99,10 @@ describe('copyAssetsConcurrently', () => {
       commonjs │ Copying .vocab/translations.json
       commonjs │ Copying other.vocab/th.translations.json
       commonjs │ Copying other.vocab/translations.json
-      es2015   │ Copying .vocab/th.translations.json
-      es2015   │ Copying .vocab/translations.json
-      es2015   │ Copying other.vocab/th.translations.json
-      es2015   │ Copying other.vocab/translations.json
+      esm   │ Copying .vocab/th.translations.json
+      esm   │ Copying .vocab/translations.json
+      esm   │ Copying other.vocab/th.translations.json
+      esm   │ Copying other.vocab/translations.json
     `);
   });
 });

--- a/src/cli/buildPackage.ts
+++ b/src/cli/buildPackage.ts
@@ -8,14 +8,14 @@ export const buildPackage = async (args = process.argv.slice(2)) => {
     [
       {
         command:
-          'tsc --module CommonJS --outDir lib-commonjs --project tsconfig.build.json',
+          'tsc --module Node16 --outDir lib-commonjs --project tsconfig.build.json',
         name: 'commonjs',
         prefixColor: 'green',
       },
       {
         command:
-          'tsc --module ES2015 --outDir lib-es2015 --project tsconfig.build.json',
-        name: 'es2015',
+          'tsc --module ES2022 --outDir lib-esm --project tsconfig.build.json',
+        name: 'esm',
         prefixColor: 'yellow',
       },
       {
@@ -37,8 +37,8 @@ export const buildPackage = async (args = process.argv.slice(2)) => {
       prefixColor: 'green',
     },
     {
-      outDir: 'lib-es2015',
-      name: 'es2015',
+      outDir: 'lib-esm',
+      name: 'esm',
       prefixColor: 'yellow',
     },
   ]);

--- a/src/cli/configure/modules/package.test.ts
+++ b/src/cli/configure/modules/package.test.ts
@@ -60,7 +60,7 @@ describe('packageModule', () => {
       ],
       license: 'UNLICENSED',
       main: './lib-commonjs/index.js',
-      module: './lib-es2015/index.js',
+      module: './lib-esm/index.js',
       private: false,
       scripts: {
         build: 'skuba build-package',
@@ -159,7 +159,7 @@ describe('packageModule', () => {
         files: ['lib', 'something-else'],
         license: 'UNLICENSED',
         main: 'lib/commonjs',
-        module: 'lib/es2015',
+        module: 'lib/esm',
         scripts: {
           build: 'smt build',
           commit: 'smt commit',
@@ -197,7 +197,7 @@ describe('packageModule', () => {
       ],
       license: 'UNLICENSED',
       main: './lib-commonjs/index.js',
-      module: './lib-es2015/index.js',
+      module: './lib-esm/index.js',
       private: false,
       scripts: {
         build: 'skuba build-package',

--- a/src/cli/configure/modules/package.ts
+++ b/src/cli/configure/modules/package.ts
@@ -103,7 +103,7 @@ export const packageModule = async ({
           // Align with the required syntax for package.json#/paths
           if (outputData.scripts.build === 'skuba build-package') {
             outputData.main = './lib-commonjs/index.js';
-            outputData.module = './lib-es2015/index.js';
+            outputData.module = './lib-esm/index.js';
             outputData.types = './lib-types/index.d.ts';
           } else {
             outputData.main = './lib/index.js';

--- a/template/oss-npm-package/_package.json
+++ b/template/oss-npm-package/_package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "sideEffects": false,
   "main": "./lib-commonjs/index.js",
-  "module": "./lib-es2015/index.js",
+  "module": "./lib-esm/index.js",
   "types": "./lib-types/index.d.ts",
   "files": [
     "lib*/**/*.d.ts",

--- a/template/private-npm-package/_package.json
+++ b/template/private-npm-package/_package.json
@@ -9,7 +9,7 @@
   "license": "UNLICENSED",
   "sideEffects": false,
   "main": "./lib-commonjs/index.js",
-  "module": "./lib-es2015/index.js",
+  "module": "./lib-esm/index.js",
   "types": "./lib-types/index.d.ts",
   "files": [
     "lib*/**/*.d.ts",


### PR DESCRIPTION
## Overview
Attempting to address issue #1483. 

### Changes
- Replaced `moduleResolution` from `node` to [Node16](https://www.typescriptlang.org/tsconfig/#moduleResolution). Should be good enough since our minimum `node` version is 18 for skuba
- Replaced `--module CommonJs` with `--module Node16`. [Source](https://www.typescriptlang.org/docs/handbook/modules/reference.html#commonjs)
- Replaced `--module ES2015` with `--module ES2022`. While `Node16` is recommended, it only works if `type` is set to `module` in `package.json`. [Source](https://www.typescriptlang.org/docs/handbook/modules/reference.html#es2015-es2020-es2022-esnext)
  > Do not use for Node.js. Use node16 or nodenext with "type": "module" in package.json to emit ES modules for Node.js.

### Additional thoughts
I have considered removing `CommonJs` entirely since it was mentioned a [long time ago](https://github.com/seek-oss/skuba/pull/296) and the only place it is used here are in `oss-npm-package` and `private-npm-package`. I am not very well-versed in library conventions so I have left them as is but let me know if we should only emit `esm` only.

Also, not sure if this should be in a changeset 🤔 