### PR TITLE
Mention CODEOWNERS in pnpm migration doc

### DIFF
--- a/docs/deep-dives/pnpm.md
+++ b/docs/deep-dives/pnpm.md
@@ -328,6 +328,13 @@ This migration guide assumes that your project was scaffolded with a **skuba** t
 
 14. Search for other references to `yarn` in your project. Replace these with `pnpm` where necessary.
 
+    For example, you may have the lockfile listed in `.github/CODEOWNERS`:
+
+    ```diff
+    - yarn.lock
+    + pnpm-lock.yaml
+    ```
+
 ## FAQ
 
 **Q:** I'm running into `ERR_PNPM_CANNOT_DEPLOY  A deploy is only possible from inside a workspace`


### PR DESCRIPTION
This has been missed a few times. I'm hoping that having the keyword in here serves as a sufficient reminder.