### PR TITLE
Add dynamic import handling to ESLint rule

### DIFF
--- a/packages/eslint-config-skuba/requireExtensions.js
+++ b/packages/eslint-config-skuba/requireExtensions.js
@@ -9,7 +9,7 @@ function createRuleListener(context, check) {
     ExportAllDeclaration: (node) => processNode(node, context, check),
     ExportNamedDeclaration: (node) => processNode(node, context, check),
     ImportDeclaration: (node) => processNode(node, context, check),
-    ImportExpression: (node) => processDynamicImport(node, context, check),
+    ImportExpression: (node) => processNode(node, context, check),
   };
 }
 
@@ -18,28 +18,12 @@ function processNode(node, context, check) {
   if (!source) {
     return;
   }
-  const value = source.value.replace(/\?.*$/, '');
-  if (!value || value.endsWith('.js')) {
+
+  // For dynamic imports, ensure the source is a literal
+  if (node.type === 'ImportExpression' && source.type !== 'Literal') {
     return;
   }
 
-  if (value.startsWith('.')) {
-    // Relative import, check if it ends with .js
-    return check(context, node, resolve(dirname(context.getFilename()), value));
-  }
-
-  if (value.startsWith('src')) {
-    const file = dirname(context.getFilename());
-    const leadingPathToSrc = file.split('/src/')[0];
-    return check(context, node, join(leadingPathToSrc, value));
-  }
-}
-
-function processDynamicImport(node, context, check) {
-  const source = node.source;
-  if (!source || source.type !== 'Literal') {
-    return;
-  }
   const value = source.value.replace(/\?.*$/, '');
   if (!value || value.endsWith('.js')) {
     return;

--- a/packages/eslint-config-skuba/requireExtensions.test.ts
+++ b/packages/eslint-config-skuba/requireExtensions.test.ts
@@ -18,3 +18,20 @@ import { test as validSrcTest } from 'src/file.js';
 
 // eslint-disable-next-line require-extensions/require-extensions, require-extensions/require-index
 import { test as bothTest } from './test/both';
+
+const asyncFunction = async () => {
+  // eslint-disable-next-line require-extensions/require-extensions
+  const dynamicImportTest = await import('./test/simple');
+  const validDynamicImportTest = await import('./test/simple.js');
+
+  // eslint-disable-next-line require-extensions/require-index
+  const indexFileDynamicImportTest = await import('./test/indexFile');
+  const validIndexFileDynamicImportTest = await import('./test/indexFile/index.js');
+
+  // eslint-disable-next-line require-extensions/require-extensions
+  const srcDynamicImportTest = await import('src/file');
+  const validSrcDynamicImportTest = await import('src/file.js');
+
+  // eslint-disable-next-line require-extensions/require-extensions, require-extensions/require-index
+  const bothDynamicImportTest = await import('./test/both');
+}


### PR DESCRIPTION
Was doing some testing and it looks like dynamic imports also need extensions. Once again will keep testing this through snapshots on a bunch of repos