### PR TITLE
Line up `skuba/no-sync-in-promise-iterable` to Promise

### DIFF
--- a/.changeset/many-moles-rescue.md
+++ b/.changeset/many-moles-rescue.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+lint: Improve location of `skuba/no-sync-in-promise-iterable` warnings

--- a/.changeset/silly-poems-prove.md
+++ b/.changeset/silly-poems-prove.md
@@ -1,0 +1,8 @@
+---
+'eslint-plugin-skuba': patch
+'eslint-config-skuba': patch
+---
+
+skuba/no-sync-in-promise-iterable: Improve warning location
+
+Previously, each warning was anchored to the underlying expression that may have thrown a synchronous error, which could be confusing to triage. The rule now emits each warning against the root argument to the static `Promise` method, and includes details about the underlying expression in its message.

--- a/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.test.ts
+++ b/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.test.ts
@@ -241,13 +241,7 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       ],
     },
     {
-      code: `
-        Promise.${method}([
-          1,
-          fail(),
-          3,
-        ]);
-      `,
+      code: `Promise.${method}([1, fail(), 3])`,
       errors: [
         {
           messageId: 'mayThrowSyncError',

--- a/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.test.ts
+++ b/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.test.ts
@@ -229,13 +229,25 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'Boolean() ? syncFn() : Promise.resolve()',
+            underlying: 'fail()',
+            line: 2,
+            column: 29,
+          },
         },
       ],
     },
     {
-      code: `Promise.${method}([1, fail(), 3])`,
+      code: `
+        Promise.${method}([
+          1,
+          fail(),
+          3,
+        ]);
+      `,
       errors: [
         {
           messageId: 'mayThrowSyncError',
@@ -256,7 +268,13 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       ],
     },
     {
-      code: `Promise.${method}([1, Namespace.method(), 3])`,
+      code: `
+        Promise.${method}([
+          1,
+          Namespace.method(),
+          3,
+        ]);
+      `,
       errors: [
         {
           messageId: 'mayThrowSyncError',
@@ -265,11 +283,23 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       ],
     },
     {
-      code: `Promise.${method}([1, Promise.resolve(syncFn()), 3])`,
+      code: `
+        Promise.${method}([
+          1,
+          Promise.resolve(syncFn()),
+          3,
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'syncFn()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'Promise.resolve(syncFn())',
+            underlying: 'syncFn()',
+            line: 4,
+            column: 26,
+          },
         },
       ],
     },
@@ -280,8 +310,14 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'syncFn()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'promises',
+            underlying: 'syncFn()',
+            line: 2,
+            column: 29,
+          },
         },
       ],
     },
@@ -295,8 +331,14 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'p3',
+            underlying: 'fail()',
+            line: 2,
+            column: 29,
+          },
         },
       ],
     },
@@ -321,11 +363,23 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
     },
     // Nested arrays
     {
-      code: `Promise.${method}([1, [syncFn(), 2], 3])`,
+      code: `
+        Promise.${method}([
+          1,
+          [syncFn(), 2],
+          3,
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'syncFn()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: '[syncFn(), 2]',
+            underlying: 'syncFn()',
+            line: 4,
+            column: 11,
+          },
         },
       ],
     },
@@ -360,8 +414,14 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'syncFn()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'level4',
+            underlying: 'syncFn()',
+            line: 2,
+            column: 27,
+          },
         },
       ],
     },
@@ -373,18 +433,36 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'syncFn()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: '...problematic',
+            underlying: 'syncFn()',
+            line: 2,
+            column: 32,
+          },
         },
       ],
     },
     // Template literal with expression
     {
-      code: `Promise.${method}([1, \`result: \${syncFn()}\`, 3])`,
+      code: `
+        Promise.${method}([
+          1,
+          \`result: \${syncFn()}\`,
+          3
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'syncFn()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: '`result: ${syncFn()}`',
+            underlying: 'syncFn()',
+            line: 4,
+            column: 21,
+          },
         },
       ],
     },
@@ -392,31 +470,60 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
     {
       code: `
         const set = new Set([1, 2, 3]);
-        Promise.${method}(set.entries().map(() => fail()));
+        Promise.${method}(
+          set.entries().map(() => fail()),
+        );
       `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'set.entries().map(() => fail())',
+            underlying: 'fail()',
+            line: 4,
+            column: 34,
+          },
         },
       ],
     },
     {
-      code: `const fn = (xs: string[]) => Promise.${method}(xs.map(() => fail()))`,
+      code: `
+        const fn = (xs: string[]) => Promise.${method}(
+          xs.map(() => fail()),
+        );
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'xs.map(() => fail())',
+            underlying: 'fail()',
+            line: 3,
+            column: 23,
+          },
         },
       ],
     },
     // IIFE
     {
-      code: `Promise.${method}([1, (() => fail())()]);`,
+      code: `
+        Promise.${method}([
+          1,
+          (() => fail())(),
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: '(() => fail())()',
+            underlying: 'fail()',
+            line: 4,
+            column: 17,
+          },
         },
       ],
     },
@@ -430,58 +537,117 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
+          messageId: 'mayLeadToSyncError',
           data: {
             method,
-            value: 'param = (x: number) => { /* block! */ return x }',
+            value: 'xs.map(() => fn(param(x)))',
+            underlying: 'param = (x: number) => { /* block! */ return x }',
+            line: 4,
+            column: 14,
           },
         },
       ],
     },
     // Object/function instance method with problematic argument
     {
-      code: `Promise.${method}([1, [1, 2].map(x => x.toLocaleString(fail()))]);`,
+      code: `
+        Promise.${method}([
+          1,
+          [1, 2].map(x => x.toLocaleString(fail())),
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: '[1, 2].map(x => x.toLocaleString(fail()))',
+            underlying: 'fail()',
+            line: 4,
+            column: 43,
+          },
         },
       ],
     },
     {
-      code: `const fn = () => undefined; Promise.${method}([1, fn.call(fail())]);`,
+      code: `
+        const fn = () => undefined;
+        Promise.${method}([
+          1,
+          fn.call(fail()),
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'fn.call(fail())',
+            underlying: 'fail()',
+            line: 5,
+            column: 18,
+          },
         },
       ],
     },
     // Safe Promise wrappers with unsafe arguments
     {
-      code: `Promise.${method}([,Promise.try(fail())])`,
+      code: `
+        Promise.${method}([
+          ,
+          Promise.try(fail()),
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'Promise.try(fail())',
+            underlying: 'fail()',
+            line: 4,
+            column: 22,
+          },
         },
       ],
     },
     {
-      code: `Promise.${method}([,Promise.try(() => fail(), 2, 3,fail())])`,
+      code: `
+        Promise.${method}([
+          ,
+          Promise.try(() => fail(), 2, 3, fail()),
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'Promise.try(() => fail(), 2, 3, fail())',
+            underlying: 'fail()',
+            line: 4,
+            column: 42,
+          },
         },
       ],
     },
     {
-      code: `Promise.${method}([,Promise.resolve().then(fail())])`,
+      code: `
+        Promise.${method}([
+          ,
+          Promise.resolve().then(fail()),
+        ]);
+      `,
       errors: [
         {
-          messageId: 'mayThrowSyncError',
-          data: { method, value: 'fail()' },
+          messageId: 'mayLeadToSyncError',
+          data: {
+            method,
+            value: 'Promise.resolve().then(fail())',
+            underlying: 'fail()',
+            line: 4,
+            column: 33,
+          },
         },
       ],
     },

--- a/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.test.ts
+++ b/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.test.ts
@@ -268,13 +268,7 @@ ruleTester.run('no-sync-in-promise-iterable', rule, {
       ],
     },
     {
-      code: `
-        Promise.${method}([
-          1,
-          Namespace.method(),
-          3,
-        ]);
-      `,
+      code: `Promise.${method}([1, Namespace.method(), 3])`,
       errors: [
         {
           messageId: 'mayThrowSyncError',

--- a/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.ts
+++ b/packages/eslint-plugin-skuba/src/rules/no-sync-in-promise-iterable.ts
@@ -529,14 +529,25 @@ const possibleNodesWithSyncError = (
   return [];
 };
 
+const getSourceCodeExcerpt = (
+  node: TSESTree.Node,
+  sourceCode: Readonly<TSESLint.SourceCode>,
+): string => {
+  const text = sourceCode.getText(node);
+  const lines = text.split('\n');
+  return lines.length <= 2
+    ? text
+    : `${lines[0]?.trimEnd()}...${lines[lines.length - 1]?.trimStart()}`;
+};
+
 const checkIterableForSyncErrors = (
-  elements: ArrayElement[],
+  elements: Array<{ element: ArrayElement; reference?: TSESTree.Expression }>,
   method: string,
   context: Context,
   esTreeNodeToTSNodeMap: ESTreeNodeToTSNodeMap,
   checker: TypeChecker,
 ): void => {
-  for (const element of elements) {
+  for (const { element, reference } of elements) {
     const nodes = possibleNodesWithSyncError(
       element,
       esTreeNodeToTSNodeMap,
@@ -547,21 +558,36 @@ const checkIterableForSyncErrors = (
     );
 
     for (const node of nodes) {
-      const text = context.sourceCode.getText(node);
-      const lines = text.split('\n');
-      const value =
-        lines.length <= 2
-          ? text
-          : `${lines[0]?.trimEnd()}...${lines[lines.length - 1]?.trimStart()}`;
+      const root = reference ?? element;
 
-      context.report({
-        node,
-        messageId: 'mayThrowSyncError',
-        data: {
-          method,
-          value,
-        },
-      });
+      const value = getSourceCodeExcerpt(root, context.sourceCode);
+
+      if (
+        root.loc.start.column === node.loc.start.column &&
+        root.loc.start.line === node.loc.start.line
+      ) {
+        context.report({
+          node,
+          messageId: 'mayThrowSyncError',
+          data: {
+            value,
+            method,
+          },
+        });
+      } else {
+        context.report({
+          node,
+          messageId: 'mayLeadToSyncError',
+          data: {
+            value,
+            method,
+
+            underlying: getSourceCodeExcerpt(node, context.sourceCode),
+            line: node.loc.start.line.toString(),
+            column: node.loc.start.column.toString(),
+          },
+        });
+      }
     }
   }
 };
@@ -605,7 +631,8 @@ const resolveArrayElements = (
   node: TSESTree.CallExpressionArgument,
   sourceCode: Readonly<TSESLint.SourceCode>,
   visited = new Set<string>(),
-): ArrayElement[] => {
+  reference?: TSESTree.Expression,
+): Array<{ element: ArrayElement; reference?: TSESTree.Expression }> => {
   switch (node.type) {
     // Handle direct array expressions like `Promise.all([1, 2])`
     case TSESTree.AST_NODE_TYPES.ArrayExpression:
@@ -623,12 +650,12 @@ const resolveArrayElements = (
           return [];
         }
 
-        return element;
+        return { element, reference };
       });
 
     // Pass through calls like `Promise.all(promises.map(fn))`
     case TSESTree.AST_NODE_TYPES.CallExpression:
-      return [node];
+      return [{ element: node, reference }];
 
     // Handle indirection like `const promises = [1, 2]; Promise.all(promises)`
     case TSESTree.AST_NODE_TYPES.Identifier:
@@ -637,7 +664,12 @@ const resolveArrayElements = (
         return [];
       }
 
-      return resolveArrayElements(expression, sourceCode, visited);
+      return resolveArrayElements(
+        expression,
+        sourceCode,
+        visited,
+        reference ?? node,
+      );
   }
 
   return [];
@@ -655,7 +687,7 @@ export const createRule = ESLintUtils.RuleCreator<PluginDocs>(
     `https://github.com/seek-oss/skuba/tree/main/docs/eslint-plugin/${name}.md`,
 );
 
-type MessageId = 'mayThrowSyncError';
+type MessageId = 'mayLeadToSyncError' | 'mayThrowSyncError';
 
 type Context = TSESLint.RuleContext<MessageId, []>;
 
@@ -678,6 +710,8 @@ export default createRule({
     },
     schema: [],
     messages: {
+      mayLeadToSyncError:
+        '{{value}} leads to {{underlying}} at {{line}}:{{column}} which may synchronously throw an error and leave preceding promises dangling. Evaluate synchronous expressions outside of the iterable argument to Promise.{{method}}, or safely wrap with the async keyword, Promise.try(), or Promise.resolve().then().',
       mayThrowSyncError:
         '{{value}} may synchronously throw an error and leave preceding promises dangling. Evaluate synchronous expressions outside of the iterable argument to Promise.{{method}}, or safely wrap with the async keyword, Promise.try(), or Promise.resolve().then().',
     },


### PR DESCRIPTION
This should make sure that the report is always against the relevant argument to the static `Promise` method. It tries to maintain some context of the underlying issue by printing the relevant expression and its `line:column` location.

https://seekchat.slack.com/archives/C06QWMV5BSA/p1755051180841209