### PR TITLE
Remove source url tag from gantry values

### DIFF
--- a/template/express-rest-api/.gantry/common.yml
+++ b/template/express-rest-api/.gantry/common.yml
@@ -9,5 +9,4 @@ image: '{{values "prodAccountId"}}.dkr.ecr.<%- region %>.amazonaws.com/{{values 
 # datadogSecretId: arn:aws:secretsmanager:<%- region %>:<aws-account-id>:secret:<secret-name>
 
 tags:
-  seek:source:url: 'https://github.com/SEEK-Jobs/<%- repoName %>'
   # seek:system:name: 'TODO: https://rfc.skinfra.xyz/RFC051-AWS-Tagging-Standard.html#tagging-schema'

--- a/template/koa-rest-api/.gantry/common.yml
+++ b/template/koa-rest-api/.gantry/common.yml
@@ -9,5 +9,4 @@ image: '{{values "prodAccountId"}}.dkr.ecr.<%- region %>.amazonaws.com/{{values 
 # datadogSecretId: arn:aws:secretsmanager:<%- region %>:<aws-account-id>:secret:<secret-name>
 
 tags:
-  seek:source:url: 'https://github.com/SEEK-Jobs/<%- repoName %>'
   # seek:system:name: 'TODO: https://rfc.skinfra.xyz/RFC051-AWS-Tagging-Standard.html#tagging-schema'


### PR DESCRIPTION
https://backstage.myseek.xyz/docs/default/component/gantry/v1/reference/resources/service/#default-tags
https://backstage.myseek.xyz/docs/default/component/gantry/v1/reference/resources/service/#default-tags

Source URL is a default value applied by Gantry, so it doesn't need to be passed in via values