### PR TITLE
Exclude pnpm from template- renovates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -104,6 +104,7 @@
     },
     {
       matchPaths: ['template/**'],
+      excludePackageNames: ['pnpm'],
 
       branchPrefix: 'renovate-template--',
       rangeStrategy: 'replace',


### PR DESCRIPTION
https://github.com/seek-oss/skuba/pull/1703

```
 ERROR  This project is configured to use v9.12.0 of pnpm. Your current pnpm is v9.12.1
If you want to bypass this version check, you can set the "package-manager-strict" configuration to "false" or set the "COREPACK_ENABLE_STRICT" environment variable to "0"
```

Not sure if this will make it available it in the repo level `pnpm` updates but we can always test it.