### PR TITLE
Determine changes from root

### DIFF
--- a/.changeset/tired-walls-enter.md
+++ b/.changeset/tired-walls-enter.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+Git.commitAllChanges: Determine changed files from git root by default

--- a/src/api/git/commitAllChanges.ts
+++ b/src/api/git/commitAllChanges.ts
@@ -32,16 +32,16 @@ export const commitAllChanges = async ({
   committer,
   ignore,
 }: CommitAllParameters): Promise<string | undefined> => {
-  const changedFiles = await getChangedFiles({ dir, ignore });
-
-  if (!changedFiles.length) {
-    return;
-  }
-
   const gitRoot = await findRoot({ dir });
 
   if (!gitRoot) {
     throw new Error(`Could not find Git root from directory: ${dir}`);
+  }
+
+  const changedFiles = await getChangedFiles({ dir: gitRoot, ignore });
+
+  if (!changedFiles.length) {
+    return;
   }
 
   await Promise.all(


### PR DESCRIPTION
Ran into a bug in another repo where we tried running this from a nested project and it produced weird results.