### PR TITLE
Hoist TypeScript

### DIFF
--- a/.changeset/bright-buckets-tie.md
+++ b/.changeset/bright-buckets-tie.md
@@ -2,4 +2,4 @@
 'skuba': minor
 ---
 
-lint: Narrow `publicHoistPattern` list in `pnpm-workspace.yaml`
+lint: Update `publicHoistPattern` list in `pnpm-workspace.yaml`

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ publicHoistPattern:
   - esbuild
   - jest
   - tsconfig-seek
+  - typescript
   # end managed by skuba
   - 'remark-lint-*'
 packages:

--- a/template/base/_pnpm-workspace.yaml
+++ b/template/base/_pnpm-workspace.yaml
@@ -8,4 +8,5 @@ publicHoistPattern:
   - esbuild
   - jest
   - tsconfig-seek
+  - typescript
   # end managed by skuba


### PR DESCRIPTION
Some tooling (*cough *cough Jest) relies on looking for TypeScript in the root folder. Otherwise it goes searching through your whole computer looking for node_modules/typescript. I imagine there's some other things that also require it so I don't see too much harm in hoisting it up.