### PR TITLE
Clean up `hot-shots` versioning

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,11 +393,11 @@ importers:
         specifier: ^5.0.0
         version: 5.2.1
       hot-shots:
-        specifier: ^14.3.1 || ~14.2.0
-        version: 14.2.0
+        specifier: ^14.3.1
+        version: 14.3.1
       seek-datadog-custom-metrics:
         specifier: ^8.0.0
-        version: 8.0.0(datadog-lambda-js@12.137.0)(hot-shots@14.2.0)
+        version: 8.0.0(datadog-lambda-js@12.137.0)(hot-shots@14.3.1)
       skuba-dive:
         specifier: workspace:*
         version: link:../../packages/skuba-dive
@@ -467,8 +467,8 @@ importers:
         specifier: ^12.0.0
         version: 12.0.0
       hot-shots:
-        specifier: ^14.3.1 || ~14.2.0
-        version: 14.2.0
+        specifier: ^14.3.1
+        version: 14.3.1
       koa:
         specifier: ^3.0.1
         version: 3.1.2
@@ -477,10 +477,10 @@ importers:
         version: 4.1.0
       seek-datadog-custom-metrics:
         specifier: ^8.0.0
-        version: 8.0.0(datadog-lambda-js@12.137.0)(hot-shots@14.2.0)
+        version: 8.0.0(datadog-lambda-js@12.137.0)(hot-shots@14.3.1)
       seek-koala:
         specifier: ^8.0.0
-        version: 8.0.0(hot-shots@14.2.0)(koa@3.1.2)
+        version: 8.0.0(hot-shots@14.3.1)(koa@3.1.2)
       skuba-dive:
         specifier: workspace:*
         version: link:../../packages/skuba-dive
@@ -4406,8 +4406,8 @@ packages:
     resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  hot-shots@14.2.0:
-    resolution: {integrity: sha512-MiEPF/VsmzY2MnfjxDNTEwrDUa+51WeYugLZkzhEqNsWoY0TgwWH3FIDT7QKzOq6K79A5w3tIBxcdyFWeJ6jbg==}
+  hot-shots@14.3.1:
+    resolution: {integrity: sha512-2mKuFf3quca37vsT4u4BW9nUZIaz1uuHSpLG0uFQxdg6QAuNU8QnMU6tpEyX/EJe1oEgOrdmFq+DL0NrBIKhkA==}
     engines: {node: '>=18.0.0'}
 
   html-escaper@2.0.2:
@@ -11814,7 +11814,7 @@ snapshots:
     dependencies:
       lru-cache: 11.2.7
 
-  hot-shots@14.2.0:
+  hot-shots@14.3.1:
     optionalDependencies:
       unix-dgram: 2.0.7
 
@@ -13784,19 +13784,19 @@ snapshots:
 
   secure-json-parse@4.1.0: {}
 
-  seek-datadog-custom-metrics@8.0.0(datadog-lambda-js@12.137.0)(hot-shots@14.2.0):
+  seek-datadog-custom-metrics@8.0.0(datadog-lambda-js@12.137.0)(hot-shots@14.3.1):
     dependencies:
       '@types/aws-lambda': 8.10.161
     optionalDependencies:
       datadog-lambda-js: 12.137.0
-      hot-shots: 14.2.0
+      hot-shots: 14.3.1
 
-  seek-koala@8.0.0(hot-shots@14.2.0)(koa@3.1.2):
+  seek-koala@8.0.0(hot-shots@14.3.1)(koa@3.1.2):
     dependencies:
       http-errors: 1.8.1
       koa: 3.1.2
     optionalDependencies:
-      hot-shots: 14.2.0
+      hot-shots: 14.3.1
 
   semantic-release@25.0.3(typescript@5.9.3):
     dependencies:

--- a/template/express-rest-api/package.json
+++ b/template/express-rest-api/package.json
@@ -29,7 +29,7 @@
     "@opentelemetry/sdk-node": "~0.214.0",
     "@seek/logger": "^12.0.0",
     "express": "^5.0.0",
-    "hot-shots": "^14.3.1 || ~14.2.0",
+    "hot-shots": "^14.3.1",
     "seek-datadog-custom-metrics": "^8.0.0",
     "skuba-dive": "^4.0.1"
   },

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -30,7 +30,7 @@
     "@opentelemetry/propagator-b3": "^2.0.0",
     "@opentelemetry/sdk-node": "~0.214.0",
     "@seek/logger": "^12.0.0",
-    "hot-shots": "^14.3.1 || ~14.2.0",
+    "hot-shots": "^14.3.1",
     "koa": "^3.0.1",
     "koa-compose": "^4.1.0",
     "seek-datadog-custom-metrics": "^8.0.0",


### PR DESCRIPTION
v14.3.1 exists now.

https://github.com/bdeitte/hot-shots/blob/main/CHANGES.md#1431-2026-4-6