### PR TITLE
Nested repo support for auto commits

### DIFF
--- a/.changeset/soft-clocks-marry.md
+++ b/.changeset/soft-clocks-marry.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+GitHub.readFileChanges, GitHub.uploadFileChanges: Allowing reading files from directories which are not the git root

--- a/src/api/git/getChangedFiles.ts
+++ b/src/api/git/getChangedFiles.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import git from 'isomorphic-git';
+import git, { findRoot } from 'isomorphic-git';
 
 import {
   ABSENT,
@@ -50,7 +50,8 @@ export const getChangedFiles = async ({
 
   ignore = [],
 }: ChangedFilesParameters): Promise<ChangedFile[]> => {
-  const allFiles = await git.statusMatrix({ fs, dir });
+  const gitRoot = await findRoot({ fs, filepath: dir });
+  const allFiles = await git.statusMatrix({ fs, dir: gitRoot || dir });
   return allFiles
     .filter(
       (row) =>

--- a/src/api/github/push.test.ts
+++ b/src/api/github/push.test.ts
@@ -168,12 +168,18 @@ describe('readFileChanges', () => {
       deletions: [{ path: 'packages/package/delete-path' }],
     };
 
-    expect(fs.promises.readFile).toHaveBeenCalledWith('some-path', {
-      encoding: 'base64',
-    });
-    expect(fs.promises.readFile).toHaveBeenCalledWith('another-path', {
-      encoding: 'base64',
-    });
+    expect(fs.promises.readFile).toHaveBeenCalledWith(
+      '/path/to/repo/packages/package/some-path',
+      {
+        encoding: 'base64',
+      },
+    );
+    expect(fs.promises.readFile).toHaveBeenCalledWith(
+      '/path/to/repo/packages/package/another-path',
+      {
+        encoding: 'base64',
+      },
+    );
     expect(result).toStrictEqual(expectedFileChanges);
   });
 });

--- a/src/api/github/push.test.ts
+++ b/src/api/github/push.test.ts
@@ -155,9 +155,9 @@ describe('readFileChanges', () => {
     jest.mocked(fs.promises.readFile).mockResolvedValue('base64-contents');
 
     const result = await readFileChanges('/path/to/repo/packages/package', [
-      { path: 'some-path', state: 'added' },
-      { path: 'another-path', state: 'modified' },
-      { path: 'delete-path', state: 'deleted' },
+      { path: 'packages/package/some-path', state: 'added' },
+      { path: 'packages/package/another-path', state: 'modified' },
+      { path: 'packages/package/delete-path', state: 'deleted' },
     ]);
 
     const expectedFileChanges: FileChanges = {

--- a/src/api/github/push.ts
+++ b/src/api/github/push.ts
@@ -140,29 +140,17 @@ export const readFileChanges = async (
 
   const gitRoot = await Git.findRoot({ dir });
 
-  const toGitHubPath = (filePath: string) => {
-    if (!gitRoot) {
-      return filePath;
-    }
-
-    const pathDir = path.relative(gitRoot, dir);
-
-    return path.join(pathDir, filePath);
-  };
-
   const toRootPath = (filePath: string) => {
     if (!gitRoot) {
       return filePath;
     }
 
-    const pathDir = path.resolve(gitRoot, dir);
-
-    return path.join(pathDir, filePath);
+    return path.resolve(gitRoot, filePath);
   };
 
   const additions: FileAddition[] = await Promise.all(
     added.map(async (filePath) => ({
-      path: toGitHubPath(filePath),
+      path: filePath,
       contents: await fs.promises.readFile(toRootPath(filePath), {
         encoding: 'base64',
       }),
@@ -170,7 +158,7 @@ export const readFileChanges = async (
   );
 
   const deletions: FileDeletion[] = deleted.map((filePath) => ({
-    path: toGitHubPath(filePath),
+    path: filePath,
   }));
 
   return {

--- a/src/api/github/push.ts
+++ b/src/api/github/push.ts
@@ -150,10 +150,20 @@ export const readFileChanges = async (
     return path.join(pathDir, filePath);
   };
 
+  const toRootPath = (filePath: string) => {
+    if (!gitRoot) {
+      return filePath;
+    }
+
+    const pathDir = path.resolve(gitRoot, dir);
+
+    return path.join(pathDir, filePath);
+  };
+
   const additions: FileAddition[] = await Promise.all(
     added.map(async (filePath) => ({
       path: toGitHubPath(filePath),
-      contents: await fs.promises.readFile(filePath, {
+      contents: await fs.promises.readFile(toRootPath(filePath), {
         encoding: 'base64',
       }),
     })),


### PR DESCRIPTION
Ran into a problem on HPP, the main cause is `getChangedFiles` is treating every file as [added](https://buildkite.com/seek/indie-hirer-posting-preferences-api/builds/3078#0196f13d-588a-4f06-bae0-09ef479cde3b/340-349) because `WORKDIR` is different from the previous commit

Adding support for pnpm workspace monorepo, main changes:

- `getChangedFiles` checks for files changed from the root path 
- `getChangedFiles` now returns absolute path
- `fs.promises.readFile` reads the absolute instead of the relative path


<details>
<summary>See problem breakdown</summary>

see isomorphic-git `StatusMatrix` [example](https://isomorphic-git.org/docs/en/statusMatrix.html#:~:text=The%20result%20is,of%20the%20entry.), to find that files that unmodified files look like the following with `WORKDIR=1`

```
["d.txt", 1, 1, 1], // unmodified
```

because we were running this from within pnpm workspace `apps/api`, it's detecting a change in `WORKDIR=2` for every single file 🫠 
```
row [ 'apps/api/src/storage/postingPreferences/ruleset.ts', 0,2,0 ]
```
</details>


tested [snapshot](https://buildkite.com/seek/indie-hirer-posting-preferences-api/builds/3156#0196fb6b-b433-4c4f-8426-993219712a19) in HPP


