### PR TITLE
Skuba Node Upgrade Fixes

### DIFF
--- a/.changeset/chilled-onions-doubt.md
+++ b/.changeset/chilled-onions-doubt.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-migrate: Re-lock yarn.lock/pnpm-lock.yaml after updating `@types/node` during node version migrations
+migrate: Update `@types/node` in lock file during Node.js version migrations

--- a/.changeset/chilled-onions-doubt.md
+++ b/.changeset/chilled-onions-doubt.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+migrate: Re-lock yarn.lock/pnpm-lock.yaml after updating `@types/node` during node version migrations

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -101,13 +101,13 @@ manually review the following configuration options:
   You may need to define explicit overrides for npm packages like so:
 
   ```diff
-  {
-  + "compilerOptions": {
-  +   "removeComments": false,
-  +   "target": "ES2023" // Continue to support package consumers on Node.js 20
-  + },
-    "extends": "../../tsconfig.json"
-  }
+    {
+  +   "compilerOptions": {
+  +     "removeComments": false,
+  +     "target": "ES2023" // Continue to support package consumers on Node.js 20
+  +   },
+      "extends": "../../tsconfig.json"
+    }
   ```
 
 As of **skuba** 10,

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -41,11 +41,16 @@ and [open an issue](https://github.com/seek-oss/skuba/issues/new) if your projec
 Exercise particular caution with monorepos,
 as some may have employed unique configurations that the migration has not accounted for.
 
-The migration will attempt to proceed if your project specifies:
+The migration will attempt to proceed if your project:
 
-- A Node.js version in `.node-version`, `.nvmrc`, and/or `package.json#/engines/node`
+- Specifies a Node.js version in `.node-version`, `.nvmrc`, and/or `package.json#/engines/node`
 
-- A project type in `package.json#/skuba/type` that is not `package`
+- Does not include a `package.json#/files` field
+
+  This field implies that your project is an npm package.
+  See below for considerations when manually upgrading npm packages.
+
+- Specifies a project type in `package.json#/skuba/type` that is not `package`
 
   Well-known project types currently include `application` and `package`.
   While we intend to improve support for monorepo projects in a future version,
@@ -110,7 +115,7 @@ As of **skuba** 10,
 
 [`Object.groupBy()` static method]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy
 [active LTS version]: https://nodejs.org/en/about/previous-releases#nodejs-releases
-[Node Target Mapping]: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping.
+[Node Target Mapping]: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping
 [patches]: ./lint.md#patches
 [semantic versioning]: https://semver.org/
 [template]: ../templates/index.md

--- a/src/cli/configure/index.ts
+++ b/src/cli/configure/index.ts
@@ -115,7 +115,7 @@ export const configure = async () => {
 
     log.newline();
     try {
-      await exec(packageManager.install);
+      await exec(packageManager.command, 'install');
     } catch {
       log.newline();
       log.warn(log.bold('✗ Failed to install dependencies. Resume with:'));

--- a/src/cli/format.int.test.ts
+++ b/src/cli/format.int.test.ts
@@ -5,6 +5,8 @@ import fs, { copy } from 'fs-extra';
 import git from 'isomorphic-git';
 import { diff } from 'jest-diff';
 
+import * as packageManager from '../utils/packageManager';
+
 import { format } from './format';
 import * as getNodeTypesVersionModule from './migrate/nodeVersion/getNodeTypesVersion';
 
@@ -25,6 +27,8 @@ jest
   .mockResolvedValue([
     { remote: 'origin', url: 'git@github.com:seek-oss/skuba.git' },
   ]);
+
+jest.spyOn(packageManager, 'relock').mockResolvedValue(undefined);
 
 const SOURCE_FILES = ['a/a/a.ts', 'b.md', 'c.json', 'd.js'];
 

--- a/src/cli/migrate/nodeVersion/checks.ts
+++ b/src/cli/migrate/nodeVersion/checks.ts
@@ -82,6 +82,7 @@ export const isPatchableSkubaType = async (): Promise<boolean> => {
         skuba: z.object({
           type: z.string().optional(),
         }),
+        files: z.string().array().optional(),
       }),
     );
 
@@ -89,6 +90,13 @@ export const isPatchableSkubaType = async (): Promise<boolean> => {
     throw new Error(
       'package.json not found, ensure it is in the correct location',
     );
+  }
+
+  if (packageJson.files) {
+    log.warn(
+      'Migrations are not supported for packages; update manually to ensure major runtime deprecations are intended',
+    );
+    return false;
   }
 
   const type = packageJson?.skuba.type;

--- a/src/cli/migrate/nodeVersion/index.ts
+++ b/src/cli/migrate/nodeVersion/index.ts
@@ -4,6 +4,7 @@ import { glob } from 'fast-glob';
 import fs from 'fs-extra';
 
 import { log } from '../../../utils/logging';
+import { relock } from '../../../utils/packageManager';
 import { createDestinationFileReader } from '../../configure/analysis/project';
 
 import {
@@ -206,6 +207,8 @@ export const nodeVersionMigration = async (
       log.warn(err);
     }
     await upgrade({ nodeVersion, nodeTypesVersion, ECMAScriptVersion }, dir);
+    await relock(dir);
+
     log.ok('Upgraded to Node.js', nodeVersion);
   } catch (error) {
     log.err('Failed to upgrade');

--- a/src/utils/packageManager.test.ts
+++ b/src/utils/packageManager.test.ts
@@ -11,7 +11,9 @@ jest
   .spyOn(console, 'log')
   .mockImplementation((...args) => stdoutMock(`${args.join(' ')}\n`));
 
-jest.spyOn(exec, 'exec').mockResolvedValue({} as any);
+const mockExec = jest.fn().mockResolvedValue({});
+
+jest.spyOn(exec, 'createExec').mockReturnValue(mockExec);
 
 const stdout = () => stdoutMock.mock.calls.flat(1).join('').trim();
 
@@ -151,6 +153,6 @@ describe('relock', () => {
     );
     await expect(relock()).resolves.toBeUndefined();
 
-    expect(exec.exec).toHaveBeenCalledWith('pnpm install');
+    expect(mockExec).toHaveBeenCalledWith('pnpm', 'install');
   });
 });

--- a/src/utils/packageManager.ts
+++ b/src/utils/packageManager.ts
@@ -2,7 +2,7 @@ import findUp from 'find-up';
 import isInstalledGlobally from 'is-installed-globally';
 import { z } from 'zod';
 
-import { exec } from './exec';
+import { createExec } from './exec';
 import { log } from './logging';
 
 // TODO: consider changing to this to `pnpm` in a future major version.
@@ -75,7 +75,11 @@ export const detectPackageManager = async (
 
 export const relock = async (cwd?: string) => {
   const packageManager = await detectPackageManager(cwd);
-  await exec(packageManager.install);
+  const exec = createExec({
+    stdio: 'pipe',
+    streamStdio: packageManager.command,
+  });
+  await exec(packageManager.command, 'install');
 };
 
 const findDepth = async (filename: string, cwd?: string) => {

--- a/src/utils/packageManager.ts
+++ b/src/utils/packageManager.ts
@@ -2,6 +2,7 @@ import findUp from 'find-up';
 import isInstalledGlobally from 'is-installed-globally';
 import { z } from 'zod';
 
+import { exec } from './exec';
 import { log } from './logging';
 
 // TODO: consider changing to this to `pnpm` in a future major version.
@@ -70,6 +71,11 @@ export const detectPackageManager = async (
   }
 
   return configForPackageManager(packageManager);
+};
+
+export const relock = async (cwd?: string) => {
+  const packageManager = await detectPackageManager(cwd);
+  await exec(packageManager.install);
 };
 
 const findDepth = async (filename: string, cwd?: string) => {


### PR DESCRIPTION
- Determine Node package via presence of `files` field.
- Re-lock after the upgrade.