### PR TITLE
Fix migrate node bug

### DIFF
--- a/.changeset/fast-regions-arrive.md
+++ b/.changeset/fast-regions-arrive.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+migrate: Fix a bug which was resulting in some missed changes in `skuba migrate`

--- a/src/cli/migrate/nodeVersion/index.ts
+++ b/src/cli/migrate/nodeVersion/index.ts
@@ -18,7 +18,7 @@ type FileSelector =
 
 type SubPatch = FileSelector & {
   tests?: Array<(path: string) => Promise<boolean>>;
-  regex?: RegExp;
+  regex?: () => RegExp;
   replace: string;
 };
 
@@ -30,56 +30,56 @@ const subPatches = ({
   {
     files: '**/Dockerfile*',
 
-    regex:
+    regex: () =>
       /^FROM(.*) (public.ecr.aws\/docker\/library\/)?node:([0-9]+(?:\.[0-9]+(?:\.[0-9]+)?)?)(-[a-z0-9]+)?(@sha256:[a-f0-9]{64})?( .*)?$/gm,
     replace: `FROM$1 $2node:${nodeVersion}$4$6`,
   },
   {
     files: '**/Dockerfile*',
-    regex:
+    regex: () =>
       /^FROM(.*) gcr.io\/distroless\/nodejs\d+-debian(\d+)(@sha256:[a-f0-9]{64})?(\.[^- \n]+)?(-[^ \n]+)?( .+|)$/gm,
     replace: `FROM$1 gcr.io/distroless/nodejs${nodeVersion}-debian$2$4$5$6`,
   },
 
   {
     files: '**/serverless*.y*ml',
-    regex: /\bnodejs\d+.x\b/gm,
+    regex: () => /\bnodejs\d+.x\b/gm,
     tests: [isPatchableServerlessVersion],
     replace: `nodejs${nodeVersion}.x`,
   },
   {
     files: '**/serverless*.y*ml',
-    regex: /\bnode\d+\b/gm,
+    regex: () => /\bnode\d+\b/gm,
     tests: [isPatchableServerlessVersion],
     replace: `node${nodeVersion}`,
   },
 
   {
     files: '**/infra/**/*.ts',
-    regex: /NODEJS_\d+_X/g,
+    regex: () => /NODEJS_\d+_X/g,
     replace: `NODEJS_${nodeVersion}_X`,
   },
   {
     files: '**/infra/**/*.ts',
-    regex: /(target:\s*'node)(\d+)(.+)$/gm,
+    regex: () => /(target:\s*'node)(\d+)(.+)$/gm,
     replace: `$1${nodeVersion}$3`,
   },
 
   {
     files: '**/.buildkite/*',
-    regex:
+    regex: () =>
       /(image: )(public.ecr.aws\/docker\/library\/)?(node:)[0-9.]+(\.[^- \n]+)?(-[^ \n]+)?$/gm,
     replace: `$1$2$3${nodeVersion}$5`,
   },
   {
     files: '.node-version*',
-    regex: /(\d+(?:\.\d+)*)/g,
+    regex: () => /(\d+(?:\.\d+)*)/g,
     replace: `${nodeVersion}`,
   },
 
   {
     files: '**/package.json',
-    regex:
+    regex: () =>
       /(["']engines["']:\s*{[\s\S]*?["']node["']:\s*["']>=)(\d+(?:\.\d+)*)(['"]\s*})/gm,
     tests: [isPatchableServerlessVersion, isPatchableSkubaType],
     replace: `$1${nodeVersion}$3`,
@@ -87,20 +87,20 @@ const subPatches = ({
 
   {
     files: '**/tsconfig*.json',
-    regex: /("target":\s*")(ES\d+)"/gim,
+    regex: () => /("target":\s*")(ES\d+)"/gim,
     tests: [isPatchableServerlessVersion, isPatchableSkubaType],
     replace: `$1${ECMAScriptVersion}"`,
   },
   {
     files: '**/tsconfig*.json',
-    regex: /("lib":\s*\[)([\S\s]*?)(ES\d+)([\S\s]*?)(\])/gim,
+    regex: () => /("lib":\s*\[)([\S\s]*?)(ES\d+)([\S\s]*?)(\])/gim,
     tests: [isPatchableServerlessVersion, isPatchableSkubaType],
     replace: `$1$2${ECMAScriptVersion}$4$5`,
   },
 
   {
     files: '**/docker-compose*.y*ml',
-    regex:
+    regex: () =>
       /(image: )(public.ecr.aws\/docker\/library\/)?(node:)[0-9.]+(\.[^- \n]+)?(-[^ \n]+)?$/gm,
 
     replace: `$1$2$3${nodeVersion}$5`,
@@ -128,7 +128,7 @@ const runSubPatch = async (dir: string, patch: SubPatch) => {
         return;
       }
 
-      if (patch.regex && !patch.regex.test(contents)) {
+      if (patch.regex && !patch.regex().test(contents)) {
         return;
       }
 
@@ -160,11 +160,11 @@ const writePatchedContents = async ({
   path: string;
   contents: string;
   templated: string;
-  regex?: RegExp;
+  regex?: () => RegExp;
 }) =>
   await fs.promises.writeFile(
     path,
-    regex ? contents.replaceAll(regex, templated) : templated,
+    regex ? contents.replaceAll(regex(), templated) : templated,
   );
 
 const upgrade = async (versions: Versions, dir: string) => {


### PR DESCRIPTION
In some repos with many files that need replacing and/or testing, the mutability of RegExp objects (TIL, thanks @kjots) was causing some changes to fail in the .test, or miss changes in the .replaceAll.

> JavaScript [RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) objects are stateful when they have the [global](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global) or [sticky](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky) flags set (e.g., /foo/g or /foo/y). They store a [lastIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) from the previous match. Using this internally, test() can be used to iterate over multiple matches in a string of text (with capture groups).

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test