### PR TITLE
Relax type definitions for vitest-koa-mocks

### DIFF
--- a/.changeset/bold-sites-fix.md
+++ b/.changeset/bold-sites-fix.md
@@ -1,0 +1,5 @@
+---
+'@skuba-lib/vitest-koa-mocks': patch
+---
+
+Relax `session` and `state` option types in `createMockContext` from `Record<string, unknown>` to `Record<string, any>`

--- a/packages/vitest-koa-mocks/src/createMockContext/createMockContext.ts
+++ b/packages/vitest-koa-mocks/src/createMockContext/createMockContext.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import stream from 'stream';
 
 import Koa, { type Context } from 'koa';
@@ -25,10 +26,10 @@ export interface Options<
   url?: string;
   method?: RequestMethod;
   statusCode?: number;
-  session?: Record<string, unknown>;
+  session?: Record<string, any>;
   headers?: Record<string, string>;
   cookies?: Record<string, string>;
-  state?: Record<string, unknown>;
+  state?: Record<string, any>;
   encrypted?: boolean;
   host?: string;
   requestBody?: RequestBody;
@@ -99,7 +100,7 @@ export const createMockContext = <
 
   // Some functions we call in the implementations will perform checks for `req.encrypted`, which delegates to the socket.
   // MockRequest doesn't set a fake socket itself, so we create one here.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   req.socket = new stream.Duplex() as any;
   Object.defineProperty(req.socket, 'encrypted', {
     writable: false,
@@ -114,10 +115,10 @@ export const createMockContext = <
 
   // This is to get around an odd behavior in the `cookies` library, where if `res.set` is defined, it will use an internal
   // node function to set headers, which results in them being set in the wrong place.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   res.set = undefined as any;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   const context = app.createContext(req, res as any) as MockContext &
     CustomProperties;
   Object.assign(context, extensions);


### PR DESCRIPTION
Ran into some grief in migrating.

Setting these to `any` seems to make it happy which aligns with the [original types](https://github.com/Shopify/quilt/blob/d98672060fc724f3fe7af9a25a0845b8d7c0774a/packages/jest-koa-mocks/src/create-mock-context/create-mock-context.ts#L34)