### PR TITLE
Auto map experimental vm modules to `pnpm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prepack": "pnpm --filter './template/**' exec rm -rf node_modules",
     "release": "pnpm --silent build && changeset publish",
     "skuba": "pnpm --silent build && pnpm --silent skuba:exec",
-    "skuba:exec": "node --experimental-vm-modules --no-warnings=ExperimentalWarning lib/skuba",
+    "skuba:exec": "node --no-warnings=ExperimentalWarning lib/skuba",
     "stage": "changeset version && node ./.changeset/inject.js && pnpm format",
     "test": "pnpm --silent skuba test --selectProjects unit",
     "test:ci": "pnpm --silent skuba test --runInBand",

--- a/packages/eslint-config-skuba/package.json
+++ b/packages/eslint-config-skuba/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "format": "pnpm --silent skuba format",
     "lint": "pnpm --silent skuba lint",
-    "skuba": "node --experimental-vm-modules ../../lib/skuba"
+    "skuba": "node ../../lib/skuba"
   },
   "dependencies": {
     "eslint-config-seek": "14.5.3",

--- a/packages/eslint-plugin-skuba/package.json
+++ b/packages/eslint-plugin-skuba/package.json
@@ -34,7 +34,7 @@
     "format": "pnpm --silent skuba format",
     "lint": "pnpm --silent skuba lint",
     "prepack": "tsdown",
-    "skuba": "node --experimental-vm-modules ../../lib/skuba",
+    "skuba": "node ../../lib/skuba",
     "test": "node --import tsx --test 'src/**/*.test.ts'",
     "test:ci": "node --import tsx --test --experimental-test-coverage 'src/**/*.test.ts'",
     "test:watch": "node --import tsx --test --watch 'src/**/*.test.ts'"

--- a/packages/skuba-dive/package.json
+++ b/packages/skuba-dive/package.json
@@ -27,7 +27,7 @@
     "format": "pnpm skuba format",
     "lint": "pnpm skuba lint",
     "prepack": "pnpm skuba build",
-    "skuba": "node --experimental-vm-modules ../../lib/skuba",
+    "skuba": "node ../../lib/skuba",
     "test": "pnpm skuba test",
     "test:ci": "pnpm skuba test --coverage"
   },

--- a/src/cli/test/index.ts
+++ b/src/cli/test/index.ts
@@ -9,6 +9,10 @@ export const test = async () => {
   // https://github.com/seek-oss/skuba/issues/1841
   process.env.TS_JEST_LOG ??= 'stdout:error';
 
+  if (!process.env.NODE_OPTIONS?.includes('--experimental-vm-modules')) {
+    process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS ?? ''} --experimental-vm-modules`;
+  }
+
   const argv = process.argv.slice(2);
 
   return run(argv);


### PR DESCRIPTION
With the move to `"module": "node18",` Jest no longer transforms `await import` calls to require which leaves us in a state where need to enable experimental vm modules or switch them to requires.

I think this is probably easier given we're going to throw Jest in the bin anyway