### PR TITLE
Allow Promise reject in tests

### DIFF
--- a/packages/eslint-config-skuba/index.js
+++ b/packages/eslint-config-skuba/index.js
@@ -173,6 +173,7 @@ module.exports = [
 
       // Allow edge-case error handling tests, including from skuba's templates
       '@typescript-eslint/only-throw-error': 'off',
+      '@typescript-eslint/prefer-promise-reject-errors': 'off',
 
       // Allow potential floating promises in tests only for Koa compatibility
       // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-misused-promises.md#checksvoidreturn


### PR DESCRIPTION
I saw a few:

```
.mockImplementation(() => { return Promise.reject('bad')});
```

and similar implementation across a few repos. Don't think it's worth forcing them to change it to a throw