### PR TITLE
Fix flakey tests

### DIFF
--- a/template/lambda-sqs-worker-cdk/src/framework/handler.test.ts
+++ b/template/lambda-sqs-worker-cdk/src/framework/handler.test.ts
@@ -12,10 +12,10 @@ describe('createHandler', () => {
     Records: [],
   };
 
-  beforeEach(stdoutMock.clear);
+  afterEach(stdoutMock.clear);
 
   it('handles happy path', async () => {
-    const output = chance.paragraph();
+    const output = chance.sentence();
 
     const handler = createHandler((event) => {
       expect(event).toBe(input);


### PR DESCRIPTION
Paragraph was sometimes creating paragraph's too large so it was getting truncated by our logger. See: https://github.com/seek-oss/skuba/actions/runs/16665133351/job/47169798967?pr=1976

Changed beforeEach to afterEach for consistency with the other files

