### PR TITLE
Consider indentation in pnpm Dockerfile autofix

### DIFF
--- a/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/9.0.1/patchPnpmDockerImages.ts
@@ -7,7 +7,7 @@ import type { PatchFunction, PatchReturnType } from '../..';
 import { log } from '../../../../../../utils/logging';
 
 const DOCKER_IMAGE_CONFIG_REGEX =
-  /^(RUN --mount=type=bind,source=package.json,target=package.json \\\n(\s+)corepack enable pnpm && corepack install(?:.|\n)+?)(RUN )(pnpm config set store-dir \/root\/.pnpm-store)/gm;
+  /^(RUN --mount=type=bind,source=package.json,target=package.json \\\n(\s+)corepack enable pnpm && corepack install(?:.|\n)+?RUN )(pnpm config set store-dir \/root\/.pnpm-store)/gm;
 const DOCKER_IMAGE_FETCH_REGEX =
   /^(RUN --mount=type=bind,source=.npmrc,target=.npmrc \\\n)((?:(?!--mount=type=bind,source=package\.json,target=package\.json)[\s\S])+?\n(\s+)pnpm (fetch|install))/gm;
 
@@ -64,8 +64,8 @@ const patchPnpmDockerImages: PatchFunction = async ({
       const patchedContents = contents
         .replace(
           DOCKER_IMAGE_CONFIG_REGEX,
-          (_, earlyCommands, whitespace, runLine, pnpmSetConfigLine) =>
-            `${earlyCommands}${runLine}${PACKAGE_JSON_MOUNT}${whitespace}${pnpmSetConfigLine}`,
+          (_, earlyCommands, whitespace, pnpmSetConfigLine) =>
+            `${earlyCommands}${PACKAGE_JSON_MOUNT}${whitespace}${pnpmSetConfigLine}`,
         )
         .replace(
           DOCKER_IMAGE_FETCH_REGEX,


### PR DESCRIPTION
This one irks me because vscode behaves differently around Dockerfiles? On this repo it seems to do spaces of 4 but on others I get 2.

https://github.com/seek-oss/skuba/blob/91af3b6a6d503f7c964e03e9cda48adad4e4c44e/template/lambda-sqs-worker/Dockerfile#L13-L17

This is indented by 4 and when I save it on vscode it doesn't format it.

But on this [repo](https://github.com/SEEK-Jobs/indie-graphql-server/blob/121ae87b1b04bec47195b44affed5ace1bff43b6/Dockerfile.dev-deps#L7-L8) there's a mix of 2 indent and 4 indent and when I save it makes it 2 indent.

So this PR decides to check how the other stuff is indented and copies the indentation.

Prettier does not care about Dockerfiles.