### PR TITLE
Bump max concurrency

### DIFF
--- a/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
+++ b/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
@@ -222,7 +222,7 @@ exports[`returns expected CloudFormation stack for dev 1`] = `
             ],
           },
         ],
-        "ReservedConcurrentExecutions": 2,
+        "ReservedConcurrentExecutions": 3,
         "Role": {
           "Fn::GetAtt": [
             "workerServiceRole2130CC7F",

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -142,7 +142,7 @@ export class AppStack extends Stack {
 
     workerDeployment.alias.addEventSource(
       new aws_lambda_event_sources.SqsEventSource(queue, {
-        maxConcurrency: config.workerLambda.reservedConcurrency,
+        maxConcurrency: config.workerLambda.reservedConcurrency - 1, // -1 so we have capacity reserved for our blue/green deployment
         batchSize: config.workerLambda.batchSize,
         reportBatchItemFailures: true,
       }),

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -142,7 +142,7 @@ export class AppStack extends Stack {
 
     workerDeployment.alias.addEventSource(
       new aws_lambda_event_sources.SqsEventSource(queue, {
-        maxConcurrency: config.workerLambda.reservedConcurrency - 1, // -1 so we have capacity reserved for our blue/green deployment
+        maxConcurrency: config.workerLambda.reservedConcurrency - 1, // Ensure we have capacity reserved for our blue/green deployment
         batchSize: config.workerLambda.batchSize,
         reportBatchItemFailures: true,
       }),

--- a/template/lambda-sqs-worker-cdk/infra/config.ts
+++ b/template/lambda-sqs-worker-cdk/infra/config.ts
@@ -26,7 +26,7 @@ const configs: Record<Environment, Config> = {
     appName: '<%- serviceName %>',
     workerLambda: {
       batchSize: 10,
-      reservedConcurrency: 2,
+      reservedConcurrency: 3,
       environment: {
         ENVIRONMENT: 'dev',
         SERVICE: '<%- serviceName %>',


### PR DESCRIPTION
Reserve capacity for our blue green deployment. Reserved concurrency spans across aliases.

`maxConcurrency` also needs to be at least 2, so we need to set our reserved to a minimum of 3.