### PR TITLE
Remove advice for global installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,10 @@ pnpm install
 pnpm exec skuba help
 ```
 
-Global installations are also supported to speed up local development:
+When starting a new project, using the latest version is recommended:
 
 ```shell
-# Install skuba globally.
-pnpm add --global skuba
-
-# Look, no `npx`!
-skuba help
+pnpm dlx skuba init
 ```
 
 If you're new here, jump ahead to the [CLI] section to [create a new project] or [update an existing one].


### PR DESCRIPTION
I feel like a global installation of skuba isn't required, as `pnpm` natively caches it for us now so I would like to instead update our advice to using the latest version of skuba to initialise new projects.