### PR TITLE
Release detect-invalid-spies

### DIFF
--- a/.changeset/full-taxes-poke.md
+++ b/.changeset/full-taxes-poke.md
@@ -1,0 +1,5 @@
+---
+'@skuba-lib/detect-invalid-spies': major
+---
+
+Publish first version

--- a/packages/detect-invalid-spies/README.md
+++ b/packages/detect-invalid-spies/README.md
@@ -1,0 +1,47 @@
+# @skuba-lib/detect-invalid-spies
+
+Detects `jest.spyOn` / `vi.spyOn` usage patterns where the spy won't work because the spied function is called internally within the same module it is exported from.
+
+## The problem
+
+When you spy on a named export, the spy replaces the binding on the **module namespace object**. But if the source module calls that function directly (using its local binding), those calls bypass the spy entirely.
+
+```ts
+// greet.ts
+export const sayHello = (name: string) => `Hello, ${name}!`;
+
+export const greetEveryone = (names: string[]) =>
+  names.map((name) => sayHello(name));
+//                   ^^^^^^^^ calls the local binding — not the export
+```
+
+```ts
+// greet.test.ts
+import * as greet from './greet.js';
+
+it('greets everyone with a custom message', () => {
+  vi.spyOn(greet, 'sayHello').mockReturnValue('Hi!');
+
+  // ✗ Fails — greetEveryone bypasses the spy and calls the original sayHello
+  expect(greet.greetEveryone(['Alice'])).toEqual(['Hi!']);
+});
+```
+
+The test silently passes in Jest (which rewrites module bindings) but fails in Vitest (which does not), making this a common source of breakage when migrating between the two.
+
+## Usage
+
+Run it against a directory of source files:
+
+```sh
+pnpm dlx @skuba-lib/detect-invalid-spies .
+```
+
+It prints each invalid spy to stderr and exits with code `1` if any are found:
+
+```
+  Invalid spy in src/greet.test.ts
+  spy:     (jest|vi).spyOn(…, 'sayHello')
+  module:  src/greet.ts (via './greet.js')
+  reason:  'sayHello' is called internally — the spy won't intercept it
+```

--- a/packages/detect-invalid-spies/package.json
+++ b/packages/detect-invalid-spies/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "pnpm skuba build-package",
+    "prepack": "pnpm build",
     "skuba": "node ../../lib/skuba",
     "test": "pnpm skuba test",
     "test:ci": "pnpm skuba test --coverage"

--- a/packages/detect-invalid-spies/package.json
+++ b/packages/detect-invalid-spies/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@skuba-lib/detect-invalid-spies",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Detect invalid spies in Jest and Vitest tests",
+  "homepage": "https://github.com/seek-oss/skuba/tree/main/packages/detect-invalid-spies#readme",
+  "bugs": {
+    "url": "https://github.com/seek-oss/skuba/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/seek-oss/skuba.git",
+    "directory": "packages/detect-invalid-spies"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "@seek/skuba/source": "./src/index.ts",
+      "default": "./lib/index.mjs"
+    },
+    "./bin": {
+      "@seek/skuba/source": "./src/bin.ts",
+      "default": "./lib/bin.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "detect-invalid-spies": "lib/bin.mjs"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "pnpm skuba build-package",
+    "skuba": "node ../../lib/skuba",
+    "test": "pnpm skuba test",
+    "test:ci": "pnpm skuba test --coverage"
+  },
+  "dependencies": {
+    "@ast-grep/napi": "^0.42.0",
+    "fast-glob": "^3.3.2",
+    "fs-extra": "^11.0.0",
+    "typescript": "~5.9.0"
+  },
+  "engines": {
+    "node": ">=22.14.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": "./lib/index.mjs",
+      "./bin": "./lib/bin.mjs",
+      "./package.json": "./package.json"
+    }
+  },
+  "skuba": {
+    "entryPoint": "src/bin.ts",
+    "template": "oss-npm-package",
+    "type": "package",
+    "version": "14.1.2"
+  }
+}

--- a/packages/detect-invalid-spies/src/bin.ts
+++ b/packages/detect-invalid-spies/src/bin.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+import path from 'node:path';
+import process from 'node:process';
+import { styleText } from 'node:util';
+
+import { detectSameFileSpyUsage } from './index.js';
+
+const dir = path.resolve(process.argv[2] ?? process.cwd());
+const warnings = await detectSameFileSpyUsage(dir);
+
+if (warnings.length === 0) {
+  process.exit(0);
+}
+
+for (const {
+  testFile,
+  importSpecifier,
+  resolvedFile,
+  spiedFunction,
+} of warnings) {
+  const rel = path.relative(process.cwd(), testFile);
+  const src = path.relative(process.cwd(), resolvedFile);
+  // eslint-disable-next-line no-console
+  console.error(
+    [
+      '',
+      `  ${styleText(['bold', 'red'], 'Invalid spy')} in ${styleText('cyan', rel)}`,
+      `  ${styleText('dim', 'spy:')}     ${styleText('yellow', `(jest|vi).spyOn(…, '${spiedFunction}')`)}`,
+      `  ${styleText('dim', 'module:')}  ${styleText('cyan', src)} (via ${styleText('bold', `'${importSpecifier}'`)})`,
+      `  ${styleText('dim', 'reason:')}  ${styleText('bold', `'${spiedFunction}'`)} is called internally — the spy won't intercept it`,
+    ].join('\n'),
+  );
+}
+
+// eslint-disable-next-line no-console
+console.error('');
+process.exit(1);

--- a/packages/detect-invalid-spies/src/index.test.ts
+++ b/packages/detect-invalid-spies/src/index.test.ts
@@ -1,0 +1,316 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import fs from 'fs-extra';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { detectSameFileSpyUsage } from './index.js';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'detect-invalid-spies-'));
+  // Write a minimal tsconfig so ts.resolveModuleName uses simple classic
+  // node module resolution within the temp directory, isolated from the
+  // project tsconfig that uses Node16.
+  await fs.promises.writeFile(
+    path.join(tmpDir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        moduleResolution: 'node',
+        strict: true,
+      },
+    }),
+    'utf8',
+  );
+});
+
+afterEach(async () => {
+  await fs.remove(tmpDir);
+});
+
+const write = (name: string, content: string) =>
+  fs.promises.writeFile(path.join(tmpDir, name), content, 'utf8');
+
+describe('detectSameFileSpyUsage', () => {
+  it('returns empty array for an empty directory', async () => {
+    await expect(detectSameFileSpyUsage(tmpDir)).resolves.toEqual([]);
+  });
+
+  it('returns empty array when no spy calls are present', async () => {
+    await write(
+      'http.ts',
+      `
+export const createServiceAuthHeaders = () => ({ authorization: 'Bearer token' });
+`,
+    );
+
+    await expect(detectSameFileSpyUsage(tmpDir)).resolves.toEqual([]);
+  });
+
+  it('warns when jest.spyOn targets a function that is called internally', async () => {
+    await write(
+      'http.ts',
+      `
+export const createServiceAuthHeaders = () => ({ authorization: 'Bearer token' });
+
+export const createServiceAuthClient = () => {
+  const headers = createServiceAuthHeaders('audience');
+  return headers;
+};
+`,
+    );
+
+    await write(
+      'spy.ts',
+      `
+import * as s2s from './http';
+
+export const mockServiceAuthHeaders = () =>
+  jest.spyOn(s2s, 'createServiceAuthHeaders').mockReturnValue({ authorization: 'Bearer mock' });
+`,
+    );
+
+    const warnings = await detectSameFileSpyUsage(tmpDir);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      importSpecifier: './http',
+      spiedFunction: 'createServiceAuthHeaders',
+      resolvedFile: path.join(tmpDir, 'http.ts'),
+    });
+  });
+
+  it('warns when vi.spyOn targets a function that is called internally', async () => {
+    await write(
+      'http.ts',
+      `
+export const createServiceAuthHeaders = () => ({ authorization: 'Bearer token' });
+
+export const createServiceAuthClient = () => {
+  const headers = createServiceAuthHeaders('audience');
+  return headers;
+};
+`,
+    );
+
+    await write(
+      'spy.ts',
+      `
+import * as s2s from './http';
+
+export const mockServiceAuthHeaders = () =>
+  vi.spyOn(s2s, 'createServiceAuthHeaders').mockReturnValue({ authorization: 'Bearer mock' });
+`,
+    );
+
+    const warnings = await detectSameFileSpyUsage(tmpDir);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      importSpecifier: './http',
+      spiedFunction: 'createServiceAuthHeaders',
+    });
+  });
+
+  it('does not warn when the spied function is only declared but not called internally', async () => {
+    await write(
+      'http.ts',
+      `
+export const createServiceAuthHeaders = () => ({ authorization: 'Bearer token' });
+
+export const createServiceAuthClient = () => 'unrelated';
+`,
+    );
+
+    await write(
+      'spy.ts',
+      `
+import * as s2s from './http';
+
+export const mockServiceAuthHeaders = () =>
+  jest.spyOn(s2s, 'createServiceAuthHeaders').mockReturnValue({ authorization: 'Bearer mock' });
+`,
+    );
+
+    await expect(detectSameFileSpyUsage(tmpDir)).resolves.toEqual([]);
+  });
+
+  it('does not warn when the module specifier cannot be resolved', async () => {
+    await write(
+      'spy.ts',
+      `
+import * as gone from './nonexistent-module';
+
+export const mock = () =>
+  jest.spyOn(gone, 'doSomething').mockReturnValue(undefined);
+`,
+    );
+
+    await expect(detectSameFileSpyUsage(tmpDir)).resolves.toEqual([]);
+  });
+
+  it('does not warn when the import is a named import rather than a namespace import', async () => {
+    await write(
+      'http.ts',
+      `
+export const doThing = () => 'x';
+export const caller = () => doThing();
+`,
+    );
+
+    // Named import — jest.spyOn cannot intercept this pattern anyway,
+    // but the detector should not flag it because there is no namespace import.
+    await write(
+      'spy.ts',
+      `
+import { doThing } from './http';
+
+export const mock = () =>
+  jest.spyOn(doThing, 'bind').mockReturnValue(doThing);
+`,
+    );
+
+    await expect(detectSameFileSpyUsage(tmpDir)).resolves.toEqual([]);
+  });
+
+  it('does not warn when the function only appears in a type position in the source module', async () => {
+    await write(
+      'http.ts',
+      `
+export const doThing = () => 'x';
+export type DoThingFn = typeof doThing;
+`,
+    );
+
+    await write(
+      'spy.ts',
+      `
+import * as http from './http';
+
+export const mock = () =>
+  jest.spyOn(http, 'doThing').mockReturnValue('mocked');
+`,
+    );
+
+    await expect(detectSameFileSpyUsage(tmpDir)).resolves.toEqual([]);
+  });
+
+  it('does not warn when the function is only re-exported via export specifier', async () => {
+    await write(
+      'impl.ts',
+      `
+export const doThing = () => 'x';
+`,
+    );
+
+    // http.ts just re-exports; doThing is not called internally here.
+    await write(
+      'http.ts',
+      `
+import { doThing } from './impl';
+export { doThing };
+`,
+    );
+
+    await write(
+      'spy.ts',
+      `
+import * as http from './http';
+
+export const mock = () =>
+  jest.spyOn(http, 'doThing').mockReturnValue('mocked');
+`,
+    );
+
+    await expect(detectSameFileSpyUsage(tmpDir)).resolves.toEqual([]);
+  });
+
+  it('reports multiple warnings when multiple spied functions are each used internally', async () => {
+    await write(
+      'api.ts',
+      `
+export const fetchUser = async (id: string) => ({ id });
+export const fetchPost = async (id: string) => ({ id });
+
+export const fetchUserAndPost = async (id: string) => {
+  const user = await fetchUser(id);
+  const post = await fetchPost(id);
+  return { user, post };
+};
+`,
+    );
+
+    await write(
+      'spy.ts',
+      `
+import * as api from './api';
+
+export const mockFetchUser = () =>
+  jest.spyOn(api, 'fetchUser').mockResolvedValue({ id: 'u1' });
+
+export const mockFetchPost = () =>
+  jest.spyOn(api, 'fetchPost').mockResolvedValue({ id: 'p1' });
+`,
+    );
+
+    const warnings = await detectSameFileSpyUsage(tmpDir);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings.map((w) => w.spiedFunction).sort()).toEqual([
+      'fetchPost',
+      'fetchUser',
+    ]);
+  });
+
+  it('reports the spy file path in testFile', async () => {
+    await write(
+      'http.ts',
+      `
+export const doThing = () => 'x';
+export const caller = () => doThing();
+`,
+    );
+
+    await write(
+      'spy.ts',
+      `
+import * as http from './http';
+
+export const mock = () =>
+  jest.spyOn(http, 'doThing').mockReturnValue('mocked');
+`,
+    );
+
+    const warnings = await detectSameFileSpyUsage(tmpDir);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.testFile).toBe(path.join(tmpDir, 'spy.ts'));
+  });
+
+  it('does not produce duplicate warnings for a chained call on spyOn', async () => {
+    await write(
+      'http.ts',
+      `
+export const doThing = () => 'x';
+export const caller = () => doThing();
+`,
+    );
+
+    // The .mockReturnValue(...) call_expression has only one argument and must
+    // NOT be mistakenly identified as a second spyOn call.
+    await write(
+      'spy.ts',
+      `
+import * as http from './http';
+
+export const mock = () =>
+  jest.spyOn(http, 'doThing').mockReturnValue('mocked');
+`,
+    );
+
+    const warnings = await detectSameFileSpyUsage(tmpDir);
+
+    expect(warnings).toHaveLength(1);
+  });
+});

--- a/packages/detect-invalid-spies/src/index.ts
+++ b/packages/detect-invalid-spies/src/index.ts
@@ -1,0 +1,331 @@
+/**
+ * Detects Jest/Vitest spy usage patterns where the spied function is also
+ * referenced internally within the same module it is exported from.
+ *
+ * When `jest.spyOn` / `vi.spyOn` replaces the module export binding, any
+ * calls to `fn` made from within that same module still use the original local
+ * binding and are therefore NOT intercepted by the spy. This makes the mock
+ * ineffective for indirect callers and can cause subtle failures, especially
+ * when migrating to Vitest where module mocking semantics differ.
+ *
+ * Example of the problematic pattern:
+ *
+ * ```ts
+ * // http.ts
+ * export const createServiceAuthHeaders = createIssuer(fetcher);
+ *
+ * export const createServiceAuthClient = ({ baseUrl }) =>
+ *   new Gaxios({
+ *     adapter: async (options, defaultAdapter) => {
+ *       // ← this call uses the local binding, NOT the module export
+ *       const headers = await createServiceAuthHeaders(audience);
+ *       ...
+ *     },
+ *   });
+ *
+ * // spy.ts
+ * import * as s2s from '#src/framework/http.js';
+ *
+ * export const mockServiceAuthHeaders = () =>
+ *   jest.spyOn(s2s, 'createServiceAuthHeaders') // ← spy won't intercept http.ts-internal calls
+ *     .mockResolvedValue({ authorization: 'Bearer token' });
+ * ```
+ */
+
+import path from 'node:path';
+import process from 'node:process';
+
+import { type SgNode, parseAsync } from '@ast-grep/napi';
+import fg from 'fast-glob';
+import fs from 'fs-extra';
+import ts from 'typescript';
+
+export type SameFileSpyWarning = {
+  /** The file that contains the `jest.spyOn` call. */
+  testFile: string;
+  /** The raw import specifier used in the namespace import, e.g. `#src/framework/http.js`. */
+  importSpecifier: string;
+  /** The absolute path of the module being spied on, after TypeScript resolution. */
+  resolvedFile: string;
+  /** The name of the function being spied on. */
+  spiedFunction: string;
+};
+
+/**
+ * Scans TypeScript files under `dir` (default: `process.cwd()`) and returns
+ * all instances where `jest.spyOn` or `vi.spyOn` targets a function that is
+ * also used internally within the same source module, meaning the spy will not
+ * intercept those internal calls.
+ */
+export const detectSameFileSpyUsage = async (
+  dir: string = process.cwd(),
+): Promise<SameFileSpyWarning[]> => {
+  const filePaths = await fg(['**/*.ts', '**/*.tsx'], {
+    absolute: true,
+    cwd: dir,
+    ignore: ['**/.git', '**/node_modules'],
+  });
+
+  const results = await Promise.all(
+    filePaths.map((filePath) => analyzeFileForSpyUsage(filePath)),
+  );
+
+  return results.flat();
+};
+
+// ---------------------------------------------------------------------------
+// File-level analysis
+// ---------------------------------------------------------------------------
+
+const analyzeFileForSpyUsage = async (
+  filePath: string,
+): Promise<SameFileSpyWarning[]> => {
+  let content: string;
+  try {
+    content = await fs.promises.readFile(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+
+  const ast = await parseAsync('TypeScript', content);
+  const root = ast.root();
+
+  // Quick bail-out: no spy calls in this file
+  const spyOnCalls = root.findAll({
+    rule: {
+      kind: 'call_expression',
+      regex: '^(jest|vi)\.spyOn',
+    },
+  });
+
+  if (spyOnCalls.length === 0) {
+    return [];
+  }
+
+  const compilerOptions = loadCompilerOptions(filePath);
+  const warnings: SameFileSpyWarning[] = [];
+
+  for (const spyCall of spyOnCalls) {
+    const warning = await analyzeSpyCall(
+      spyCall,
+      filePath,
+      root,
+      compilerOptions,
+    );
+    if (warning) {
+      warnings.push(warning);
+    }
+  }
+
+  return warnings;
+};
+
+// ---------------------------------------------------------------------------
+// Single call-expression analysis
+// ---------------------------------------------------------------------------
+
+const analyzeSpyCall = async (
+  spyCall: SgNode,
+  filePath: string,
+  root: SgNode,
+  compilerOptions: ts.CompilerOptions,
+): Promise<SameFileSpyWarning | undefined> => {
+  const args = spyCall.children().find((c) => c.kind() === 'arguments');
+  if (!args) {
+    return undefined;
+  }
+
+  // arguments node children: '(', arg1, ',', arg2, ..., ')'
+  const argList = args
+    .children()
+    .filter((c) => c.kind() !== '(' && c.kind() !== ')' && c.kind() !== ',');
+
+  // We need at least two arguments: the namespace object and the method name.
+  // Outer chained calls (e.g. .mockResolvedValue) only have 1 argument.
+  if (argList.length < 2) {
+    return undefined;
+  }
+
+  const namespaceNode = argList[0];
+  const methodNode = argList[1];
+
+  if (!namespaceNode || !methodNode) {
+    return undefined;
+  }
+
+  const namespaceName = namespaceNode.text().trim();
+  // Strip surrounding quotes  (" ' `)
+  const spiedFunction = methodNode.text().replace(/^['"`]|['"`]$/g, '');
+
+  // Find: import * as <namespaceName> from '<specifier>'
+  const importStatement = root.find({
+    rule: {
+      kind: 'import_statement',
+      has: {
+        kind: 'import_clause',
+        has: {
+          kind: 'namespace_import',
+          has: {
+            kind: 'identifier',
+            regex: `^${namespaceName}$`,
+          },
+        },
+      },
+    },
+  });
+
+  if (!importStatement) {
+    return undefined;
+  }
+
+  // The string literal child of the import_statement is the module specifier.
+  const specifierNode = importStatement
+    .children()
+    .find((c) => c.kind() === 'string');
+  if (!specifierNode) {
+    return undefined;
+  }
+
+  const specifier = specifierNode.text().replace(/^['"`]|['"`]$/g, '');
+
+  // Resolve the specifier to an absolute file path via the TypeScript resolver.
+  // This handles `#src/...` subpath imports, path aliases, and custom conditions.
+  const resolved = ts.resolveModuleName(
+    specifier,
+    path.resolve(filePath),
+    compilerOptions,
+    ts.sys,
+  );
+
+  const resolvedFile = resolved.resolvedModule?.resolvedFileName;
+  if (!resolvedFile) {
+    return undefined;
+  }
+
+  // Check whether the spied function appears as an internal usage in the
+  // resolved module (i.e. referenced somewhere other than its own declaration).
+  const internallyUsed = await isFunctionUsedInternally(
+    resolvedFile,
+    spiedFunction,
+  );
+
+  if (!internallyUsed) {
+    return undefined;
+  }
+
+  const warning: SameFileSpyWarning = {
+    testFile: filePath,
+    importSpecifier: specifier,
+    resolvedFile,
+    spiedFunction,
+  };
+
+  return warning;
+};
+
+// ---------------------------------------------------------------------------
+// Internal-usage check
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` if `functionName` is referenced in `filePath` at least once
+ * outside of its own declaration — meaning the module's internal code binds
+ * to the local symbol rather than the exported binding.
+ */
+const isFunctionUsedInternally = async (
+  filePath: string,
+  functionName: string,
+): Promise<boolean> => {
+  let content: string;
+  try {
+    content = await fs.promises.readFile(filePath, 'utf8');
+  } catch {
+    return false;
+  }
+
+  const ast = await parseAsync('TypeScript', content);
+  const root = ast.root();
+
+  // Find every identifier whose text exactly matches the function name.
+  const identifiers = root.findAll({
+    rule: {
+      kind: 'identifier',
+      regex: `^${functionName}$`,
+    },
+  });
+
+  for (const id of identifiers) {
+    const parent = id.parent();
+    if (!parent) {
+      continue;
+    }
+
+    const parentKind = parent.kind();
+
+    // Skip the declaration name inside `variable_declarator` (`const name = …`).
+    // The name is always the very first child of the declarator node.
+    if (parentKind === 'variable_declarator') {
+      const firstChild = parent.children()[0];
+      if (firstChild?.range().start.index === id.range().start.index) {
+        continue;
+      }
+    }
+
+    // Skip `function functionName() { … }` declarations.
+    if (parentKind === 'function_declaration') {
+      continue;
+    }
+
+    // Skip import/export specifiers (`import { functionName }`, `export { functionName }`).
+    if (
+      parentKind === 'import_specifier' ||
+      parentKind === 'export_specifier' ||
+      parentKind === 'namespace_import'
+    ) {
+      continue;
+    }
+
+    // Skip TypeScript type-level references.
+    if (
+      parentKind === 'type_identifier' ||
+      parentKind === 'type_query' ||
+      parentKind === 'property_signature'
+    ) {
+      continue;
+    }
+
+    // Any other position is a runtime reference to the local binding.
+    return true;
+  }
+
+  return false;
+};
+
+// ---------------------------------------------------------------------------
+// TypeScript compiler options helper
+// ---------------------------------------------------------------------------
+
+const loadCompilerOptions = (filePath: string): ts.CompilerOptions => {
+  const configFile = ts.findConfigFile(
+    path.dirname(path.resolve(filePath)),
+    (f) => ts.sys.fileExists(f),
+  );
+
+  if (!configFile) {
+    return { noEmit: true };
+  }
+
+  const readResult = ts.readConfigFile(configFile, (f) => ts.sys.readFile(f));
+
+  if (readResult.error) {
+    return { noEmit: true };
+  }
+
+  const { options } = ts.parseJsonConfigFileContent(
+    readResult.config,
+    ts.sys,
+    path.dirname(configFile),
+  );
+
+  return { ...options, noEmit: true };
+};

--- a/packages/detect-invalid-spies/src/index.ts
+++ b/packages/detect-invalid-spies/src/index.ts
@@ -198,7 +198,7 @@ const analyzeSpyCall = async (
   );
 
   const resolvedFile = resolved.resolvedModule?.resolvedFileName;
-  if (!resolvedFile) {
+  if (!resolvedFile || resolvedFile.includes('/node_modules/')) {
     return undefined;
   }
 

--- a/packages/detect-invalid-spies/tsconfig.json
+++ b/packages/detect-invalid-spies/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "declaration": true,
+    "lib": ["ES2023"],
+    "outDir": "lib",
+    "removeComments": false,
+    "skipLibCheck": true, // tsdown has optional peer deps
+    "target": "ES2023"
+  },
+  "exclude": ["lib*/**/*"],
+  "extends": "../../config/tsconfig.json"
+}

--- a/packages/detect-invalid-spies/tsdown.config.mts
+++ b/packages/detect-invalid-spies/tsdown.config.mts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'tsdown/config';
+
+export default defineConfig({
+  failOnWarn: true,
+  entry: ['src/index.ts', 'src/bin.ts'],
+  dts: true,
+  format: ['esm'],
+  outDir: 'lib',
+  exports: {
+    devExports: '@seek/skuba/source',
+  },
+  checks: {
+    legacyCjs: false,
+  },
+  attw: {
+    profile: 'esm-only',
+  },
+  publint: true,
+});

--- a/packages/detect-invalid-spies/vitest.config.ts
+++ b/packages/detect-invalid-spies/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      thresholds: {
+        branches: 100,
+        functions: 100,
+        lines: 100,
+        statements: 100,
+      },
+    },
+    exclude: ['**/node_modules'],
+  },
+});

--- a/packages/detect-invalid-spies/vitest.config.ts
+++ b/packages/detect-invalid-spies/vitest.config.ts
@@ -2,14 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    coverage: {
-      thresholds: {
-        branches: 100,
-        functions: 100,
-        lines: 100,
-        statements: 100,
-      },
-    },
     exclude: ['**/node_modules'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,21 @@ importers:
         specifier: ^4.3.5
         version: 4.3.6
 
+  packages/detect-invalid-spies:
+    dependencies:
+      '@ast-grep/napi':
+        specifier: ^0.42.0
+        version: 0.42.0
+      fast-glob:
+        specifier: ^3.3.2
+        version: 3.3.3
+      fs-extra:
+        specifier: ^11.0.0
+        version: 11.3.4
+      typescript:
+        specifier: ~5.9.0
+        version: 5.9.3
+
   packages/eslint-config-skuba:
     dependencies:
       eslint-config-seek:


### PR DESCRIPTION
Vibe coded a little something something for detecting invalid spy usage when migrating from Jest -> Vitest. This was a little difficult to throw into a lint rule and I figure it'll mostly be for 1 time runs to get from Jest -> Vitest.
