### PR TITLE
Increase our own `prConcurrentLimit`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -115,7 +115,7 @@
   commitMessageAction: '',
   gitIgnoredAuthors: ['34733141+seek-oss-ci@users.noreply.github.com'],
   postUpdateOptions: [],
-  prConcurrentLimit: 3,
+  prConcurrentLimit: 6,
   prNotPendingHours: 1,
   rangeStrategy: 'replace',
   schedule: 'after 3:00 am and before 6:00 am every weekday',


### PR DESCRIPTION
Looks like we're falling behind here because we have a couple parked Renovates hogging our concurrent limit. I am hoping to work on those soon™️ but I anticipate this will recur at various points.