### PR TITLE
Allow throwing non errors in tests

### DIFF
--- a/packages/eslint-config-skuba/index.js
+++ b/packages/eslint-config-skuba/index.js
@@ -180,6 +180,9 @@ module.exports = [
           checksVoidReturn: false,
         },
       ],
+
+      // Allow throwing non errors in tests
+      '@typescript-eslint/only-throw-error': 'off',
     },
   },
   ...eslintPluginYml.configs['flat/prettier'].map((config) => ({


### PR DESCRIPTION
Noticed this while upgrading

![image](https://github.com/user-attachments/assets/9ec65c88-292e-4ab2-86f2-764edc4c640a)
