### PR TITLE
RFC: Try to remove ESLint `languageOptions`

### DIFF
--- a/.changeset/wet-owls-attack.md
+++ b/.changeset/wet-owls-attack.md
@@ -1,0 +1,10 @@
+---
+'eslint-config-skuba': minor
+---
+
+Revert to modern JavaScript language option defaults
+
+- `ecmaVersion: 5 => latest`
+- `sourceType: script => module`
+
+See [JavaScript language options](https://eslint.org/docs/latest/use/configure/language-options#specifying-javascript-options) for more information.

--- a/packages/eslint-config-skuba/index.js
+++ b/packages/eslint-config-skuba/index.js
@@ -100,15 +100,6 @@ module.exports = [
     name: 'skuba/typescript',
     files: [`**/*.{${tsExtensions}}`],
 
-    languageOptions: {
-      ecmaVersion: 5,
-      sourceType: 'script',
-
-      parserOptions: {
-        projectService: true,
-      },
-    },
-
     rules: {
       '@typescript-eslint/consistent-type-exports': 'error',
       '@typescript-eslint/no-floating-promises': 'error',


### PR DESCRIPTION
We have more modern defaults specified in `eslint-config-seek/base`.

- https://github.com/seek-oss/eslint-config-seek/blob/b06e07d6370c5a0bd585a6dc30ffd7708ff68e06/base.js#L120-L121
- https://github.com/seek-oss/eslint-config-seek/blob/b06e07d6370c5a0bd585a6dc30ffd7708ff68e06/base.js#L138-L141

This may require some manual testing to ensure it doesn't break things on a typical back-end repository that still uses CommonJS.