### PR TITLE
Dedupe some deps

### DIFF
--- a/.changeset/free-bats-jump.md
+++ b/.changeset/free-bats-jump.md
@@ -1,0 +1,7 @@
+---
+'skuba': minor
+---
+
+deps: Drop dependencies `validate-npm-package-name` and `libnpmsearch`
+
+These dependencies have been removed, replaced by `npm-registry-fetch`.

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "isomorphic-git": "^1.11.1",
     "jest": "^29.0.1",
     "jest-watch-typeahead": "^2.1.1",
-    "libnpmsearch": "^8.0.0",
     "lodash.mergewith": "^4.6.2",
     "minimist": "^1.2.6",
     "normalize-package-data": "^7.0.0",
@@ -118,7 +117,6 @@
     "tsconfig-seek": "2.0.0",
     "tsx": "^4.16.2",
     "typescript": "~5.8.0",
-    "validate-npm-package-name": "^6.0.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -130,7 +128,6 @@
     "@types/express": "5.0.0",
     "@types/fs-extra": "11.0.4",
     "@types/koa": "2.15.0",
-    "@types/libnpmsearch": "2.0.7",
     "@types/lodash.mergewith": "4.6.9",
     "@types/minimist": "1.2.5",
     "@types/module-alias": "2.0.4",
@@ -139,7 +136,6 @@
     "@types/picomatch": "3.0.2",
     "@types/semver": "7.5.8",
     "@types/supertest": "6.0.2",
-    "@types/validate-npm-package-name": "4.0.2",
     "enhanced-resolve": "5.18.1",
     "express": "5.0.1",
     "fastify": "5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,6 @@ importers:
       jest-watch-typeahead:
         specifier: ^2.1.1
         version: 2.2.2(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@20.17.23)(typescript@5.8.2)))
-      libnpmsearch:
-        specifier: ^8.0.0
-        version: 8.0.0
       lodash.mergewith:
         specifier: ^4.6.2
         version: 4.6.2
@@ -158,9 +155,6 @@ importers:
       typescript:
         specifier: ~5.8.0
         version: 5.8.2
-      validate-npm-package-name:
-        specifier: ^6.0.0
-        version: 6.0.0
       zod:
         specifier: ^3.22.4
         version: 3.24.2
@@ -189,9 +183,6 @@ importers:
       '@types/koa':
         specifier: 2.15.0
         version: 2.15.0
-      '@types/libnpmsearch':
-        specifier: 2.0.7
-        version: 2.0.7
       '@types/lodash.mergewith':
         specifier: 4.6.9
         version: 4.6.9
@@ -216,9 +207,6 @@ importers:
       '@types/supertest':
         specifier: 6.0.2
         version: 6.0.2
-      '@types/validate-npm-package-name':
-        specifier: 4.0.2
-        version: 4.0.2
       enhanced-resolve:
         specifier: 5.18.1
         version: 5.18.1
@@ -2218,9 +2206,6 @@ packages:
   '@types/koa__router@12.0.4':
     resolution: {integrity: sha512-Y7YBbSmfXZpa/m5UGGzb7XadJIRBRnwNY9cdAojZGp65Cpe5MAP3mOZE7e3bImt8dfKS4UFcR16SLH8L/z7PBw==}
 
-  '@types/libnpmsearch@2.0.7':
-    resolution: {integrity: sha512-veF2pJz2gKwN2qmZZeQY9clT9BhmMNWJTiJaIr2rnTT/8/eDUNGW83sDEHiDp/Te4R2Gu0m03EK67SuPUjQ2OA==}
-
   '@types/lodash.mergewith@4.6.9':
     resolution: {integrity: sha512-fgkoCAOF47K7sxrQ7Mlud2TH023itugZs2bUg8h/KzT+BnZNrR2jAOmaokbLunHNnobXVWOezAeNn/lZqwxkcw==}
 
@@ -2322,9 +2307,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/validate-npm-package-name@4.0.2':
-    resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -9049,11 +9031,6 @@ snapshots:
     dependencies:
       '@types/koa': 2.15.0
 
-  '@types/libnpmsearch@2.0.7':
-    dependencies:
-      '@types/node': 20.17.23
-      '@types/npm-registry-fetch': 8.0.7
-
   '@types/lodash.mergewith@4.6.9':
     dependencies:
       '@types/lodash': 4.17.16
@@ -9161,8 +9138,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/validate-npm-package-name@4.0.2': {}
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/src/cli/configure/analyseDependencies.ts
+++ b/src/cli/configure/analyseDependencies.ts
@@ -6,7 +6,7 @@ import type { NormalizedReadResult } from 'read-pkg-up';
 import { type TextProcessor, copyFiles } from '../../utils/copy';
 import { log } from '../../utils/logging';
 import type { ProjectType } from '../../utils/manifest';
-import { getSkubaVersion, latestNpmVersion } from '../../utils/version';
+import { getLatestNpmVersion, getSkubaVersion } from '../../utils/version';
 
 import { diffDependencies } from './analysis/package';
 import * as dependencyMutators from './dependencies';
@@ -40,7 +40,11 @@ const pinUnspecifiedVersions = async (
       .map(async ([name]) => {
         const version = await (name === 'skuba'
           ? getSkubaVersion()
-          : latestNpmVersion(name));
+          : getLatestNpmVersion(name));
+
+        if (version === null) {
+          throw new Error(`Failed to fetch latest version of ${name}`);
+        }
 
         return [name, version] as const;
       }),

--- a/src/cli/migrate/nodeVersion/getNodeTypesVersion.test.ts
+++ b/src/cli/migrate/nodeVersion/getNodeTypesVersion.test.ts
@@ -45,7 +45,7 @@ describe('getNodeTypesVersion', () => {
         }),
       {
         version: '22.9.0',
-        err: 'Failed to fetch latest @types/node version, using fallback version 22.9.0',
+        err: 'No matching @types/node versions for Node.js 22',
       },
     ],
     [

--- a/src/cli/migrate/nodeVersion/getNodeTypesVersion.ts
+++ b/src/cli/migrate/nodeVersion/getNodeTypesVersion.ts
@@ -1,52 +1,39 @@
 import { inspect } from 'util';
 
-import npmFetch from 'npm-registry-fetch';
 import { gt, satisfies, valid } from 'semver';
-import { z } from 'zod';
 
 import { log } from '../../../utils/logging';
+import { getNpmVersions } from '../../../utils/version';
 
 type VersionResult = {
   version: string;
   err?: string;
 };
 
-const NpmFetchResponse = z.object({
-  versions: z.record(
-    z.string(),
-    z.object({
-      name: z.string(),
-      version: z.string(),
-      deprecated: z.string().optional(),
-    }),
-  ),
-});
-
 export const getNodeTypesVersion = async (
   major: number,
   defaultVersion: string,
 ): Promise<VersionResult> => {
   try {
-    const response = await npmFetch.json('@types/node', {
-      headers: {
-        Accept:
-          'application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*',
-      },
-    });
+    const versions = await getNpmVersions('@types/node');
 
-    const parsedVersions = NpmFetchResponse.safeParse(response);
-    if (!parsedVersions.success) {
-      throw new Error('Failed to parse @types/node response from npm');
+    const matchingVersions = Object.values(versions ?? {}).filter(
+      (v) =>
+        valid(v.version) &&
+        satisfies(v.version, `${major}.x.x`) &&
+        !v.deprecated,
+    );
+
+    if (!matchingVersions.length) {
+      return {
+        version: defaultVersion,
+        err: `No matching @types/node versions for Node.js ${major}`,
+      };
     }
 
-    const { version } = Object.values(parsedVersions.data.versions)
-      .filter(
-        (v) =>
-          valid(v.version) &&
-          satisfies(v.version, `${major}.x.x`) &&
-          !v.deprecated,
-      )
-      .reduce((a, b) => (gt(a.version, b.version) ? a : b));
+    const { version } = matchingVersions.reduce((a, b) =>
+      gt(a.version, b.version) ? a : b,
+    );
 
     return {
       version,


### PR DESCRIPTION
`npm-registry-fetch` was used in the skuba migration code, and its purpose clashes with `libnpmsearch`, which is also causing us annoyance in https://github.com/seek-oss/skuba/pull/1758. 

While there, I was able to drop `validate-npm-package-name` (we'll just get a 404, which is probably fine?). 