### PR TITLE
Prevent Jest config and setup files from being linted

### DIFF
--- a/.changeset/eighty-kids-prove.md
+++ b/.changeset/eighty-kids-prove.md
@@ -1,0 +1,6 @@
+---
+'eslint-config-skuba': patch
+'skuba': patch
+---
+
+lint: Prevent Jest config and setup files from being linted with extensions

--- a/packages/eslint-config-skuba/index.js
+++ b/packages/eslint-config-skuba/index.js
@@ -11,6 +11,11 @@ module.exports = [
   ...requireExtensionsPlugin.configs.recommended.map((config) => ({
     ...config,
     files: [`**/*.{${tsExtensions}}`],
+    ignores: [
+      // Jest configuration files
+      '**/jest.config*',
+      '**/jest.setup*',
+    ],
   })),
   {
     name: 'skuba/ignores',

--- a/packages/eslint-config-skuba/requireExtensions.js
+++ b/packages/eslint-config-skuba/requireExtensions.js
@@ -195,7 +195,9 @@ const requireExtensionsPlugin = {
               fix(fixer) {
                 return fixer.replaceText(
                   node.source,
-                  `'${node.source.value}/index.js'`,
+                  node.source.value.endsWith('/')
+                    ? `'${node.source.value}index.js'`
+                    : `'${node.source.value}/index.js'`,
                 );
               },
             });

--- a/packages/eslint-config-skuba/requireExtensions.test.ts
+++ b/packages/eslint-config-skuba/requireExtensions.test.ts
@@ -12,6 +12,10 @@ import { test as validSimpleTest } from './src/simple.js';
 import { test as indexFileTest } from './src/indexFile';
 import { test as validIndexFileTest } from './src/indexFile/index.js';
 
+// eslint-disable-next-line require-extensions/require-index
+import { test as indexFileTest2 } from './src/indexFile/';
+import { test as validIndexFileTest2 } from './src/indexFile/index.js';
+
 // eslint-disable-next-line require-extensions/require-extensions
 import { test as srcTest } from './src/file';
 import { test as validSrcTest } from './src/file.js';

--- a/packages/eslint-config-skuba/src/index.ts
+++ b/packages/eslint-config-skuba/src/index.ts
@@ -1,0 +1,1 @@
+export const test = 'test';


### PR DESCRIPTION
Unfortunately Jest's TypeScript processor doesn't use modern standards and can't read TypeScript files with `.js` extensions 🙄. So any `.js` extension it encounters will cause an error.

This change won't stop cases where someone may import another TypeScript file which is using extensions but should prevent a decent majority of cases.

See: https://github.com/SEEK-Jobs/indie-graphql-server/pull/3325/commits/40fdf8a5f150a98e9fe6edd1adf7b2692e18f6f7 as an example.
