### PR TITLE
Fix Node16 module compatibility

### DIFF
--- a/.changeset/common-corners-fall.md
+++ b/.changeset/common-corners-fall.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-lint,test: Fix `Node16` module resolution compatibility
+lint, test: Fix `Node16` module resolution compatibility

--- a/.changeset/common-corners-fall.md
+++ b/.changeset/common-corners-fall.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+GitHub: Fix Node16 moduleResolution type compatibility

--- a/.changeset/common-corners-fall.md
+++ b/.changeset/common-corners-fall.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-GitHub: Fix Node16 moduleResolution type compatibility
+GitHub: Fix `Node16` module resolution type compatibility

--- a/.changeset/common-corners-fall.md
+++ b/.changeset/common-corners-fall.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-GitHub: Fix `Node16` module resolution type compatibility
+lint,test: Fix `Node16` module resolution compatibility

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -19,7 +19,6 @@ const isolatedModules = maybeTsConfig?.options.isolatedModules ?? true;
 
 const BROKEN_MODULE_RESOLUTIONS = new Set([
   ModuleResolutionKind.Bundler,
-  ModuleResolutionKind.Node16,
   ModuleResolutionKind.NodeNext,
 ]);
 

--- a/src/api/github/pullRequest.ts
+++ b/src/api/github/pullRequest.ts
@@ -1,4 +1,4 @@
-import type { Octokit } from '@octokit/rest';
+import type { Octokit } from '@octokit/rest' with { 'resolution-mode': 'import' };
 
 import * as Git from '../git';
 


### PR DESCRIPTION
Looks like when you do a lock file maintenance on the Octokit deps the type issues you see in other repos disappear as they properly added `type: 'module'` to their package jsons.

This one is the only thing that complains in my project.

```bash
node_modules/.pnpm/skuba@11.0.0_@babel+core@7.27.1_@jest+transform@29.7.0_@swc+core@1.11.29_@typescript-es_d151c735ea38d56f044e010092928178/node_modules/skuba/lib/api/github/pullRequest.d.ts(1,30): error TS1541: Type-only import of an ECMAScript module from a CommonJS module must have a 'resolution-mode' attribute.
```