### PR TITLE
Bump default memory to 512mb

### DIFF
--- a/.changeset/fresh-ducks-clap.md
+++ b/.changeset/fresh-ducks-clap.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/lambda-sqs-worker-cdk: Set worker memory to 512mb by default

--- a/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
+++ b/template/lambda-sqs-worker-cdk/infra/__snapshots__/appStack.test.ts.snap
@@ -235,6 +235,7 @@ exports[`returns expected CloudFormation stack for dev 1`] = `
             ],
           },
         ],
+        "MemorySize": 512,
         "ReservedConcurrentExecutions": 3,
         "Role": {
           "Fn::GetAtt": [
@@ -988,6 +989,7 @@ exports[`returns expected CloudFormation stack for prod 1`] = `
             ],
           },
         ],
+        "MemorySize": 512,
         "ReservedConcurrentExecutions": 20,
         "Role": {
           "Fn::GetAtt": [

--- a/template/lambda-sqs-worker-cdk/infra/appStack.ts
+++ b/template/lambda-sqs-worker-cdk/infra/appStack.ts
@@ -87,6 +87,7 @@ export class AppStack extends Stack {
     const worker = new aws_lambda_nodejs.NodejsFunction(this, 'worker', {
       architecture: aws_lambda.Architecture[architecture],
       runtime: aws_lambda.Runtime.NODEJS_22_X,
+      memorySize: 512,
       environmentEncryption: kmsKey,
       // aws-sdk-v3 sets this to true by default, so it is not necessary to set the environment variable
       // https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/node-reusing-connections.html


### PR DESCRIPTION
Given our telemetry instrumentation we should give this a little more juice by default