### PR TITLE
lint: Plug `Promise.try()` and `Promise.resolve().then()`

### DIFF
--- a/.changeset/cool-pants-wonder.md
+++ b/.changeset/cool-pants-wonder.md
@@ -14,8 +14,8 @@ await Promise.allSettled([
   promiseResolve(syncFn() /* If this throws an error synchronously  */),
   //             ~~~~~~~~
   // syncFn() may synchronously throw an error and leave preceding promises dangling.
-  // Evaluate synchronous expressions outside of the iterable argument to Promise.allSettled.
-  // Use the async keyword to denote asynchronous functions.
+  // Evaluate synchronous expressions outside of the iterable argument to Promise.allSettled,
+  // or safely wrap with the async keyword, Promise.try(), or Promise.resolve().then().
 ]);
 ```
 

--- a/docs/eslint-plugin/no-sync-in-promise-iterable.md
+++ b/docs/eslint-plugin/no-sync-in-promise-iterable.md
@@ -16,8 +16,8 @@ Heuristically flags synchronous logic in the iterable argument of [static `Promi
 const [x, y] = await Promise.allSettled([asyncX(), syncY()]);
 //                                                 ~~~~~~~
 // syncY() may synchronously throw an error and leave preceding promises dangling.
-// Evaluate synchronous expressions outside of the iterable argument to Promise.allSettled.
-// Use the async keyword to denote asynchronous functions.
+// Evaluate synchronous expressions outside of the iterable argument to Promise.allSettled,
+// or safely wrap with the async keyword, Promise.try(), or Promise.resolve().then().
 ```
 
 ## Problem
@@ -139,8 +139,8 @@ const syncParam = () => {
 const [x, y] = await Promise.all([asyncX(), asyncY(syncParam())]);
 //                                                 ~~~~~~~~~~~
 // syncParam() may synchronously throw an error and leave preceding promises dangling.
-// Evaluate synchronous expressions outside of the iterable argument to Promise.all.
-// Use the async keyword to denote asynchronous functions.
+// Evaluate synchronous expressions outside of the iterable argument to Promise.all,
+// or safely wrap with the async keyword, Promise.try(), or Promise.resolve().then().
 ```
 
 We recommend restructuring your code regardless to avoid this class of issue;
@@ -178,7 +178,15 @@ const good = (async () => {
 }) satisfies () => Promise<void>;
 ```
 
-Other options like [`Promise.try()`] may be explored in future.
+You can also consider wrapping the function invocation with [`Promise.try()`] or the slower `Promise.resolve().then()`:
+
+```typescript
+// Node.js >=24
+Promise.all([asyncX(), Promise.try(() => syncY())]);
+
+// Node.js <=22
+Promise.all([asyncX(), Promise.resolve().then(() => syncY())]);
+```
 
 ### Getters and setters
 

--- a/docs/eslint-plugin/no-sync-in-promise-iterable.md
+++ b/docs/eslint-plugin/no-sync-in-promise-iterable.md
@@ -114,6 +114,17 @@ see the [relevant section](#asynchronous-functions) below for more information.
   await Promise.all([asyncX(), asyncX()]);
 ```
 
+You can alternatively wrap the function invocation with [`Promise.try()`] or the slower `Promise.resolve().then()`:
+
+```diff
+  Promise.all([
+    asyncX(),
+-   syncY(),
++   Promise.try(() => syncY()), // Node.js >=24
++   Promise.resolve().then(() => syncY()), // Node.js <=22
+  ]);
+```
+
 By default, an unhandled promise rejection will cause the Node.js process to exit (!).
 The resilience of back-end applications can be improved by changing the [`--unhandled-rejections` CLI mode] or adding a [`process.on('unhandledRejection')` event handler] to avoid this terminal state.
 Addressing the underlying issue is still useful to avoid dispatching unnecessary promises which may degrade performance or trigger unanticipated partial failure states.

--- a/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.ts
+++ b/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.ts
@@ -130,6 +130,13 @@ const SAFE_ISH_INSTANCE_METHODS = new Set([
   'toString',
 ]);
 
+const isPromiseTry = (node: TSESTree.CallExpression) =>
+  node.callee.type === TSESTree.AST_NODE_TYPES.MemberExpression &&
+  node.callee.object.type === TSESTree.AST_NODE_TYPES.Identifier &&
+  node.callee.object.name === 'Promise' &&
+  node.callee.property.type === TSESTree.AST_NODE_TYPES.Identifier &&
+  node.callee.property.name === 'try';
+
 /**
  * Whether a call expression represents a safe-ish built-in.
  *
@@ -254,6 +261,7 @@ const possibleNodesWithSyncError = (
   checker: TypeChecker,
   sourceCode: Readonly<TSESLint.SourceCode>,
   visited: Set<string>,
+  calls: number,
 ): TSESTree.Node[] => {
   switch (node.type) {
     case TSESTree.AST_NODE_TYPES.ArrayExpression:
@@ -266,6 +274,7 @@ const possibleNodesWithSyncError = (
               checker,
               sourceCode,
               visited,
+              calls,
             )
           : [],
       );
@@ -273,6 +282,11 @@ const possibleNodesWithSyncError = (
     case TSESTree.AST_NODE_TYPES.ArrowFunctionExpression:
     case TSESTree.AST_NODE_TYPES.FunctionExpression:
     case TSESTree.AST_NODE_TYPES.FunctionDeclaration:
+      // Allow a function that doesn't appear to be invoked
+      if (calls === 0) {
+        return [];
+      }
+
       if (node.async) {
         return [];
       }
@@ -289,6 +303,7 @@ const possibleNodesWithSyncError = (
         checker,
         sourceCode,
         visited,
+        calls - 1,
       );
 
     case TSESTree.AST_NODE_TYPES.AssignmentExpression:
@@ -299,6 +314,7 @@ const possibleNodesWithSyncError = (
         checker,
         sourceCode,
         visited,
+        calls,
       );
 
     case TSESTree.AST_NODE_TYPES.BinaryExpression:
@@ -311,12 +327,31 @@ const possibleNodesWithSyncError = (
           checker,
           sourceCode,
           visited,
+          calls,
         ),
       );
 
     case TSESTree.AST_NODE_TYPES.CallExpression: {
       if (isSafeIshBuilder(node)) {
         return [];
+      }
+
+      if (isPromiseTry(node)) {
+        return node.arguments.flatMap((arg, index) =>
+          possibleNodesWithSyncError(
+            arg,
+            esTreeNodeToTSNodeMap,
+            checker,
+            sourceCode,
+            visited,
+            // We generally increment the call count to indicate that we expect
+            // that a callback argument may be invoked by the parent function.
+            // However, we know that `Promise.try()` will safely wrap its `func`
+            // callback so we don't need to simulate invoking it.
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/try#parameters
+            index === 0 ? calls : calls + 1,
+          ),
+        );
       }
 
       // Allow common safe-ish built-ins and Promise-like return types
@@ -328,6 +363,7 @@ const possibleNodesWithSyncError = (
             checker,
             sourceCode,
             visited,
+            calls + 1,
           ),
         );
       }
@@ -348,22 +384,26 @@ const possibleNodesWithSyncError = (
             checker,
             sourceCode,
             visited,
+            calls + 1,
           ),
         );
       }
 
       if (isChainedPromise(node, esTreeNodeToTSNodeMap, checker)) {
         return node.arguments.flatMap((arg) =>
-          arg.type === TSESTree.AST_NODE_TYPES.ArrowFunctionExpression ||
-          arg.type === TSESTree.AST_NODE_TYPES.FunctionExpression
-            ? []
-            : possibleNodesWithSyncError(
-                arg,
-                esTreeNodeToTSNodeMap,
-                checker,
-                sourceCode,
-                visited,
-              ),
+          possibleNodesWithSyncError(
+            arg,
+            esTreeNodeToTSNodeMap,
+            checker,
+            sourceCode,
+            visited,
+            // We generally increment the call count to indicate that we expect
+            // that a callback argument may be invoked by the parent function.
+            // However, we assume that `.catch()`, `.finally()`, `.then()` will
+            // will safely wrap their callbacks so we don't need to simulate
+            // invoking them.
+            calls,
+          ),
         );
       }
 
@@ -378,6 +418,7 @@ const possibleNodesWithSyncError = (
             checker,
             sourceCode,
             visited,
+            calls + 1,
           ),
         );
       }
@@ -394,6 +435,7 @@ const possibleNodesWithSyncError = (
         checker,
         sourceCode,
         visited,
+        calls,
       );
 
     case TSESTree.AST_NODE_TYPES.ConditionalExpression:
@@ -405,6 +447,7 @@ const possibleNodesWithSyncError = (
           checker,
           sourceCode,
           visited,
+          calls,
         ),
       );
 
@@ -441,6 +484,7 @@ const possibleNodesWithSyncError = (
           checker,
           sourceCode,
           visited,
+          calls,
         ),
       );
 
@@ -460,6 +504,7 @@ const possibleNodesWithSyncError = (
         checker,
         sourceCode,
         visited,
+        calls,
       );
     }
 
@@ -476,6 +521,7 @@ const possibleNodesWithSyncError = (
           checker,
           sourceCode,
           visited,
+          calls,
         ),
       );
   }
@@ -497,6 +543,7 @@ const checkIterableForSyncErrors = (
       checker,
       context.sourceCode,
       new Set<string>(),
+      0,
     );
 
     for (const node of nodes) {
@@ -633,7 +680,7 @@ export default createRule({
     schema: [],
     messages: {
       mayThrowSyncError:
-        '{{value}} may synchronously throw an error and leave preceding promises dangling. Evaluate synchronous expressions outside of the iterable argument to Promise.{{method}}. Use the async keyword to denote asynchronous functions.',
+        '{{value}} may synchronously throw an error and leave preceding promises dangling. Evaluate synchronous expressions outside of the iterable argument to Promise.{{method}}, or safely wrap with the async keyword, Promise.try(), or Promise.resolve().then().',
     },
   },
   create: (context) => {

--- a/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.ts
+++ b/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.ts
@@ -608,14 +608,6 @@ const resolveArrayElements = (
           return [];
         }
 
-        // Skip unevaluated functions as they are harmless
-        if (
-          element.type === TSESTree.AST_NODE_TYPES.ArrowFunctionExpression ||
-          element.type === TSESTree.AST_NODE_TYPES.FunctionExpression
-        ) {
-          return [];
-        }
-
         // Skip first element as it doesn't leave preceding promises dangling
         if (
           index === 0 &&

--- a/src/cli/build/assets.ts
+++ b/src/cli/build/assets.ts
@@ -78,7 +78,7 @@ export const copyAssetsConcurrently = async (configs: CopyAssetsConfig[]) => {
   );
 
   await Promise.all(
-    configs.map(({ outDir, name, prefixColor }) =>
+    configs.map(async ({ outDir, name, prefixColor }) =>
       copyAssets(
         outDir,
         createLogger({

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -58,7 +58,7 @@ export const runForm = <T = Record<string, string>>(props: {
     name,
     validate: async (values) => {
       const results = await Promise.all(
-        choices.map((choice) => choice.validate(values[choice.name])),
+        choices.map(async (choice) => choice.validate(values[choice.name])),
       );
 
       return (

--- a/src/cli/lint/internal.ts
+++ b/src/cli/lint/internal.ts
@@ -70,7 +70,7 @@ const lintConcurrently = async (
   for (const lintGroup of lints) {
     results.push(
       ...(await Promise.all(
-        lintGroup.map(({ name, lint }) =>
+        lintGroup.map(async ({ name, lint }) =>
           lint(
             mode,
             childLogger(logger, { suffixes: [chalk.dim(name)] }),

--- a/src/cli/lint/internalLints/upgrade/patches/8.2.1/upgradeESLint.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/8.2.1/upgradeESLint.ts
@@ -87,7 +87,7 @@ const writeTemporaryFiles = async (contents: Record<string, string>) => {
   const dir = await fsp.mkdtemp('eslint-migrate-config');
 
   await Promise.all(
-    Object.entries(contents).map(([file, content]) =>
+    Object.entries(contents).map(async ([file, content]) =>
       fsp.writeFile(path.join(dir, file), content),
     ),
   );

--- a/src/wrapper/main.test.ts
+++ b/src/wrapper/main.test.ts
@@ -45,7 +45,7 @@ test('asyncFunctionHandler', async () => {
         `),
       ),
 
-    Promise.try(() =>
+    Promise.resolve().then(() =>
       agent
         .post('/')
         .send([null, {}])
@@ -156,7 +156,7 @@ test('syncFunctionHandler', async () => {
       .expect(200)
       .expect(({ body }) => expect(body).toMatchInlineSnapshot(`"aaa"`)),
 
-    Promise.try(() =>
+    Promise.resolve().then(() =>
       agent
         .post('/')
         .send('Invalid JSON')

--- a/src/wrapper/main.test.ts
+++ b/src/wrapper/main.test.ts
@@ -45,13 +45,15 @@ test('asyncFunctionHandler', async () => {
         `),
       ),
 
-    agent
-      .post('/')
-      .send([null, {}])
-      .expect(500)
-      .expect(({ text }) =>
-        expect(text.split('\n')[0]).toBe('Error: falsy event'),
-      ),
+    Promise.try(() =>
+      agent
+        .post('/')
+        .send([null, {}])
+        .expect(500)
+        .expect(({ text }) =>
+          expect(text.split('\n')[0]).toBe('Error: falsy event'),
+        ),
+    ),
   ]);
 });
 
@@ -154,15 +156,17 @@ test('syncFunctionHandler', async () => {
       .expect(200)
       .expect(({ body }) => expect(body).toMatchInlineSnapshot(`"aaa"`)),
 
-    agent
-      .post('/')
-      .send('Invalid JSON')
-      .expect(500)
-      .expect(({ text }) =>
-        expect(text.split('\n')[0]).toBe(
-          `SyntaxError: Unexpected token 'I', "Invalid JSON" is not valid JSON`,
+    Promise.try(() =>
+      agent
+        .post('/')
+        .send('Invalid JSON')
+        .expect(500)
+        .expect(({ text }) =>
+          expect(text.split('\n')[0]).toBe(
+            `SyntaxError: Unexpected token 'I', "Invalid JSON" is not valid JSON`,
+          ),
         ),
-      ),
+    ),
   ]);
 });
 


### PR DESCRIPTION
This bites the bullet and starts tracking whether a given function will be invoked. This means we stop traversing `() => () => () => fail()` if we are confident it won't reach `fail()`, and allows us to properly model the relative safety of `.then()` and `Promise.try()` callbacks.