### PR TITLE
Consider current path when finding parent package.json

### DIFF
--- a/.changeset/breezy-donkeys-lick.md
+++ b/.changeset/breezy-donkeys-lick.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+migrate: Check nearest `package.json` during Node.js version migrations

--- a/src/cli/migrate/nodeVersion/checks.test.ts
+++ b/src/cli/migrate/nodeVersion/checks.test.ts
@@ -18,6 +18,8 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+const cwd = process.cwd();
+
 describe('isPatchableServerlessVersion', () => {
   it('resolves as a noop when serverless version is supported', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -31,7 +33,7 @@ describe('isPatchableServerlessVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableServerlessVersion()).resolves.toBe(true);
+    await expect(isPatchableServerlessVersion(cwd)).resolves.toBe(true);
   });
   it('should return false when the serverless version is below 4', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -45,7 +47,7 @@ describe('isPatchableServerlessVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableServerlessVersion()).resolves.toBe(false);
+    await expect(isPatchableServerlessVersion(cwd)).resolves.toBe(false);
   });
   it('should return true when serverless version is not found', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -59,11 +61,11 @@ describe('isPatchableServerlessVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableServerlessVersion()).resolves.toBe(true);
+    await expect(isPatchableServerlessVersion(cwd)).resolves.toBe(true);
   });
   it('throws when no package.json is found', async () => {
     jest.mocked(findUp).mockResolvedValueOnce(undefined);
-    await expect(isPatchableServerlessVersion()).rejects.toThrow(
+    await expect(isPatchableServerlessVersion(cwd)).rejects.toThrow(
       'package.json not found, ensure it is in the correct location',
     );
   });
@@ -73,7 +75,7 @@ describe('isPatchableServerlessVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('invalid json' as never);
-    await expect(isPatchableServerlessVersion()).rejects.toThrow(
+    await expect(isPatchableServerlessVersion(cwd)).rejects.toThrow(
       'package.json is not valid JSON',
     );
   });
@@ -92,7 +94,7 @@ describe('isPatchableSkubaType', () => {
           },
         }) as never,
       );
-    await expect(isPatchableSkubaType()).resolves.toBe(true);
+    await expect(isPatchableSkubaType(cwd)).resolves.toBe(true);
   });
   it('should return false when skuba type is "package"', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -106,7 +108,7 @@ describe('isPatchableSkubaType', () => {
           },
         }) as never,
       );
-    await expect(isPatchableSkubaType()).resolves.toBe(false);
+    await expect(isPatchableSkubaType(cwd)).resolves.toBe(false);
   });
   it('should return false when skuba type is not found', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -120,11 +122,11 @@ describe('isPatchableSkubaType', () => {
           },
         }) as never,
       );
-    await expect(isPatchableSkubaType()).resolves.toBe(false);
+    await expect(isPatchableSkubaType(cwd)).resolves.toBe(false);
   });
   it('should throw when no package.json is not found', async () => {
     jest.mocked(findUp).mockResolvedValueOnce(undefined);
-    await expect(isPatchableSkubaType()).rejects.toThrow(
+    await expect(isPatchableSkubaType(cwd)).rejects.toThrow(
       'package.json not found, ensure it is in the correct location',
     );
   });
@@ -137,7 +139,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('20' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(true);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(true);
   });
   it('should return false when the node version is greater than the target version', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.nvmrc');
@@ -145,7 +147,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('24' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when the node version is not found', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.nvmrc');
@@ -153,7 +155,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue(null as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when the current node version is not a number', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.nvmrc');
@@ -161,7 +163,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('twenty' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when the target node version is invalid', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.nvmrc');
@@ -169,7 +171,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('20' as never);
-    await expect(isPatchableNodeVersion(-1)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(-1, cwd)).resolves.toBe(false);
   });
   it('should return true when the node version is equal to the target version', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.nvmrc');
@@ -177,7 +179,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('22' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(true);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(true);
   });
   it('should return true when the node version is found in .node-version', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.node-version');
@@ -185,7 +187,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('20' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(true);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(true);
   });
   it('should return true when the node version is found in package.json engines', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -199,7 +201,7 @@ describe('isPatchableNodeVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(true);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(true);
   });
   it('should return false when the node version in package.json engines is greater than the target version', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -213,7 +215,7 @@ describe('isPatchableNodeVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when the node version in package.json engines is invalid', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -227,11 +229,11 @@ describe('isPatchableNodeVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when no version is found in any file', async () => {
     jest.mocked(findUp).mockResolvedValueOnce(undefined);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when the version in .nvmrc is invalid', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.nvmrc');
@@ -239,7 +241,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('invalid' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when the version in .node-version is invalid', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.node-version');
@@ -247,7 +249,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('invalid' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return false when the version in package.json engines is invalid', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
@@ -261,7 +263,7 @@ describe('isPatchableNodeVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
   });
   it('should return true when the version in .nvmrc and .node-version is invalid but a valid package.json engines version', async () => {
     jest.mocked(findUp).mockResolvedValueOnce('.nvmrc');
@@ -269,7 +271,7 @@ describe('isPatchableNodeVersion', () => {
       .spyOn(fs, 'readFile')
       .mockImplementation()
       .mockReturnValue('invalid' as never);
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(false);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(false);
     jest.mocked(findUp).mockResolvedValueOnce('package.json');
     jest
       .spyOn(fs, 'readFile')
@@ -281,6 +283,6 @@ describe('isPatchableNodeVersion', () => {
           },
         }) as never,
       );
-    await expect(isPatchableNodeVersion(22)).resolves.toBe(true);
+    await expect(isPatchableNodeVersion(22, cwd)).resolves.toBe(true);
   });
 });

--- a/src/cli/migrate/nodeVersion/index.ts
+++ b/src/cli/migrate/nodeVersion/index.ts
@@ -19,7 +19,7 @@ type FileSelector =
   | { file: string; files?: never };
 
 type SubPatch = FileSelector & {
-  tests?: Array<() => Promise<boolean>>;
+  tests?: Array<(path: string) => Promise<boolean>>;
   regex?: RegExp;
   replace: string;
 };
@@ -143,7 +143,9 @@ const runSubPatch = async (dir: string, patch: SubPatch) => {
       }
 
       if (patch.tests) {
-        const results = await Promise.all(patch.tests.map((test) => test()));
+        const results = await Promise.all(
+          patch.tests.map((test) => test(path)),
+        );
         if (!results.every(Boolean)) {
           return;
         }
@@ -195,7 +197,7 @@ export const nodeVersionMigration = async (
 ) => {
   log.ok(`Upgrading to Node.js ${nodeVersion}`);
   try {
-    if (!(await isPatchableNodeVersion(nodeVersion))) {
+    if (!(await isPatchableNodeVersion(nodeVersion, dir))) {
       throw new Error('Node.js version is not patchable');
     }
 


### PR DESCRIPTION
At the moment, `isPatchableSkubaType` keeps checking the root directory's package.json file, where it should be checking for the nearest package.json to the file that we have.

Before:
<img width="979" alt="image" src="https://github.com/user-attachments/assets/1ebb49fb-9c68-4089-ab04-2c77c9d8d931" />

After:
<img width="993" alt="image" src="https://github.com/user-attachments/assets/2c8db7bd-936f-4736-b6b1-5e7c29319af4" />