### PR TITLE
Require latest eslint-config-seek 

### DIFF
--- a/.changeset/three-wasps-prove.md
+++ b/.changeset/three-wasps-prove.md
@@ -1,0 +1,6 @@
+---
+'eslint-config-skuba': patch
+'skuba': patch
+---
+
+deps: eslint-config-seek

--- a/.changeset/three-wasps-prove.md
+++ b/.changeset/three-wasps-prove.md
@@ -3,4 +3,6 @@
 'skuba': patch
 ---
 
-deps: eslint-config-seek
+deps: eslint-config-seek ^14.3.2
+
+This version pins `eslint-plugin-import-x` to an older version, due to compatibility issues with the **skuba** ecosystem.

--- a/packages/eslint-config-skuba/package.json
+++ b/packages/eslint-config-skuba/package.json
@@ -26,7 +26,7 @@
     "skuba": "node --experimental-vm-modules ../../lib/skuba"
   },
   "dependencies": {
-    "eslint-config-seek": "0.0.0-import-x-again-20250318050943",
+    "eslint-config-seek": "^14.3.2",
     "eslint-plugin-yml": "^1.14.0",
     "typescript-eslint": "^8.26.0"
   },

--- a/packages/eslint-config-skuba/package.json
+++ b/packages/eslint-config-skuba/package.json
@@ -26,7 +26,7 @@
     "skuba": "node --experimental-vm-modules ../../lib/skuba"
   },
   "dependencies": {
-    "eslint-config-seek": "^14.3.1",
+    "eslint-config-seek": "0.0.0-import-x-again-20250318050943",
     "eslint-plugin-yml": "^1.14.0",
     "typescript-eslint": "^8.26.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
       jest-watch-typeahead:
         specifier: ^2.1.1
-        version: 2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
+        version: 2.2.2(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
       lodash.mergewith:
         specifier: ^4.6.2
         version: 4.6.2
@@ -247,8 +247,8 @@ importers:
   packages/eslint-config-skuba:
     dependencies:
       eslint-config-seek:
-        specifier: 0.0.0-import-x-again-20250318050943
-        version: 0.0.0-import-x-again-20250318050943(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
+        specifier: ^14.3.2
+        version: 14.3.2(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       eslint-plugin-yml:
         specifier: ^1.14.0
         version: 1.17.0(eslint@9.21.0)
@@ -308,7 +308,7 @@ importers:
         version: 13.0.0
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
       supertest:
         specifier: ^7.0.0
         version: 7.0.0
@@ -324,7 +324,7 @@ importers:
         version: 22.13.10
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
 
   template/koa-rest-api:
     dependencies:
@@ -409,7 +409,7 @@ importers:
         version: 13.0.0
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
       supertest:
         specifier: ^7.0.0
         version: 7.0.0
@@ -479,7 +479,7 @@ importers:
         version: 13.0.0
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
 
 packages:
 
@@ -872,15 +872,6 @@ packages:
 
   '@datadog/sketches-js@2.1.1':
     resolution: {integrity: sha512-d5RjycE+MObE/hU+8OM5Zp4VjTwiPLRa8299fj7muOmR16fb942z8byoMbCErnGh0lBevvgkGrLclQDvINbIyg==}
-
-  '@emnapi/core@1.3.1':
-    resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
-
-  '@emnapi/runtime@1.3.1':
-    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
-
-  '@emnapi/wasi-threads@1.0.1':
-    resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
 
   '@esbuild-plugins/tsconfig-paths@0.1.2':
     resolution: {integrity: sha512-TusFR26Y+Ze+Zm+NdfqZTSG4XyrXKxIaAfYCL3jASEI/gHjSdoCujATjzNWaaXs6Sk6Bv2D7NLr4Jdz1gysy/Q==}
@@ -1442,9 +1433,6 @@ packages:
   '@microsoft/tsdoc@0.15.0':
     resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
 
-  '@napi-rs/wasm-runtime@0.2.7':
-    resolution: {integrity: sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw==}
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1788,61 +1776,6 @@ packages:
     resolution: {integrity: sha512-4VlGgo32k2EQ2wcCY3vEU28A0O13aOtHz3Xt2/2U5FAh9EfhD6t6DqL5Z6yAnRCntbTFDU4YfbpyzSlHNWycPw==}
     engines: {node: '>=14'}
 
-  '@oxc-resolver/binding-darwin-arm64@5.0.0':
-    resolution: {integrity: sha512-zwHAf+owoxSWTDD4dFuwW+FkpaDzbaL30H5Ltocb+RmLyg4WKuteusRLKh5Y8b/cyu7UzhxM0haIqQjyqA1iuA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@oxc-resolver/binding-darwin-x64@5.0.0':
-    resolution: {integrity: sha512-1lS3aBNVjVQKBvZdHm13+8tSjvu2Tl1Cv4FnUyMYxqx6+rsom2YaOylS5LhDUwfZu0zAgpLMwK6kGpF/UPncNg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@oxc-resolver/binding-freebsd-x64@5.0.0':
-    resolution: {integrity: sha512-q9sRd68wC1/AJ0eu6ClhxlklVfe8gH4wrUkSyEbIYTZ8zY5yjsLY3fpqqsaCvWJUx65nW+XtnAxCGCi5AXr1Mw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@oxc-resolver/binding-linux-arm-gnueabihf@5.0.0':
-    resolution: {integrity: sha512-catYavWsvqViYnCveQjhrK6yVYDEPFvIOgGLxnz5r2dcgrjpmquzREoyss0L2QG/J5HTTbwqwZ1kk+g56hE/1A==}
-    cpu: [arm]
-    os: [linux]
-
-  '@oxc-resolver/binding-linux-arm64-gnu@5.0.0':
-    resolution: {integrity: sha512-l/0pWoQM5kVmJLg4frQ1mKZOXgi0ex/hzvFt8E4WK2ifXr5JgKFUokxsb/oat7f5YzdJJh5r9p+qS/t3dA26Aw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-resolver/binding-linux-arm64-musl@5.0.0':
-    resolution: {integrity: sha512-bx0oz/oaAW4FGYqpIIxJCnmgb906YfMhTEWCJvYkxjpEI8VKLJEL3PQevYiqDq36SA0yRLJ/sQK2fqry8AFBfA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@oxc-resolver/binding-linux-x64-gnu@5.0.0':
-    resolution: {integrity: sha512-4PH++qbSIhlRsFYdN1P9neDov4OGhTGo5nbQ1D7AL6gWFLo3gdZTc00FM2y8JjeTcPWEXkViZuwpuc0w5i6qHg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-resolver/binding-linux-x64-musl@5.0.0':
-    resolution: {integrity: sha512-mLfQFpX3/5y9oWi0b+9FbWDkL2hM0Y29653beCHiHxAdGyVgb2DsJbK74WkMTwtSz9by8vyBh8jGPZcg1yLZbQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@oxc-resolver/binding-wasm32-wasi@5.0.0':
-    resolution: {integrity: sha512-uEhsAZSo65qsRi6+IfBTEUUFbjg7T2yruJeLYpFfEATpm3ory5Mgo5vx3L0c2/Cz1OUZXBgp3A8x6VMUB2jT2A==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@oxc-resolver/binding-win32-arm64-msvc@5.0.0':
-    resolution: {integrity: sha512-8DbSso9Jp1ns8AYuZFXdRfAcdJrzZwkFm/RjPuvAPTENsm685dosBF8G6gTHQlHvULnk6o3sa9ygZaTGC/UoEw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@oxc-resolver/binding-win32-x64-msvc@5.0.0':
-    resolution: {integrity: sha512-ylppfPEg63NuRXOPNsXFlgyl37JrtRn0QMO26X3K3Ytp5HtLrMreQMGVtgr30e1l2YmAWqhvmKlCryOqzGPD/g==}
-    cpu: [x64]
-    os: [win32]
-
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2161,9 +2094,6 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
-
-  '@tybys/wasm-util@0.9.0':
-    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
   '@types/accepts@1.3.7':
     resolution: {integrity: sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==}
@@ -3400,15 +3330,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-seek@0.0.0-import-x-again-20250318050943:
-    resolution: {integrity: sha512-jJiD+aGwPmxsaPUyLDSbAU4y+bj3GLDkLRItuPE5FdM2q0fUQWeuCRC3I+pQ5ZJsJUoV9dxZdwwbjG/mcVyPxg==}
-    engines: {node: '>=18.18.0'}
-    peerDependencies:
-      eslint: '>=9.9.1'
-      typescript: '>=5.5.4'
-
-  eslint-config-seek@14.3.1:
-    resolution: {integrity: sha512-pODdcvDPJcbLnaYMVsrGP5O0zcr3PCw94qh2iOzzsdOBmW+5ahATbpYz95axn8p2eRKLkrcAugAV4xkN3Invow==}
+  eslint-config-seek@14.3.2:
+    resolution: {integrity: sha512-7m/w3h9p2akxDm1oIEN0UfACp2GJ7KFxqVFexwEvAWG+0LyPCenuJ7x+d/HuDRKrbYyiJG7ilgKbnvls7uo5Tw==}
     engines: {node: '>=18.18.0'}
     peerDependencies:
       eslint: '>=9.9.1'
@@ -3444,12 +3367,6 @@ packages:
 
   eslint-plugin-import-x@4.6.1:
     resolution: {integrity: sha512-wluSUifMIb7UfwWXqx7Yx0lE/SGCcGXECLx/9bCmbY2nneLwvAZ4vkd1IXDjPKFvdcdUgr1BaRnaRpx3k2+Pfw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-
-  eslint-plugin-import-x@4.7.0:
-    resolution: {integrity: sha512-LHxq8V6SJ99hSFYAexxUKk3gVsjb8fuNRGsbMinwlJGvcuREP9SVzCCNKJ3POdDowEHdExy/bPN6YfjraueIXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -4874,10 +4791,6 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
-
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -5209,9 +5122,6 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
-
-  oxc-resolver@5.0.0:
-    resolution: {integrity: sha512-66fopyAqCN8Mx4tzNiBXWbk8asCSuxUWN62gwTc3yfRs7JfWhX/eVJCf+fUrfbNOdQVOWn+o8pAKllp76ysMXA==}
 
   p-each-series@3.0.0:
     resolution: {integrity: sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==}
@@ -6011,9 +5921,6 @@ packages:
 
   stable-hash@0.0.4:
     resolution: {integrity: sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==}
-
-  stable-hash@0.0.5:
-    resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -7515,22 +7422,6 @@ snapshots:
 
   '@datadog/sketches-js@2.1.1': {}
 
-  '@emnapi/core@1.3.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.0.1
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.3.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.0.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@esbuild-plugins/tsconfig-paths@0.1.2(esbuild@0.24.2)(typescript@5.6.3)':
     dependencies:
       debug: 4.4.0
@@ -8080,13 +7971,6 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.0': {}
 
-  '@napi-rs/wasm-runtime@0.2.7':
-    dependencies:
-      '@emnapi/core': 1.3.1
-      '@emnapi/runtime': 1.3.1
-      '@tybys/wasm-util': 0.9.0
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8561,41 +8445,6 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.30.0': {}
 
-  '@oxc-resolver/binding-darwin-arm64@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-darwin-x64@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-freebsd-x64@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-arm-gnueabihf@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-arm64-gnu@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-arm64-musl@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-x64-gnu@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-linux-x64-musl@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-wasm32-wasi@5.0.0':
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.7
-    optional: true
-
-  '@oxc-resolver/binding-win32-arm64-msvc@5.0.0':
-    optional: true
-
-  '@oxc-resolver/binding-win32-x64-msvc@5.0.0':
-    optional: true
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -9062,11 +8911,6 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
-
-  '@tybys/wasm-util@0.9.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@types/accepts@1.3.7':
     dependencies:
@@ -10163,21 +10007,6 @@ snapshots:
 
   crc-32@1.2.2: {}
 
-  create-jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
@@ -10634,7 +10463,7 @@ snapshots:
     dependencies:
       eslint: 9.21.0
 
-  eslint-config-seek@0.0.0-import-x-again-20250318050943(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
+  eslint-config-seek@14.3.2(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       eslint: 9.21.0
       eslint-config-prettier: 10.1.1(eslint@9.21.0)
@@ -10653,14 +10482,14 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-seek@14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+  eslint-config-seek@14.3.2(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
     dependencies:
       eslint: 9.21.0
       eslint-config-prettier: 10.1.1(eslint@9.21.0)
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)
       eslint-plugin-cypress: 4.1.0(eslint@9.21.0)
-      eslint-plugin-import-x: 4.7.0(eslint@9.21.0)(typescript@5.6.3)
-      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-plugin-import-x: 4.6.1(eslint@9.21.0)(typescript@5.6.3)
+      eslint-plugin-jest: 28.11.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
       eslint-plugin-react: 7.37.4(eslint@9.21.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.21.0)
       globals: 16.0.0
@@ -10672,43 +10501,10 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-seek@14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+  eslint-config-skuba@5.0.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
     dependencies:
       eslint: 9.21.0
-      eslint-config-prettier: 10.1.1(eslint@9.21.0)
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)
-      eslint-plugin-cypress: 4.1.0(eslint@9.21.0)
-      eslint-plugin-import-x: 4.7.0(eslint@9.21.0)(typescript@5.6.3)
-      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
-      eslint-plugin-react: 7.37.4(eslint@9.21.0)
-      eslint-plugin-react-hooks: 5.2.0(eslint@9.21.0)
-      globals: 16.0.0
-      typescript: 5.6.3
-      typescript-eslint: 8.26.0(eslint@9.21.0)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - '@typescript-eslint/eslint-plugin'
-      - eslint-plugin-import
-      - jest
-      - supports-color
-
-  eslint-config-skuba@5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
-    dependencies:
-      eslint: 9.21.0
-      eslint-config-seek: 14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
-      eslint-plugin-tsdoc: 0.3.0
-      eslint-plugin-yml: 1.17.0(eslint@9.21.0)
-      typescript: 5.6.3
-      typescript-eslint: 8.26.0(eslint@9.21.0)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - '@typescript-eslint/eslint-plugin'
-      - eslint-plugin-import
-      - jest
-      - supports-color
-
-  eslint-config-skuba@5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
-    dependencies:
-      eslint: 9.21.0
-      eslint-config-seek: 14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-config-seek: 14.3.2(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
       eslint-plugin-tsdoc: 0.3.0
       eslint-plugin-yml: 1.17.0(eslint@9.21.0)
       typescript: 5.6.3
@@ -10727,6 +10523,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.0
+      enhanced-resolve: 5.18.1
+      eslint: 9.21.0
+      get-tsconfig: 4.10.0
+      is-bun-module: 1.3.0
+      stable-hash: 0.0.4
+      tinyglobby: 0.2.12
+    optionalDependencies:
+      eslint-plugin-import-x: 4.6.1(eslint@9.21.0)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.8.3(eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -10742,25 +10553,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0
-      enhanced-resolve: 5.18.1
-      eslint: 9.21.0
-      get-tsconfig: 4.10.0
-      is-bun-module: 1.3.0
-      stable-hash: 0.0.4
-      tinyglobby: 0.2.12
-    optionalDependencies:
-      eslint-plugin-import-x: 4.7.0(eslint@9.21.0)(typescript@5.6.3)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-cypress@4.1.0(eslint@9.21.0):
     dependencies:
       eslint: 9.21.0
       globals: 15.15.0
+
+  eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.6.3):
+    dependencies:
+      '@types/doctrine': 0.0.9
+      '@typescript-eslint/scope-manager': 8.26.1
+      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
+      debug: 4.4.0
+      doctrine: 3.0.0
+      enhanced-resolve: 5.18.1
+      eslint: 9.21.0
+      eslint-import-resolver-node: 0.3.9
+      get-tsconfig: 4.10.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      stable-hash: 0.0.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.8.2):
     dependencies:
@@ -10782,53 +10598,22 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3):
-    dependencies:
-      '@types/doctrine': 0.0.9
-      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
-      debug: 4.4.0
-      doctrine: 3.0.0
-      eslint: 9.21.0
-      eslint-import-resolver-node: 0.3.9
-      get-tsconfig: 4.10.0
-      is-glob: 4.0.3
-      minimatch: 10.0.1
-      oxc-resolver: 5.0.0
-      semver: 7.7.1
-      stable-hash: 0.0.5
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
-      eslint: 9.21.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3)
-      jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
-      eslint: 9.21.0
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
-      jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.8.2)
       eslint: 9.21.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
+      jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-jest@28.11.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
+      eslint: 9.21.0
+    optionalDependencies:
       jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
     transitivePeerDependencies:
       - supports-color
@@ -11862,25 +11647,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
@@ -11899,37 +11665,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
-
-  jest-config@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
-    dependencies:
-      '@babel/core': 7.26.9
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.9)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.17.23
-      ts-node: 10.9.2(@types/node@22.13.10)(typescript@5.8.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
 
   jest-config@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
@@ -12159,7 +11894,7 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.4.1
@@ -12187,18 +11922,6 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-
-  jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
 
   jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
@@ -12740,10 +12463,6 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
-
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -13015,20 +12734,6 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
-
-  oxc-resolver@5.0.0:
-    optionalDependencies:
-      '@oxc-resolver/binding-darwin-arm64': 5.0.0
-      '@oxc-resolver/binding-darwin-x64': 5.0.0
-      '@oxc-resolver/binding-freebsd-x64': 5.0.0
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 5.0.0
-      '@oxc-resolver/binding-linux-arm64-gnu': 5.0.0
-      '@oxc-resolver/binding-linux-arm64-musl': 5.0.0
-      '@oxc-resolver/binding-linux-x64-gnu': 5.0.0
-      '@oxc-resolver/binding-linux-x64-musl': 5.0.0
-      '@oxc-resolver/binding-wasm32-wasi': 5.0.0
-      '@oxc-resolver/binding-win32-arm64-msvc': 5.0.0
-      '@oxc-resolver/binding-win32-x64-msvc': 5.0.0
 
   p-each-series@3.0.0: {}
 
@@ -13968,7 +13673,7 @@ snapshots:
     dependencies:
       module-alias: 2.2.3
 
-  skuba@9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0):
+  skuba@9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0):
     dependencies:
       '@esbuild-plugins/tsconfig-paths': 0.1.2(esbuild@0.24.2)(typescript@5.6.3)
       '@eslint/migrate-config': 1.3.8(eslint@9.21.0)
@@ -13986,7 +13691,7 @@ snapshots:
       enquirer: 2.4.1
       esbuild: 0.24.2
       eslint: 9.21.0
-      eslint-config-skuba: 5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-config-skuba: 5.0.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
       execa: 5.1.1
       fast-glob: 3.3.3
       find-up: 5.0.0
@@ -13998,75 +13703,7 @@ snapshots:
       is-installed-globally: 0.4.0
       isomorphic-git: 1.29.0
       jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
-      libnpmsearch: 8.0.0
-      lodash.mergewith: 4.6.2
-      minimist: 1.2.8
-      normalize-package-data: 7.0.0
-      npm-run-path: 4.0.1
-      npm-which: 3.0.1
-      picomatch: 4.0.2
-      prettier: 3.3.3
-      prettier-plugin-packagejson: 2.5.10(prettier@3.3.3)
-      read-pkg-up: 7.0.1
-      semantic-release: 22.0.12(typescript@5.6.3)
-      serialize-error: 8.1.0
-      simple-git: 3.27.0
-      ts-dedent: 2.2.0
-      ts-jest: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
-      ts-node: 10.9.2(@types/node@20.17.23)(typescript@5.6.3)
-      tsconfig-paths: 4.2.0
-      tsconfig-seek: 2.0.0
-      tsx: 4.19.3
-      typescript: 5.6.3
-      validate-npm-package-name: 6.0.0
-      zod: 3.24.2
-    optionalDependencies:
-      skuba-dive: 2.0.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@jest/transform'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@typescript-eslint/eslint-plugin'
-      - babel-jest
-      - babel-plugin-macros
-      - eslint-plugin-import
-      - jiti
-      - node-notifier
-      - supports-color
-
-  skuba@9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0):
-    dependencies:
-      '@esbuild-plugins/tsconfig-paths': 0.1.2(esbuild@0.24.2)(typescript@5.6.3)
-      '@eslint/migrate-config': 1.3.8(eslint@9.21.0)
-      '@jest/types': 29.6.3
-      '@octokit/graphql': 8.2.1
-      '@octokit/graphql-schema': 15.26.0
-      '@octokit/rest': 21.1.1
-      '@octokit/types': 13.8.0
-      '@types/jest': 29.5.14
-      '@types/node': 20.17.23
-      chalk: 4.1.2
-      concurrently: 9.1.2
-      dotenv: 16.4.7
-      ejs: 3.1.10
-      enquirer: 2.4.1
-      esbuild: 0.24.2
-      eslint: 9.21.0
-      eslint-config-skuba: 5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
-      execa: 5.1.1
-      fast-glob: 3.3.3
-      find-up: 5.0.0
-      fs-extra: 11.3.0
-      function-arguments: 1.0.9
-      get-port: 5.1.1
-      golden-fleece: 1.0.9
-      ignore: 5.3.2
-      is-installed-globally: 0.4.0
-      isomorphic-git: 1.29.0
-      jest: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
       libnpmsearch: 8.0.0
       lodash.mergewith: 4.6.2
       minimist: 1.2.8
@@ -14187,8 +13824,6 @@ snapshots:
       minipass: 7.1.2
 
   stable-hash@0.0.4: {}
-
-  stable-hash@0.0.5: {}
 
   stack-utils@2.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
       jest-watch-typeahead:
         specifier: ^2.1.1
-        version: 2.2.2(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
+        version: 2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
       lodash.mergewith:
         specifier: ^4.6.2
         version: 4.6.2
@@ -247,8 +247,8 @@ importers:
   packages/eslint-config-skuba:
     dependencies:
       eslint-config-seek:
-        specifier: ^14.3.1
-        version: 14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
+        specifier: 0.0.0-import-x-again-20250318050943
+        version: 0.0.0-import-x-again-20250318050943(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       eslint-plugin-yml:
         specifier: ^1.14.0
         version: 1.17.0(eslint@9.21.0)
@@ -308,7 +308,7 @@ importers:
         version: 13.0.0
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
       supertest:
         specifier: ^7.0.0
         version: 7.0.0
@@ -324,7 +324,7 @@ importers:
         version: 22.13.10
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
 
   template/koa-rest-api:
     dependencies:
@@ -409,7 +409,7 @@ importers:
         version: 13.0.0
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
       supertest:
         specifier: ^7.0.0
         version: 7.0.0
@@ -479,7 +479,7 @@ importers:
         version: 13.0.0
       skuba:
         specifier: '*'
-        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
+        version: 9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0)
 
 packages:
 
@@ -3400,6 +3400,13 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
+  eslint-config-seek@0.0.0-import-x-again-20250318050943:
+    resolution: {integrity: sha512-jJiD+aGwPmxsaPUyLDSbAU4y+bj3GLDkLRItuPE5FdM2q0fUQWeuCRC3I+pQ5ZJsJUoV9dxZdwwbjG/mcVyPxg==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      eslint: '>=9.9.1'
+      typescript: '>=5.5.4'
+
   eslint-config-seek@14.3.1:
     resolution: {integrity: sha512-pODdcvDPJcbLnaYMVsrGP5O0zcr3PCw94qh2iOzzsdOBmW+5ahATbpYz95axn8p2eRKLkrcAugAV4xkN3Invow==}
     engines: {node: '>=18.18.0'}
@@ -3434,6 +3441,12 @@ packages:
     resolution: {integrity: sha512-JhqkMY02mw74USwK9OFhectx3YSj6Co1NgWBxlGdKvlqiAp9vdEuQqt33DKGQFvvGS/NWtduuhWXWNnU29xDSg==}
     peerDependencies:
       eslint: '>=9'
+
+  eslint-plugin-import-x@4.6.1:
+    resolution: {integrity: sha512-wluSUifMIb7UfwWXqx7Yx0lE/SGCcGXECLx/9bCmbY2nneLwvAZ4vkd1IXDjPKFvdcdUgr1BaRnaRpx3k2+Pfw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
 
   eslint-plugin-import-x@4.7.0:
     resolution: {integrity: sha512-LHxq8V6SJ99hSFYAexxUKk3gVsjb8fuNRGsbMinwlJGvcuREP9SVzCCNKJ3POdDowEHdExy/bPN6YfjraueIXA==}
@@ -10150,6 +10163,21 @@ snapshots:
 
   crc-32@1.2.2: {}
 
+  create-jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
       '@jest/types': 29.6.3
@@ -10606,13 +10634,13 @@ snapshots:
     dependencies:
       eslint: 9.21.0
 
-  eslint-config-seek@14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
+  eslint-config-seek@0.0.0-import-x-again-20250318050943(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2):
     dependencies:
       eslint: 9.21.0
       eslint-config-prettier: 10.1.1(eslint@9.21.0)
-      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)
       eslint-plugin-cypress: 4.1.0(eslint@9.21.0)
-      eslint-plugin-import-x: 4.7.0(eslint@9.21.0)(typescript@5.8.2)
+      eslint-plugin-import-x: 4.6.1(eslint@9.21.0)(typescript@5.8.2)
       eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.8.2)
       eslint-plugin-react: 7.37.4(eslint@9.21.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.21.0)
@@ -10625,14 +10653,14 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-seek@14.3.1(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+  eslint-config-seek@14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
     dependencies:
       eslint: 9.21.0
       eslint-config-prettier: 10.1.1(eslint@9.21.0)
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)
       eslint-plugin-cypress: 4.1.0(eslint@9.21.0)
       eslint-plugin-import-x: 4.7.0(eslint@9.21.0)(typescript@5.6.3)
-      eslint-plugin-jest: 28.11.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
       eslint-plugin-react: 7.37.4(eslint@9.21.0)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.21.0)
       globals: 16.0.0
@@ -10644,10 +10672,43 @@ snapshots:
       - jest
       - supports-color
 
-  eslint-config-skuba@5.0.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+  eslint-config-seek@14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
     dependencies:
       eslint: 9.21.0
-      eslint-config-seek: 14.3.1(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-config-prettier: 10.1.1(eslint@9.21.0)
+      eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)
+      eslint-plugin-cypress: 4.1.0(eslint@9.21.0)
+      eslint-plugin-import-x: 4.7.0(eslint@9.21.0)(typescript@5.6.3)
+      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-plugin-react: 7.37.4(eslint@9.21.0)
+      eslint-plugin-react-hooks: 5.2.0(eslint@9.21.0)
+      globals: 16.0.0
+      typescript: 5.6.3
+      typescript-eslint: 8.26.0(eslint@9.21.0)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - '@typescript-eslint/eslint-plugin'
+      - eslint-plugin-import
+      - jest
+      - supports-color
+
+  eslint-config-skuba@5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+    dependencies:
+      eslint: 9.21.0
+      eslint-config-seek: 14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-plugin-tsdoc: 0.3.0
+      eslint-plugin-yml: 1.17.0(eslint@9.21.0)
+      typescript: 5.6.3
+      typescript-eslint: 8.26.0(eslint@9.21.0)(typescript@5.6.3)
+    transitivePeerDependencies:
+      - '@typescript-eslint/eslint-plugin'
+      - eslint-plugin-import
+      - jest
+      - supports-color
+
+  eslint-config-skuba@5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+    dependencies:
+      eslint: 9.21.0
+      eslint-config-seek: 14.3.1(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
       eslint-plugin-tsdoc: 0.3.0
       eslint-plugin-yml: 1.17.0(eslint@9.21.0)
       typescript: 5.6.3
@@ -10666,6 +10727,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.0
+      enhanced-resolve: 5.18.1
+      eslint: 9.21.0
+      get-tsconfig: 4.10.0
+      is-bun-module: 1.3.0
+      stable-hash: 0.0.4
+      tinyglobby: 0.2.12
+    optionalDependencies:
+      eslint-plugin-import-x: 4.6.1(eslint@9.21.0)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -10681,25 +10757,30 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.8.3(eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0
-      enhanced-resolve: 5.18.1
-      eslint: 9.21.0
-      get-tsconfig: 4.10.0
-      is-bun-module: 1.3.0
-      stable-hash: 0.0.4
-      tinyglobby: 0.2.12
-    optionalDependencies:
-      eslint-plugin-import-x: 4.7.0(eslint@9.21.0)(typescript@5.8.2)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-plugin-cypress@4.1.0(eslint@9.21.0):
     dependencies:
       eslint: 9.21.0
       globals: 15.15.0
+
+  eslint-plugin-import-x@4.6.1(eslint@9.21.0)(typescript@5.8.2):
+    dependencies:
+      '@types/doctrine': 0.0.9
+      '@typescript-eslint/scope-manager': 8.26.1
+      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.8.2)
+      debug: 4.4.0
+      doctrine: 3.0.0
+      enhanced-resolve: 5.18.1
+      eslint: 9.21.0
+      eslint-import-resolver-node: 0.3.9
+      get-tsconfig: 4.10.0
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.7.1
+      stable-hash: 0.0.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.6.3):
     dependencies:
@@ -10720,21 +10801,24 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import-x@4.7.0(eslint@9.21.0)(typescript@5.8.2):
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
     dependencies:
-      '@types/doctrine': 0.0.9
-      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.8.2)
-      debug: 4.4.0
-      doctrine: 3.0.0
+      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
       eslint: 9.21.0
-      eslint-import-resolver-node: 0.3.9
-      get-tsconfig: 4.10.0
-      is-glob: 4.0.3
-      minimatch: 10.0.1
-      oxc-resolver: 5.0.0
-      semver: 7.7.1
-      stable-hash: 0.0.5
-      tslib: 2.8.1
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3)
+      jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
+      eslint: 9.21.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
+      jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10745,16 +10829,6 @@ snapshots:
       eslint: 9.21.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2)
-      jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  eslint-plugin-jest@28.11.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.26.1(eslint@9.21.0)(typescript@5.6.3)
-      eslint: 9.21.0
-    optionalDependencies:
       jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
     transitivePeerDependencies:
       - supports-color
@@ -11788,6 +11862,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
       '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
@@ -11806,6 +11899,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
+    dependencies:
+      '@babel/core': 7.26.9
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.9)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.17.23
+      ts-node: 10.9.2(@types/node@22.13.10)(typescript@5.8.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
@@ -12035,7 +12159,7 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.4.1
@@ -12063,6 +12187,18 @@ snapshots:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)):
     dependencies:
@@ -13832,7 +13968,7 @@ snapshots:
     dependencies:
       module-alias: 2.2.3
 
-  skuba@9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0):
+  skuba@9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0):
     dependencies:
       '@esbuild-plugins/tsconfig-paths': 0.1.2(esbuild@0.24.2)(typescript@5.6.3)
       '@eslint/migrate-config': 1.3.8(eslint@9.21.0)
@@ -13850,7 +13986,7 @@ snapshots:
       enquirer: 2.4.1
       esbuild: 0.24.2
       eslint: 9.21.0
-      eslint-config-skuba: 5.0.0(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      eslint-config-skuba: 5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(typescript@5.6.3))(eslint@9.21.0)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
       execa: 5.1.1
       fast-glob: 3.3.3
       find-up: 5.0.0
@@ -13862,7 +13998,75 @@ snapshots:
       is-installed-globally: 0.4.0
       isomorphic-git: 1.29.0
       jest: 29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
+      libnpmsearch: 8.0.0
+      lodash.mergewith: 4.6.2
+      minimist: 1.2.8
+      normalize-package-data: 7.0.0
+      npm-run-path: 4.0.1
+      npm-which: 3.0.1
+      picomatch: 4.0.2
+      prettier: 3.3.3
+      prettier-plugin-packagejson: 2.5.10(prettier@3.3.3)
+      read-pkg-up: 7.0.1
+      semantic-release: 22.0.12(typescript@5.6.3)
+      serialize-error: 8.1.0
+      simple-git: 3.27.0
+      ts-dedent: 2.2.0
+      ts-jest: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      ts-node: 10.9.2(@types/node@20.17.23)(typescript@5.6.3)
+      tsconfig-paths: 4.2.0
+      tsconfig-seek: 2.0.0
+      tsx: 4.19.3
+      typescript: 5.6.3
+      validate-npm-package-name: 6.0.0
+      zod: 3.24.2
+    optionalDependencies:
+      skuba-dive: 2.0.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@jest/transform'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@typescript-eslint/eslint-plugin'
+      - babel-jest
+      - babel-plugin-macros
+      - eslint-plugin-import
+      - jiti
+      - node-notifier
+      - supports-color
+
+  skuba@9.1.0(@babel/core@7.26.9)(@jest/transform@29.7.0)(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(babel-jest@29.7.0(@babel/core@7.26.9))(skuba-dive@2.0.0):
+    dependencies:
+      '@esbuild-plugins/tsconfig-paths': 0.1.2(esbuild@0.24.2)(typescript@5.6.3)
+      '@eslint/migrate-config': 1.3.8(eslint@9.21.0)
+      '@jest/types': 29.6.3
+      '@octokit/graphql': 8.2.1
+      '@octokit/graphql-schema': 15.26.0
+      '@octokit/rest': 21.1.1
+      '@octokit/types': 13.8.0
+      '@types/jest': 29.5.14
+      '@types/node': 20.17.23
+      chalk: 4.1.2
+      concurrently: 9.1.2
+      dotenv: 16.4.7
+      ejs: 3.1.10
+      enquirer: 2.4.1
+      esbuild: 0.24.2
+      eslint: 9.21.0
+      eslint-config-skuba: 5.0.0(@typescript-eslint/eslint-plugin@8.26.0(@typescript-eslint/parser@8.26.0(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(typescript@5.8.2))(eslint@9.21.0)(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))(typescript@5.6.3)
+      execa: 5.1.1
+      fast-glob: 3.3.3
+      find-up: 5.0.0
+      fs-extra: 11.3.0
+      function-arguments: 1.0.9
+      get-port: 5.1.1
+      golden-fleece: 1.0.9
+      ignore: 5.3.2
+      is-installed-globally: 0.4.0
+      isomorphic-git: 1.29.0
+      jest: 29.7.0(@types/node@20.17.23)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@22.13.10)(ts-node@10.9.2(@types/node@22.13.10)(typescript@5.8.2)))
       libnpmsearch: 8.0.0
       lodash.mergewith: 4.6.2
       minimist: 1.2.8


### PR DESCRIPTION
This should make skuba upgrades be seamless, hopefully.