### PR TITLE
Prevent running this version's patches on self

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,6 @@
     "entryPoint": "src/index.ts",
     "template": null,
     "type": "package",
-    "version": "15.3.0"
+    "version": "16.0.0"
   }
 }


### PR DESCRIPTION
https://github.com/seek-oss/skuba/pull/2286 is running the replace global vars patch and messing up our own patches 😆 