### PR TITLE
Handle `/index` and `.ts` logging imports

### DIFF
--- a/src/cli/lint/internalLints/upgrade/patches/12.0.2/unhandledRejections.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/12.0.2/unhandledRejections.ts
@@ -39,7 +39,7 @@ const tryReadFilesSequentially = async (
 };
 
 export const IMPORT_REGEX =
-  /import\s+(?:\{\s*(\w*[Ll]ogger)(?:\s+as\s+(\w*[Ll]ogger))?\s*\}|(\w*[Ll]ogger))\s+from\s+['"][^'"]+\/(?:logger|logging)(?:\.js)?['"]/u;
+  /import\s+(?:\{\s*(\w*[Ll]ogger)(?:\s+as\s+(\w*[Ll]ogger))?\s*\}|(\w*[Ll]ogger))\s+from\s+['"][^'"]+\/(?:logger|logging)(?:\/index)?(?:\.[jt]s)?['"]/u;
 
 export const NAMED_EXPORT_REGEX =
   /export\s+(?:const\s+|\{[^{}]*)\b(\w*[Ll]ogger)\b/u;


### PR DESCRIPTION
NBD but https://github.com/search?q=org%3ASEEK-Jobs%20path%3A**%2Flogging%2Findex.ts&type=code