### PR TITLE
Fix pnpm dlx usage

### DIFF
--- a/.changeset/yellow-paws-train.md
+++ b/.changeset/yellow-paws-train.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+init: Fix `pnpm dlx skuba init` usage

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -90,8 +90,8 @@ export const init = async (args = process.argv.slice(2)) => {
   await initialiseRepo(destinationDir, templateData);
 
   const [manifest, packageManagerConfig] = await Promise.all([
-    getConsumerManifest(),
-    detectPackageManager(),
+    getConsumerManifest(destinationDir),
+    detectPackageManager(destinationDir),
   ]);
 
   if (!manifest) {


### PR DESCRIPTION
Fixes `init` usage when used with `pnpm dlx`. At the moment it doesn't pass in the `destinationDir` so it fails to find the skuba manifest which we create in the line before.

Before:

![image](https://github.com/user-attachments/assets/8b4aadfc-94b9-438d-bede-70f5efbdc605)

After:

![image](https://github.com/user-attachments/assets/ea93631e-4b8e-4fb8-9a34-21e39ff7d1ab)

A little tricky to test with our integration tests/not worth my time