### PR TITLE
Fix integration tests

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -79,8 +79,9 @@ pnpm exec skuba --version
 set +e
 echo "--- pnpm build ${template}"
 output=$(pnpm build 2>&1)
-echo $output
-if [[ $? -ne 0 && $output != *"Command \"build\" not found"* ]]; then
+result=$?
+echo "$output"
+if [[ $result -ne 0 && $output != *"Command \"build\" not found"* ]]; then
     exit 1
 fi
 set -e
@@ -96,7 +97,7 @@ if [ "$update_snapshot" = true ]; then
   pnpm test -- --updateSnapshot
   cd ../../skuba || exit 1
   bash ./scripts/update-template-snapshot.sh ${skuba_temp_directory} ${template}
-else 
+else
   echo "--- pnpm test ${template}"
-  pnpm test 
+  pnpm test
 fi

--- a/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
+++ b/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
@@ -304,6 +304,12 @@ exports[`returns expected CloudFormation stack for dev 1`] = `
             ],
           ],
         },
+        "Tags": [
+          {
+            "Key": "aws-codedeploy-hooks",
+            "Value": "x.x.x-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+          },
+        ],
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
@@ -1007,6 +1013,12 @@ exports[`returns expected CloudFormation stack for prod 1`] = `
             ],
           ],
         },
+        "Tags": [
+          {
+            "Key": "aws-codedeploy-hooks",
+            "Value": "x.x.x-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+          },
+        ],
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },


### PR DESCRIPTION
There were a few shellcheck warnings in this file relating to POSIX compatibility, and branches started to fail with suspiciously related issues; something under the hood in the GitHub Actions runners must have changed. Easy fix is to use bash given we have it!

(Drive-by cleanups of an incorrect check for `pnpm build` failures + trailing whitespace + failing snapshots)