### PR TITLE
RFC: use the currently used package manager from init

### DIFF
--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -91,7 +91,7 @@ export const init = async (args = process.argv.slice(2)) => {
 
   const [manifest, packageManagerConfig] = await Promise.all([
     getConsumerManifest(destinationDir),
-    detectPackageManager(destinationDir),
+    packageManagerFromUserAgent(process.env.npm_config_user_agent),
   ]);
 
   if (!manifest) {

--- a/src/utils/packageManager.ts
+++ b/src/utils/packageManager.ts
@@ -36,6 +36,16 @@ export const configForPackageManager = (
   command: packageManager,
 });
 
+export const packageManagerFromUserAgent = (userAgent: string | undefined) => {
+  if (!userAgent) return undefined
+  const pkgSpec = userAgent.split(' ')[0]
+  const pkgSpecArr = pkgSpec.split('/')
+  return {
+    name: pkgSpecArr[0],
+    version: pkgSpecArr[1],
+  }
+}
+
 export const detectPackageManager = async (
   cwd?: string,
 ): Promise<PackageManagerConfig> => {


### PR DESCRIPTION
It seems strange to use `detectPackageManager` which uses find-up to find the closest lock file as it means you could end up with the "wrong" manager during fresh installs.

We can detect the package manager from the user agent. For example, if they use `pnpm dlx skuba init`, it'll extract the pnpm user agent.

One edge case is monorepos, this would use the _current_ package manager which might differ from the monorepo package manager... But that should be okay?