### PR TITLE
tsdown config: Resolve #src alias

### DIFF
--- a/.changeset/public-llamas-beam.md
+++ b/.changeset/public-llamas-beam.md
@@ -1,5 +1,5 @@
 ---
-'skuba': minor
+'skuba': patch
 ---
 
-build: Resolve #src alias to ./src directory during package builds
+template/\*-npm-package: Resolve `#src` alias to `./src` directory during package builds

--- a/.changeset/public-llamas-beam.md
+++ b/.changeset/public-llamas-beam.md
@@ -1,0 +1,5 @@
+---
+'skuba': minor
+---
+
+build: Resolve #src alias to ./src directory during package builds

--- a/template/oss-npm-package/_package.json
+++ b/template/oss-npm-package/_package.json
@@ -9,6 +9,12 @@
   "license": "MIT",
   "type": "module",
   "sideEffects": false,
+  "imports": {
+    "#src/*": {
+      "@seek/<%- moduleName %>/source": "./src/*",
+      "default": "./lib/*"
+    }
+  },
   "exports": {
     ".": {
       "@seek/<%- moduleName %>/source": "./src/index.ts",

--- a/template/oss-npm-package/tsdown.config.mts
+++ b/template/oss-npm-package/tsdown.config.mts
@@ -6,6 +6,13 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   outDir: 'lib',
   dts: true,
+  inputOptions: {
+    resolve: {
+      alias: {
+        '#src': './src',
+      },
+    },
+  },
   checks: {
     legacyCjs: false,
   },

--- a/template/private-npm-package/_package.json
+++ b/template/private-npm-package/_package.json
@@ -9,6 +9,12 @@
   "license": "UNLICENSED",
   "sideEffects": false,
   "type": "module",
+  "imports": {
+    "#src/*": {
+      "@seek/<%- moduleName %>/source": "./src/*",
+      "default": "./lib/*"
+    }
+  },
   "exports": {
     ".": {
       "@seek/<%- moduleName %>/source": "./src/index.ts",

--- a/template/private-npm-package/tsdown.config.mts
+++ b/template/private-npm-package/tsdown.config.mts
@@ -6,6 +6,13 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   outDir: 'lib',
   dts: true,
+  inputOptions: {
+    resolve: {
+      alias: {
+        '#src': './src',
+      },
+    },
+  },
   checks: {
     legacyCjs: false,
   },


### PR DESCRIPTION
This setting supports bundling packages which are using the `#src` alias. Otherwise `attw` will throw an error to prevent `#src` imports from making an appearance in the bundled types (both `.mts` and `.cts`).

ie `import { DomainConfig as DomainConfig$1 } from "#src/types.js";`

Sample error during build-package detected by `attw`:

 ERROR  [attw] problems found:
  💥 Internal resolution error in /node_modules/@ts-internal/interactions-domain/lib/index.d.cts (node10)
     Module: #src/types.js | Mode: undefined
  💥 Internal resolution error in /node_modules/@ts-internal/interactions-domain/lib/index.d.cts (node16)
     Module: #src/types.js | Mode: 1
  💥 Internal resolution error in /node_modules/@ts-internal/interactions-domain/lib/index.d.mts (node16)
     Module: #src/types.js | Mode: 99
  💥 Internal resolution error in /node_modules/@ts-internal/interactions-domain/lib/index.d.mts (bundler)
     Module: #src/types.js | Mode: 99

reference PR where the fix was originally applied:
https://github.com/SEEK-Jobs/talentsearch-systems/pull/1455/