### PR TITLE
Apply tweaks to the ESM plan

### DIFF
--- a/docs/deep-dives/esm.md
+++ b/docs/deep-dives/esm.md
@@ -131,7 +131,7 @@ Your local `tsconfig.json` files will require a `rootDir` and `customConditions`
 ```diff
 {
   "compilerOptions": {
--   "baseUrl": ".",
+    "baseUrl": ".",
 +   "rootDir": ".",
 +   "customConditions": ["@seek/my-repo/source"],
 -   "paths": {

--- a/docs/deep-dives/esm.md
+++ b/docs/deep-dives/esm.md
@@ -148,7 +148,12 @@ This allows us to import modules like this:
 import { module } from '#src/imported-module.js';
 ```
 
-To ensure your builds still work like before, we will need to also modify `tsconfig.build.json` to set the `rootDir` to point to `src`. This value differs from `tsconfig.json` so that files like `scripts/script.ts` can still use `#src/` imports without being included in the build.
+We will also need to set different `rootDir` values for our local development and builds:
+
+- **`tsconfig.json`** uses `"rootDir": "."` to ensure all TypeScript files (including `scripts/script.ts` and root-level files) can use `#src/` imports and are subject to type checking.
+- **`tsconfig.build.json`** uses `"rootDir": "src"` to ensure that only source files are included in the build output.
+
+tsconfig.build.json:
 
 ```diff
 {

--- a/docs/deep-dives/esm.md
+++ b/docs/deep-dives/esm.md
@@ -126,16 +126,16 @@ Our base `skuba/config/tsconfig.json` will update [`moduleResolution`] from `nod
 }
 ```
 
-Your local `tsconfig.json` files will require a `baseUrl`, `rootDir` and `customConditions` to help TypeScript resolve the subpath imports correctly:
+Your local `tsconfig.json` files will require a `rootDir` and `customConditions` to help TypeScript resolve the subpath imports correctly:
 
 ```diff
 {
   "compilerOptions": {
-    "baseUrl": ".",
+-   "baseUrl": ".",
 +   "rootDir": ".",
 +   "customConditions": ["@seek/my-repo/source"],
 -   "paths": {
--     "#src/*": ["src/*"]
+-     "src/*": ["src/*"]
 -    }
   },
   "extends": "skuba/config/tsconfig.json"
@@ -146,6 +146,19 @@ This allows us to import modules like this:
 
 ```ts
 import { module } from '#src/imported-module.js';
+```
+
+You'll also need to update your `tsconfig.build.json` to specify `"rootDir": "src"` to ensure builds continue to work correctly:
+
+```diff
+{
++ "compilerOptions": {
++   "rootDir": "src"
++ },
+  "exclude": ["**/__mocks__/**/*", "**/*.test.ts", "src/testing/**/*"],
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*"]
+}
 ```
 
 [Custom conditions] enable tooling to use TypeScript source files during development while automatically switching to the correct compiled outputs for deployment or publishing. This is done without additional configuration to modify package.json imports and exports. Monorepo users may already be familiar with this concept through pnpm's `publishConfig` feature. For more details, see [Live types in a TypeScript monorepo].

--- a/docs/deep-dives/esm.md
+++ b/docs/deep-dives/esm.md
@@ -131,12 +131,12 @@ Your local `tsconfig.json` files will require a `rootDir` and `customConditions`
 ```diff
 {
   "compilerOptions": {
-    "baseUrl": ".",
+-   "baseUrl": ".",
 +   "rootDir": ".",
 +   "customConditions": ["@seek/my-repo/source"],
 -   "paths": {
--     "src/*": ["src/*"]
--    }
+-     "#src/*": ["src/*"]
+-   }
   },
   "extends": "skuba/config/tsconfig.json"
 }
@@ -148,7 +148,7 @@ This allows us to import modules like this:
 import { module } from '#src/imported-module.js';
 ```
 
-You'll also need to update your `tsconfig.build.json` to specify `"rootDir": "src"` to ensure builds continue to work correctly:
+To ensure your builds still work like before, we will need to also modify `tsconfig.build.json` to set the `rootDir` to point to `src`. This value differs from `tsconfig.json` so that files like `scripts/script.ts` can still use `#src/` imports without being included in the build.
 
 ```diff
 {

--- a/docs/deep-dives/esm.md
+++ b/docs/deep-dives/esm.md
@@ -135,7 +135,7 @@ Your local `tsconfig.json` files will require a `rootDir` and `customConditions`
 +   "rootDir": ".",
 +   "customConditions": ["@seek/my-repo/source"],
 -   "paths": {
--     "#src/*": ["src/*"]
+-     "src/*": ["src/*"]
 -   }
   },
   "extends": "skuba/config/tsconfig.json"


### PR DESCRIPTION
Setting [`rootDir` ](https://www.typescriptlang.org/tsconfig/#rootDir) to `.` means that the `src` folder ends up in our `lib` output.

So we need to also modify `tsconfig.build.json` to point to `src` so that it isn't included in the output