### PR TITLE
 fix local test colors

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,7 @@
 import * as Jest from './lib/api/jest/index.js';
 
+process.env.FORCE_COLOR = 'false';
+
 export default Jest.mergePreset({
   coveragePathIgnorePatterns: ['<rootDir>/integration/', '<rootDir>/template/'],
   displayName: 'unit',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,3 +1,1 @@
-process.env.FORCE_COLOR = '0';
-
 export {};


### PR DESCRIPTION
local tests are failing because of different console color formatting like so
<img width="400" alt="Screenshot 2025-12-04 at 10 16 47 am" src="https://github.com/user-attachments/assets/1c411348-b654-4552-9667-4c7e35dbb7a1" />


previously it was [chalk config](https://github.com/chalk/chalk?tab=readme-ov-file#supportscolor), after we removed chalk this setting was no longer overriding [jest](https://github.com/jestjs/jest/blob/c12575b6b298b787ec8b45fbe889500040002358/packages/jest-worker/src/workers/ChildProcessWorker.ts#L117)

somehow this fixes it, I think [setup](https://jestjs.io/docs/configuration#setupfiles-array) is ran once per file, we need to set the [color](https://jestjs.io/docs/cli#--colors) env var in the config instead
