### PR TITLE
Patch Pnpm Dockerfile

### DIFF
--- a/.changeset/strange-cameras-brake.md
+++ b/.changeset/strange-cameras-brake.md
@@ -1,0 +1,7 @@
+---
+'skuba': minor
+---
+
+lint, format, template: Use pinned pnpm version in Dockerfiles
+
+This fixes usage of the latest pnpm version instead of the pinned version when running pnpm commands in Dockerfiles

--- a/.changeset/strange-cameras-brake.md
+++ b/.changeset/strange-cameras-brake.md
@@ -2,6 +2,6 @@
 'skuba': minor
 ---
 
-lint, format, template: Use pinned pnpm version in Dockerfiles
+lint, format, template: Use pinned `pnpm` version in Dockerfiles
 
-This fixes commands run within Dockerfiles using the latest pnpm version instead of the pinned version.
+This fixes an issue where `pnpm` commands in Dockerfiles incorrectly use the latest pnpm version instead of the pinned version.

--- a/.changeset/strange-cameras-brake.md
+++ b/.changeset/strange-cameras-brake.md
@@ -4,4 +4,4 @@
 
 lint, format, template: Use pinned pnpm version in Dockerfiles
 
-This fixes usage of the latest pnpm version instead of the pinned version when running pnpm commands in Dockerfiles
+This fixes commands run within Dockerfiles using the latest pnpm version instead of the pinned version.

--- a/docs/deep-dives/pnpm.md
+++ b/docs/deep-dives/pnpm.md
@@ -211,9 +211,10 @@ This migration guide assumes that your project was scaffolded with a **skuba** t
       FROM --platform=arm64 node:20-alpine AS dev-deps
     
     + RUN --mount=type=bind,source=package.json,target=package.json \
-    + corepack enable pnpm && corepack install
+    +     corepack enable pnpm && corepack install
     
-    + RUN pnpm config set store-dir /root/.pnpm-store
+    + RUN --mount=type=bind,source=package.json,target=package.json \
+    +     pnpm config set store-dir /root/.pnpm-store
     
       WORKDIR /workdir
     
@@ -223,6 +224,7 @@ This migration guide assumes that your project was scaffolded with a **skuba** t
     - RUN --mount=type=secret,id=npm,dst=/workdir/.npmrc \
     -     yarn install --frozen-lockfile --ignore-optional --non-interactive
     + RUN --mount=type=bind,source=.npmrc,target=.npmrc \
+    +     --mount=type=bind,source=package.json,target=package.json \
     +     --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
     +     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     +     pnpm fetch

--- a/src/cli/__snapshots__/format.int.test.ts.snap
+++ b/src/cli/__snapshots__/format.int.test.ts.snap
@@ -29,6 +29,8 @@ Patch skipped: Update docker image references to use public.ecr.aws and remove -
 
 Patch skipped: Move .npmrc mounts from tmp/.npmrc to /tmp/.npmrc - no Buildkite files found
 
+Patch skipped: Use pinned pnpm version in Dockerfiles - no Dockerfiles found
+
 skuba update complete.
 
 Refreshed .gitignore. refresh-config-files
@@ -113,6 +115,8 @@ Patch skipped: Update docker image references to use public.ecr.aws and remove -
 
 Patch skipped: Move .npmrc mounts from tmp/.npmrc to /tmp/.npmrc - no Buildkite files found
 
+Patch skipped: Use pinned pnpm version in Dockerfiles - no Dockerfiles found
+
 skuba update complete.
 
 Refreshed .gitignore. refresh-config-files
@@ -192,6 +196,8 @@ Patch skipped: Update docker image references to use public.ecr.aws and remove -
 
 Patch skipped: Move .npmrc mounts from tmp/.npmrc to /tmp/.npmrc - no Buildkite files found
 
+Patch skipped: Use pinned pnpm version in Dockerfiles - no Dockerfiles found
+
 skuba update complete.
 
 Refreshed .gitignore. refresh-config-files
@@ -241,6 +247,8 @@ Patch skipped: Remove version field from docker-compose files - no docker-compos
 Patch skipped: Update docker image references to use public.ecr.aws and remove --platform flag - no Dockerfile or docker-compose files found
 
 Patch skipped: Move .npmrc mounts from tmp/.npmrc to /tmp/.npmrc - no Buildkite files found
+
+Patch skipped: Use pinned pnpm version in Dockerfiles - no Dockerfiles found
 
 skuba update complete.
 

--- a/src/cli/lint/internalLints/upgrade/patches/9.0.1/index.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/9.0.1/index.ts
@@ -5,6 +5,6 @@ import { tryPatchPnpmDockerImages } from './patchPnpmDockerImages';
 export const patches: Patches = [
   {
     apply: tryPatchPnpmDockerImages,
-    description: 'Pin pnpm version in Dockerfiles',
+    description: 'Use pinned pnpm version in Dockerfiles',
   },
 ];

--- a/src/cli/lint/internalLints/upgrade/patches/9.0.1/index.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/9.0.1/index.ts
@@ -1,0 +1,10 @@
+import type { Patches } from '../..';
+
+import { tryPatchPnpmDockerImages } from './patchPnpmDockerImages';
+
+export const patches: Patches = [
+  {
+    apply: tryPatchPnpmDockerImages,
+    description: 'Pin pnpm version in Dockerfiles',
+  },
+];

--- a/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.test.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.test.ts
@@ -25,7 +25,7 @@ describe('patchPnpmDockerImages', () => {
 
   it('should skip if no Dockerfiles to patch', async () => {
     jest.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
-    jest.mocked(readFile).mockResolvedValueOnce('beep' as never);
+    jest.mocked(readFile).mockResolvedValueOnce(`beep` as never);
 
     await expect(
       tryPatchPnpmDockerImages({
@@ -37,18 +37,23 @@ describe('patchPnpmDockerImages', () => {
     });
   });
 
-  it('should skip if mode is lint', async () => {
+  it('should return apply and not modify files if mode is lint', async () => {
     jest.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
-    jest.mocked(readFile).mockResolvedValueOnce('beep' as never);
+    jest
+      .mocked(readFile)
+      .mockResolvedValueOnce(
+        `RUN pnpm config set store-dir /root/.pnpm-store` as never,
+      );
 
     await expect(
       tryPatchPnpmDockerImages({
         mode: 'lint',
       } as PatchConfig),
     ).resolves.toEqual({
-      result: 'skip',
-      reason: 'no Dockerfiles to patch',
+      result: 'apply',
     });
+
+    expect(writeFile).not.toHaveBeenCalled();
   });
 
   it('should patch Dockerfiles', async () => {

--- a/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.test.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.test.ts
@@ -1,0 +1,106 @@
+import fg from 'fast-glob';
+import { readFile, writeFile } from 'fs-extra';
+
+import type { PatchConfig } from '../..';
+
+import { tryPatchPnpmDockerImages } from './patchPnpmDockerImages';
+
+jest.mock('fast-glob');
+jest.mock('fs-extra');
+
+describe('patchPnpmDockerImages', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('should skip if no Dockerfiles found', async () => {
+    jest.mocked(fg).mockResolvedValueOnce([]);
+    await expect(
+      tryPatchPnpmDockerImages({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual({
+      result: 'skip',
+      reason: 'no Dockerfiles found',
+    });
+  });
+
+  it('should skip if no Dockerfiles to patch', async () => {
+    jest.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
+    jest.mocked(readFile).mockResolvedValueOnce('beep' as never);
+
+    await expect(
+      tryPatchPnpmDockerImages({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual({
+      result: 'skip',
+      reason: 'no Dockerfiles to patch',
+    });
+  });
+
+  it('should skip if mode is lint', async () => {
+    jest.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
+    jest.mocked(readFile).mockResolvedValueOnce('beep' as never);
+
+    await expect(
+      tryPatchPnpmDockerImages({
+        mode: 'lint',
+      } as PatchConfig),
+    ).resolves.toEqual({
+      result: 'skip',
+      reason: 'no Dockerfiles to patch',
+    });
+  });
+
+  it('should patch Dockerfiles', async () => {
+    jest.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
+    jest.mocked(readFile).mockResolvedValueOnce(
+      `# syntax=docker/dockerfile:1.10
+
+FROM public.ecr.aws/docker/library/node:20-alpine AS dev-deps
+
+RUN --mount=type=bind,source=package.json,target=package.json \\
+    corepack enable pnpm && corepack install
+
+RUN pnpm config set store-dir /root/.pnpm-store
+
+WORKDIR /workdir
+
+RUN --mount=type=bind,source=.npmrc,target=.npmrc \\
+    --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \\
+    --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \\
+    pnpm fetch
+` as never,
+    );
+
+    await expect(
+      tryPatchPnpmDockerImages({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual({
+      result: 'apply',
+    });
+
+    expect(writeFile).toHaveBeenNthCalledWith(
+      1,
+      'Dockerfile',
+      `# syntax=docker/dockerfile:1.10
+
+FROM public.ecr.aws/docker/library/node:20-alpine AS dev-deps
+
+RUN --mount=type=bind,source=package.json,target=package.json \\
+    corepack enable pnpm && corepack install
+
+RUN --mount=type=bind,source=package.json,target=package.json \\
+    pnpm config set store-dir /root/.pnpm-store
+
+WORKDIR /workdir
+
+RUN --mount=type=bind,source=.npmrc,target=.npmrc \\
+    --mount=type=bind,source=package.json,target=package.json \\
+    --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \\
+    --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \\
+    pnpm fetch
+`,
+    );
+  });
+});

--- a/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.ts
@@ -1,0 +1,81 @@
+import { inspect } from 'util';
+
+import fg from 'fast-glob';
+import { readFile, writeFile } from 'fs-extra';
+
+import type { PatchFunction, PatchReturnType } from '../..';
+import { log } from '../../../../../../utils/logging';
+
+const DOCKER_IMAGE_CONFIG_REGEX =
+  /^(RUN )(pnpm config set store-dir \/root\/.pnpm-store)/gm;
+const DOCKER_IMAGE_FETCH_REGEX =
+  /(^RUN --mount=type=bind,source=\.npmrc,target=\.npmrc \\\n)([\s\S]*)(?!--mount=type=bind,source=package\.json,target=package\.json[\s\S]*pnpm fetch)/gm;
+
+const PACKAGE_JSON_MOUNT =
+  '--mount=type=bind,source=package.json,target=package.json \\\n';
+
+const fetchFiles = async (files: string[]) =>
+  Promise.all(
+    files.map(async (file) => {
+      const contents = await readFile(file, 'utf8');
+
+      return {
+        file,
+        contents,
+      };
+    }),
+  );
+
+const patchPnpmDockerImages: PatchFunction = async ({
+  mode,
+}): Promise<PatchReturnType> => {
+  const maybeDockerFilesPaths = await fg(['Dockerfile*']);
+
+  if (!maybeDockerFilesPaths.length) {
+    return {
+      result: 'skip',
+      reason: 'no Dockerfiles found',
+    };
+  }
+
+  const dockerFiles = await fetchFiles(maybeDockerFilesPaths);
+
+  const dockerFilesToPatch = dockerFiles.filter(({ contents }) =>
+    DOCKER_IMAGE_CONFIG_REGEX.exec(contents),
+  );
+
+  if (!dockerFilesToPatch.length) {
+    return {
+      result: 'skip',
+      reason: 'no Dockerfiles to patch',
+    };
+  }
+
+  if (mode === 'lint') {
+    return {
+      result: 'apply',
+    };
+  }
+
+  await Promise.all(
+    dockerFilesToPatch.map(async ({ file, contents }) => {
+      const patchedContents = contents
+        .replace(DOCKER_IMAGE_CONFIG_REGEX, `$1${PACKAGE_JSON_MOUNT}    $2`)
+        .replace(DOCKER_IMAGE_FETCH_REGEX, `$1    ${PACKAGE_JSON_MOUNT}$2`);
+
+      await writeFile(file, patchedContents);
+    }),
+  );
+
+  return { result: 'apply' };
+};
+
+export const tryPatchPnpmDockerImages: PatchFunction = async (config) => {
+  try {
+    return await patchPnpmDockerImages(config);
+  } catch (err) {
+    log.warn('Failed to patch Docker images');
+    log.subtle(inspect(err));
+    return { result: 'skip', reason: 'due to an error' };
+  }
+};

--- a/template/express-rest-api/Dockerfile.dev-deps
+++ b/template/express-rest-api/Dockerfile.dev-deps
@@ -5,11 +5,13 @@ FROM public.ecr.aws/docker/library/node:20-alpine AS dev-deps
 RUN --mount=type=bind,source=package.json,target=package.json \
     corepack enable pnpm && corepack install
 
-RUN pnpm config set store-dir /root/.pnpm-store
+RUN --mount=type=bind,source=package.json,target=package.json \
+    pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=.npmrc,target=.npmrc \
+    --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/greeter/Dockerfile
+++ b/template/greeter/Dockerfile
@@ -5,11 +5,13 @@ FROM public.ecr.aws/docker/library/node:20-alpine AS dev-deps
 RUN --mount=type=bind,source=package.json,target=package.json \
     corepack enable pnpm && corepack install
 
-RUN pnpm config set store-dir /root/.pnpm-store
+RUN --mount=type=bind,source=package.json,target=package.json \
+    pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=.npmrc,target=.npmrc \
+    --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/koa-rest-api/Dockerfile.dev-deps
+++ b/template/koa-rest-api/Dockerfile.dev-deps
@@ -5,11 +5,13 @@ FROM public.ecr.aws/docker/library/node:20-alpine AS dev-deps
 RUN --mount=type=bind,source=package.json,target=package.json \
     corepack enable pnpm && corepack install
 
-RUN pnpm config set store-dir /root/.pnpm-store
+RUN --mount=type=bind,source=package.json,target=package.json \
+    pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=.npmrc,target=.npmrc \
+    --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/lambda-sqs-worker-cdk/Dockerfile
+++ b/template/lambda-sqs-worker-cdk/Dockerfile
@@ -8,11 +8,13 @@ RUN apk add --no-cache bash
 RUN --mount=type=bind,source=package.json,target=package.json \
     corepack enable pnpm && corepack install
 
-RUN pnpm config set store-dir /root/.pnpm-store
+RUN --mount=type=bind,source=package.json,target=package.json \
+    pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=.npmrc,target=.npmrc \
+    --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch

--- a/template/lambda-sqs-worker/Dockerfile
+++ b/template/lambda-sqs-worker/Dockerfile
@@ -5,11 +5,13 @@ FROM public.ecr.aws/docker/library/node:20-alpine AS dev-deps
 RUN --mount=type=bind,source=package.json,target=package.json \
     corepack enable pnpm && corepack install
 
-RUN pnpm config set store-dir /root/.pnpm-store
+RUN --mount=type=bind,source=package.json,target=package.json \
+    pnpm config set store-dir /root/.pnpm-store
 
 WORKDIR /workdir
 
 RUN --mount=type=bind,source=.npmrc,target=.npmrc \
+    --mount=type=bind,source=package.json,target=package.json \
     --mount=type=bind,source=pnpm-lock.yaml,target=pnpm-lock.yaml \
     --mount=type=secret,id=npm,dst=/root/.npmrc,required=true \
     pnpm fetch


### PR DESCRIPTION
Corepack seems to always fetch the latest package manager if you don't have a `package.json` present despite us installing a specific version of `pnpm` beforehand. This autofixes our Dockerfiles to always mount the package.json file when running a pnpm command

https://seekchat.slack.com/archives/C07C02YUF9S/p1729154703475989?thread_ts=1729142626.867769&cid=C07C02YUF9S

