### PR TITLE
Patch Jest snapshots

### DIFF
--- a/.changeset/floppy-wings-double.md
+++ b/.changeset/floppy-wings-double.md
@@ -1,0 +1,5 @@
+---
+'skuba': minor
+---
+
+lint: Update Jest snapshot URLs

--- a/src/cli/lint/internalLints/upgrade/patches/12.1.1/index.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/12.1.1/index.ts
@@ -1,0 +1,10 @@
+import type { Patches } from '../../index.js';
+
+import { tryPatchJestSnapshots } from './patchJestSnapshots.js';
+
+export const patches: Patches = [
+  {
+    apply: tryPatchJestSnapshots,
+    description: 'Update Jest snapshot URLs to the new documentation site',
+  },
+];

--- a/src/cli/lint/internalLints/upgrade/patches/12.1.1/patchJestSnapshots.test.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/12.1.1/patchJestSnapshots.test.ts
@@ -1,0 +1,97 @@
+import fg from 'fast-glob';
+import fs from 'fs-extra';
+
+import type { PatchConfig, PatchReturnType } from '../../index.js';
+
+import { tryPatchJestSnapshots } from './patchJestSnapshots.js';
+
+jest.mock('fast-glob');
+jest.mock('fs-extra');
+
+describe('patchJestSnapshots', () => {
+  afterEach(() => jest.resetAllMocks());
+
+  it('should skip if no test files found', async () => {
+    jest.mocked(fg).mockResolvedValueOnce([]);
+    await expect(
+      tryPatchJestSnapshots({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual<PatchReturnType>({
+      result: 'skip',
+      reason: 'no test files found',
+    });
+  });
+
+  it('should skip if test files do not contain the old URL', async () => {
+    jest.mocked(fg).mockResolvedValueOnce(['test1.test.ts']);
+    jest
+      .mocked(fs.readFile)
+      .mockResolvedValueOnce('No snapshot URL here' as never);
+    await expect(
+      tryPatchJestSnapshots({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual<PatchReturnType>({
+      result: 'skip',
+      reason: 'no test files to patch',
+    });
+  });
+
+  it('should return apply and not modify files if mode is lint', async () => {
+    jest.mocked(fg).mockResolvedValueOnce(['test1.test.ts']);
+    jest
+      .mocked(fs.readFile)
+      .mockResolvedValueOnce(
+        'Some content with https://goo.gl/fbAQLP' as never,
+      );
+
+    await expect(
+      tryPatchJestSnapshots({
+        mode: 'lint',
+      } as PatchConfig),
+    ).resolves.toEqual<PatchReturnType>({
+      result: 'apply',
+    });
+
+    expect(fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should patch test files', async () => {
+    jest
+      .mocked(fg)
+      .mockResolvedValueOnce([
+        'test1.test.ts',
+        'test2.test.ts',
+        'test3.test.ts.snap',
+      ]);
+    jest
+      .mocked(fs.readFile)
+      .mockResolvedValueOnce('Some content with https://goo.gl/fbAQLP' as never)
+      .mockResolvedValueOnce('No snapshot URL here' as never)
+      .mockResolvedValueOnce(
+        'Some other content with https://goo.gl/fbAQLP' as never,
+      );
+
+    await expect(
+      tryPatchJestSnapshots({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual<PatchReturnType>({
+      result: 'apply',
+    });
+
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      'test1.test.ts',
+      'Some content with https://jestjs.io/docs/snapshot-testing',
+      'utf8',
+    );
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      'test3.test.ts.snap',
+      'Some other content with https://jestjs.io/docs/snapshot-testing',
+      'utf8',
+    );
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/cli/lint/internalLints/upgrade/patches/12.1.1/patchJestSnapshots.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/12.1.1/patchJestSnapshots.ts
@@ -1,0 +1,77 @@
+import { inspect } from 'util';
+
+import fg from 'fast-glob';
+import fs from 'fs-extra';
+
+import { log } from '../../../../../../utils/logging.js';
+import type { PatchFunction, PatchReturnType } from '../../index.js';
+
+const JEST_SNAPSHOT_OLD_URL = 'https://goo.gl/fbAQLP';
+const JEST_SNAPSHOT_NEW_URL = 'https://jestjs.io/docs/snapshot-testing';
+
+export const patchJestSnapshots = async (
+  mode: 'lint' | 'format',
+): Promise<PatchReturnType> => {
+  const testFilePaths = await fg(['*.test.ts', '*.test.ts.snap'], {
+    ignore: ['**/.git', '**/node_modules'],
+  });
+
+  if (testFilePaths.length === 0) {
+    return {
+      result: 'skip',
+      reason: 'no test files found',
+    };
+  }
+
+  const testsFiles = await Promise.all(
+    testFilePaths.map(async (file) => {
+      const contents = await fs.readFile(file, 'utf8');
+
+      return {
+        file,
+        contents,
+      };
+    }),
+  );
+
+  const testFilesToPatch = testsFiles.filter(({ contents }) =>
+    contents.includes(JEST_SNAPSHOT_OLD_URL),
+  );
+
+  if (testFilesToPatch.length === 0) {
+    return {
+      result: 'skip',
+      reason: 'no test files to patch',
+    };
+  }
+
+  if (mode === 'lint') {
+    return {
+      result: 'apply',
+    };
+  }
+
+  await Promise.all(
+    testFilesToPatch.map(async ({ file, contents }) => {
+      const updatedContents = contents.replaceAll(
+        JEST_SNAPSHOT_OLD_URL,
+        JEST_SNAPSHOT_NEW_URL,
+      );
+      await fs.writeFile(file, updatedContents, 'utf8');
+    }),
+  );
+
+  return {
+    result: 'apply',
+  };
+};
+
+export const tryPatchJestSnapshots: PatchFunction = async ({ mode }) => {
+  try {
+    return await patchJestSnapshots(mode);
+  } catch (err) {
+    log.warn('Failed to apply Jest snapshot URL patch.');
+    log.subtle(inspect(err));
+    return { result: 'skip', reason: 'due to an error' };
+  }
+};


### PR DESCRIPTION
Looks like a Jest package update via lock file maintenance is going to make our existing tests fail: https://github.com/seek-oss/skuba/actions/runs/17463229091/job/49592638032?pr=2046

So I've written a little something something to re-write these hopefully before consumers run lock file maintenance