### PR TITLE
Patch instrumentation libraries

### DIFF
--- a/.changeset/neat-steaks-like.md
+++ b/.changeset/neat-steaks-like.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/\*: Migrate to ESM

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -197,8 +197,14 @@ The following changes are made:
 
 - type `module` is added to `package.json` files
 - CommonJS syntax is replaced with ESM syntax in source files, test files, and configuration files
+  - `__dirname` and `__filename` are replaced with `import.meta.dirname` and `import.meta.filename`.
+  - `module.exports` are replaced with `export default` or named exports as appropriate
+  - `.json` imports are updated to include `with { type: 'json' }`
+  - `require()` calls are replaced with `import` statements or dynamic `import()` as appropriate
+- Datadog and OpenTelemetry instrumentation ESM imports are added to Dockerfiles
 - AWS CDK worker and Serverless files are migrated to ESM format
 - ESLint config files and Prettier config files are migrated to ESM format
+- `vocab.config.js` is migrated to `vocab.config.cjs`
 - Jest is replaced with Vitest as the test runner
   - The [sku codemod] is run along with additional transformations to fix additional cases
   - `aws-sdk-client-mock-jest` → `aws-sdk-client-mock-vitest` + `@types/node`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-grpc':
         specifier: ~0.216.0
         version: 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
+        specifier: ~0.216.0
+        version: 0.216.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-aws-sdk':
         specifier: ^0.71.0
         version: 0.71.0(@opentelemetry/api@1.9.1)
@@ -468,6 +471,9 @@ importers:
         specifier: ~2.7.0
         version: 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-grpc':
+        specifier: ~0.216.0
+        version: 0.216.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
         specifier: ~0.216.0
         version: 0.216.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-aws-sdk':

--- a/src/cli/format/__snapshots__/format.int.test.ts.snap
+++ b/src/cli/format/__snapshots__/format.int.test.ts.snap
@@ -90,6 +90,8 @@ Patch skipped: Migrate Lambdas to ESM - no lambdas to migrate
 
 Patch skipped: Migrate Dockerfiles to replace --require with --import - no Dockerfile files found
 
+Patch skipped: Patch Dockerfile CMD lines to add dd-trace or opentelemetry imports - no Dockerfile files found
+
 Patch skipped: Migrate from Jest to Vitest - skipping in integration test environment
 
 Patch applied: Migrate to ESM upgrade-skuba
@@ -235,6 +237,8 @@ Patch skipped: Migrate Lambdas to ESM - no lambdas to migrate
 
 Patch skipped: Migrate Dockerfiles to replace --require with --import - no Dockerfile files found
 
+Patch skipped: Patch Dockerfile CMD lines to add dd-trace or opentelemetry imports - no Dockerfile files found
+
 Patch skipped: Migrate from Jest to Vitest - skipping in integration test environment
 
 Patch applied: Migrate to ESM upgrade-skuba
@@ -373,6 +377,8 @@ Patch skipped: Migrate Lambdas to ESM - no lambdas to migrate
 
 Patch skipped: Migrate Dockerfiles to replace --require with --import - no Dockerfile files found
 
+Patch skipped: Patch Dockerfile CMD lines to add dd-trace or opentelemetry imports - no Dockerfile files found
+
 Patch skipped: Migrate from Jest to Vitest - skipping in integration test environment
 
 Patch applied: Migrate to ESM upgrade-skuba
@@ -482,6 +488,8 @@ Patch skipped: Upgrade skuba-dive to support ESM - no package.json or pnpm-works
 Patch skipped: Migrate Lambdas to ESM - no lambdas to migrate
 
 Patch skipped: Migrate Dockerfiles to replace --require with --import - no Dockerfile files found
+
+Patch skipped: Patch Dockerfile CMD lines to add dd-trace or opentelemetry imports - no Dockerfile files found
 
 Patch skipped: Migrate from Jest to Vitest - skipping in integration test environment
 

--- a/src/cli/migrate/esm/index.ts
+++ b/src/cli/migrate/esm/index.ts
@@ -16,6 +16,7 @@ import { migrateExportEqualsToDefaultPatch } from './migrateExportEqualsToDefaul
 import { migrateImportExportStatementsPatch } from './migrateImportExportStatements.js';
 import { tryMigrateLambdas } from './migrateLambdas.js';
 import { tryMigrateVocab } from './migrateVocab.js';
+import { tryPatchInstrumentation } from './patchInstrumentation.js';
 import { rewriteGlobalVars } from './rewriteGlobalVars.js';
 import { tryUpgradeSkubaDive } from './upgradeSkubaDive.js';
 import { migrateToVitest } from './vitest/vitest.js';
@@ -58,6 +59,11 @@ const patches: Patch[] = [
   {
     apply: tryMigrateDockerfileRequires,
     description: 'Migrate Dockerfiles to replace --require with --import',
+  },
+  {
+    apply: tryPatchInstrumentation,
+    description:
+      'Patch Dockerfile CMD lines to add dd-trace or opentelemetry imports',
   },
   {
     apply: migrateToVitest,

--- a/src/cli/migrate/esm/patchInstrumentation.test.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.test.ts
@@ -1,0 +1,266 @@
+import memfs, { vol } from 'memfs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { log } from '../../../utils/logging.js';
+import { configForPackageManager } from '../../../utils/packageManager.js';
+import type {
+  PatchConfig,
+  PatchReturnType,
+} from '../../lint/internalLints/upgrade/index.js';
+
+import { patchInstrumentation } from './patchInstrumentation.js';
+
+vi.mock('../../../../../../utils/exec.js', () => ({
+  createExec: () => vi.fn(),
+}));
+
+vi.mock('fs-extra', () => ({
+  default: memfs.fs,
+  ...memfs.fs,
+}));
+vi.mock('fast-glob', () => ({
+  default: async (pat: any, opts: any) => {
+    const actualFastGlob =
+      await vi.importActual<typeof import('fast-glob')>('fast-glob');
+    return actualFastGlob.glob(pat, { ...opts, fs: memfs });
+  },
+}));
+
+const volToJson = () => vol.toJSON(process.cwd(), undefined, true);
+
+beforeEach(() => {
+  vol.reset();
+  vi.clearAllMocks();
+});
+
+const baseArgs: PatchConfig = {
+  manifest: {
+    packageJson: {
+      name: 'test',
+      version: '1.0.0',
+      readme: 'README.md',
+      _id: 'test',
+    },
+    path: 'package.json',
+  },
+  packageManager: configForPackageManager('yarn'),
+  mode: 'format',
+};
+
+describe('patchInstrumentation', () => {
+  it('should skip if no Dockerfile files are found', async () => {
+    await expect(
+      patchInstrumentation({
+        ...baseArgs,
+        mode: 'format',
+      }),
+    ).resolves.toEqual({
+      result: 'skip',
+      reason: 'no Dockerfile files found',
+    } satisfies PatchReturnType);
+  });
+
+  it('should skip if no imports for Datadog or OpenTelemetry instrumentation are found in source files', async () => {
+    vol.fromJSON({
+      Dockerfile: '',
+      'src/index.ts': '',
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'skip',
+      reason:
+        'no imports for Datadog or OpenTelemetry instrumentation found in source files',
+    } satisfies PatchReturnType);
+  });
+
+  it('should patch a Dockerfile with dd-trace import and explicit node CMD', async () => {
+    vol.fromJSON({
+      Dockerfile: `FROM node:14
+CMD ["node", "lib/listen.js"]`,
+      'src/index.ts': "import tracer from 'dd-trace';",
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD ["node", "--import", "dd-trace/initialize.mjs", "lib/listen.js"]",
+        "src/index.ts": "import tracer from 'dd-trace';",
+      }
+    `);
+  });
+
+  it('should patch a Dockerfile with @opentelemetry/api import and explicit node CMD', async () => {
+    vol.fromJSON({
+      Dockerfile: `FROM node:14
+CMD ["node", "lib/listen.js"]`,
+      'src/index.ts': "import { trace } from '@opentelemetry/api';",
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD ["node", "--experimental-loader", "@opentelemetry/instrumentation/hook.mjs", "lib/listen.js"]",
+        "src/index.ts": "import { trace } from '@opentelemetry/api';",
+      }
+    `);
+  });
+
+  it('should patch a Dockerfile with both dd-trace and @opentelemetry/api imports and explicit node CMD', async () => {
+    const logWarnSpy = vi
+      .spyOn(log, 'warn')
+      .mockImplementation(() => undefined);
+
+    vol.fromJSON({
+      Dockerfile: `FROM node:14
+CMD ["node", "lib/listen.js"]`,
+      'src/index.ts': `
+          import tracer from 'dd-trace';
+          import { trace } from '@opentelemetry/api';
+        `,
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      'Found imports for both Datadog and OpenTelemetry instrumentation in source files, unsure which to patch',
+    );
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD ["node", "--import", "dd-trace/initialize.mjs", "--experimental-loader", "@opentelemetry/instrumentation/hook.mjs", "lib/listen.js"]",
+        "src/index.ts": "
+                import tracer from 'dd-trace';
+                import { trace } from '@opentelemetry/api';
+              ",
+      }
+    `);
+  });
+
+  it('should patch a Dockerfile with dd-trace import and implicit node CMD', async () => {
+    vol.fromJSON(
+      {
+        Dockerfile: `FROM node:14
+CMD ["lib/listen.js"]`,
+        'src/index.ts': "import tracer from 'dd-trace';",
+      },
+      process.cwd(),
+    );
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD ["--import", "dd-trace/initialize.mjs", "lib/listen.js"]",
+        "src/index.ts": "import tracer from 'dd-trace';",
+      }
+    `);
+  });
+
+  it('should patch a Dockerfile with @opentelemetry/api import and implicit node CMD', async () => {
+    vol.fromJSON({
+      Dockerfile: `FROM node:14
+CMD ["lib/listen.js"]`,
+      'src/index.ts': "import { trace } from '@opentelemetry/api';",
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD ["--experimental-loader", "@opentelemetry/instrumentation/hook.mjs", "lib/listen.js"]",
+        "src/index.ts": "import { trace } from '@opentelemetry/api';",
+      }
+    `);
+  });
+
+  it('should patch a Dockerfile with a dd-trace import and shell form CMD', async () => {
+    vol.fromJSON({
+      Dockerfile: `FROM node:14
+CMD node lib/listen.js`,
+      'src/index.ts': "import tracer from 'dd-trace';",
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD node --import dd-trace/initialize.mjs lib/listen.js",
+        "src/index.ts": "import tracer from 'dd-trace';",
+      }
+    `);
+  });
+
+  it('should patch a Dockerfile with a @opentelemetry/api import and shell form CMD', async () => {
+    vol.fromJSON({
+      Dockerfile: `FROM node:14
+CMD node lib/listen.js`,
+      'src/index.ts': "import { trace } from '@opentelemetry/api';",
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD node --experimental-loader @opentelemetry/instrumentation/hook.mjs lib/listen.js",
+        "src/index.ts": "import { trace } from '@opentelemetry/api';",
+      }
+    `);
+  });
+
+  it('should patch a Dockerfile with both dd-trace and @opentelemetry/api imports and shell form CMD', async () => {
+    const logWarnSpy = vi
+      .spyOn(log, 'warn')
+      .mockImplementation(() => undefined);
+
+    vol.fromJSON({
+      Dockerfile: `FROM node:14
+CMD node lib/listen.js`,
+      'src/index.ts': `
+          import tracer from 'dd-trace';
+          import { trace } from '@opentelemetry/api';
+        `,
+    });
+
+    await expect(patchInstrumentation(baseArgs)).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(logWarnSpy).toHaveBeenCalledWith(
+      'Found imports for both Datadog and OpenTelemetry instrumentation in source files, unsure which to patch',
+    );
+
+    expect(volToJson()).toMatchInlineSnapshot(`
+      {
+        "Dockerfile": "FROM node:14
+      CMD node --import dd-trace/initialize.mjs --experimental-loader @opentelemetry/instrumentation/hook.mjs lib/listen.js",
+        "src/index.ts": "
+                import tracer from 'dd-trace';
+                import { trace } from '@opentelemetry/api';
+              ",
+      }
+    `);
+  });
+});

--- a/src/cli/migrate/esm/patchInstrumentation.test.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.test.ts
@@ -138,7 +138,7 @@ CMD ["node", "lib/listen.js"]`,
     expect(volToJson()).toMatchInlineSnapshot(`
       {
         "Dockerfile": "FROM node:14
-      CMD ["node", "--import", "dd-trace/initialize.mjs", "--experimental-loader", "@opentelemetry/instrumentation/hook.mjs", "lib/listen.js"]",
+      CMD ["node", TODO: skuba failed to determine whether to add dd-trace or OpenTelemetry flags, please choose the appropriate flags to add to your Dockerfile "--import", "dd-trace/initialize.mjs", "--experimental-loader", "@opentelemetry/instrumentation/hook.mjs", "lib/listen.js"]",
         "src/index.ts": "
                 import tracer from 'dd-trace';
                 import { trace } from '@opentelemetry/api';
@@ -255,7 +255,7 @@ CMD node lib/listen.js`,
     expect(volToJson()).toMatchInlineSnapshot(`
       {
         "Dockerfile": "FROM node:14
-      CMD node --import dd-trace/initialize.mjs --experimental-loader @opentelemetry/instrumentation/hook.mjs lib/listen.js",
+      CMD node TODO: skuba failed to determine whether to add dd-trace or OpenTelemetry flags, please choose the appropriate flags to add to your Dockerfile --import dd-trace/initialize.mjs --experimental-loader @opentelemetry/instrumentation/hook.mjs lib/listen.js",
         "src/index.ts": "
                 import tracer from 'dd-trace';
                 import { trace } from '@opentelemetry/api';

--- a/src/cli/migrate/esm/patchInstrumentation.test.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.test.ts
@@ -10,7 +10,7 @@ import type {
 
 import { patchInstrumentation } from './patchInstrumentation.js';
 
-vi.mock('../../../../../../utils/exec.js', () => ({
+vi.mock('../../../utils/exec.js', () => ({
   createExec: () => vi.fn(),
 }));
 

--- a/src/cli/migrate/esm/patchInstrumentation.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.ts
@@ -69,6 +69,11 @@ export const patchInstrumentation: PatchFunction = async ({
     );
   }
 
+  const warning =
+    hasDDTraceImport && hasOpenTelemetryImport
+      ? 'TODO: skuba failed to determine whether to add dd-trace or OpenTelemetry flags, please choose the appropriate flags to add to your Dockerfile '
+      : '';
+
   const commandsToAdd = [
     hasDDTraceImport ? '--import dd-trace/initialize.mjs' : '',
     hasOpenTelemetryImport
@@ -95,7 +100,7 @@ export const patchInstrumentation: PatchFunction = async ({
         if (cmd.startsWith('node ')) {
           const patchedCmd = cmd.replace(
             'node ',
-            `node ${commandsToAdd.join(' ')} `,
+            `node ${warning}${commandsToAdd.join(' ')} `,
           );
           return { filePath, content: content.replace(cmd, patchedCmd) };
         }
@@ -115,7 +120,7 @@ export const patchInstrumentation: PatchFunction = async ({
       if (/^\s*\[\s*"node"\s*[,\]]/.test(cmd)) {
         const patchedCmd = cmd.replace(
           /^(\s*\[\s*"node"\s*)([,\]])/,
-          `$1, ${flags}$2`,
+          `$1, ${warning}${flags}$2`,
         );
 
         return { filePath, content: content.replace(cmd, patchedCmd) };

--- a/src/cli/migrate/esm/patchInstrumentation.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.ts
@@ -92,7 +92,6 @@ export const patchInstrumentation: PatchFunction = async ({
       const isShellForm = !cmd.startsWith('[');
 
       if (isShellForm) {
-        // first arg is node
         if (cmd.startsWith('node ')) {
           const patchedCmd = cmd.replace(
             'node ',
@@ -141,8 +140,6 @@ export const patchInstrumentation: PatchFunction = async ({
   }
 
   if (hasOpenTelemetryImport) {
-    // Make sure these dirs have the instrumentation package as a dependency
-
     const packageJsons = await Promise.all(
       otelImports.map(async ({ filePath }) =>
         getConsumerManifest(dirname(filePath)),

--- a/src/cli/migrate/esm/patchInstrumentation.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.ts
@@ -1,12 +1,18 @@
+import { dirname } from 'path';
 import { inspect } from 'util';
 
 import fg from 'fast-glob';
 import fs from 'fs-extra';
 
+import { createExec } from '../../../utils/exec.js';
 import { log } from '../../../utils/logging.js';
+import { getConsumerManifest } from '../../../utils/manifest.js';
 import type { PatchFunction } from '../../lint/internalLints/upgrade/index.js';
 
-export const patchInstrumentation: PatchFunction = async ({ mode }) => {
+export const patchInstrumentation: PatchFunction = async ({
+  mode,
+  packageManager,
+}) => {
   const [dockerfilePaths, tsPaths] = await Promise.all([
     fg(['**/Dockerfile*'], {
       ignore: ['**/.git', '**/node_modules'],
@@ -41,9 +47,11 @@ export const patchInstrumentation: PatchFunction = async ({ mode }) => {
   const hasDDTraceImport = tsFiles.some(({ content }) =>
     /from\s+['"]dd-trace['"]/.test(content),
   );
-  const hasOpenTelemetryImport = tsFiles.some(({ content }) =>
+  const otelImports = tsFiles.filter(({ content }) =>
     /from\s+['"]@opentelemetry\/api['"]/.test(content),
   );
+
+  const hasOpenTelemetryImport = otelImports.length > 0;
 
   if (!hasDDTraceImport && !hasOpenTelemetryImport) {
     return {
@@ -130,6 +138,48 @@ export const patchInstrumentation: PatchFunction = async ({ mode }) => {
     return {
       result: 'apply',
     };
+  }
+
+  if (hasOpenTelemetryImport) {
+    // Make sure these dirs have the instrumentation package as a dependency
+
+    const packageJsons = await Promise.all(
+      otelImports.map(async ({ filePath }) =>
+        getConsumerManifest(dirname(filePath)),
+      ),
+    );
+
+    await Promise.all(
+      packageJsons
+        .filter((pkg) => pkg !== undefined)
+        .map(async (pkg) => {
+          const { packageJson, path } = pkg;
+
+          if (
+            packageJson.dependencies?.['@opentelemetry/instrumentation'] ||
+            packageJson.devDependencies?.['@opentelemetry/instrumentation']
+          ) {
+            return;
+          }
+
+          const folderExec = createExec({ cwd: dirname(path) });
+          if (packageManager.command === 'pnpm') {
+            return folderExec(
+              'pnpm',
+              'install',
+              '@opentelemetry/instrumentation@0.216.0',
+              '--prefer-offline',
+              '--ignore-workspace-root-check',
+            );
+          }
+          return folderExec(
+            'yarn',
+            'add',
+            '@opentelemetry/instrumentation@0.216.0',
+            '--prefer-offline',
+          );
+        }),
+    );
   }
 
   await Promise.all(

--- a/src/cli/migrate/esm/patchInstrumentation.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.ts
@@ -1,0 +1,156 @@
+import { inspect } from 'util';
+
+import fg from 'fast-glob';
+import fs from 'fs-extra';
+
+import { log } from '../../../utils/logging.js';
+import type { PatchFunction } from '../../lint/internalLints/upgrade/index.js';
+
+export const patchInstrumentation: PatchFunction = async ({ mode }) => {
+  const [dockerfilePaths, tsPaths] = await Promise.all([
+    fg(['**/Dockerfile*'], {
+      ignore: ['**/.git', '**/node_modules'],
+    }),
+    fg(['**/*.ts'], {
+      ignore: ['**/.git', '**/node_modules'],
+    }),
+  ]);
+
+  if (!dockerfilePaths.length) {
+    return {
+      result: 'skip',
+      reason: 'no Dockerfile files found',
+    };
+  }
+
+  const [dockerFiles, tsFiles] = await Promise.all([
+    Promise.all(
+      dockerfilePaths.map(async (filePath) => ({
+        filePath,
+        content: await fs.promises.readFile(filePath, 'utf-8'),
+      })),
+    ),
+    Promise.all(
+      tsPaths.map(async (filePath) => ({
+        filePath,
+        content: await fs.promises.readFile(filePath, 'utf-8'),
+      })),
+    ),
+  ]);
+
+  const hasDDTraceImport = tsFiles.some(({ content }) =>
+    /from\s+['"]dd-trace['"]/.test(content),
+  );
+  const hasOpenTelemetryImport = tsFiles.some(({ content }) =>
+    /from\s+['"]@opentelemetry\/api['"]/.test(content),
+  );
+
+  if (!hasDDTraceImport && !hasOpenTelemetryImport) {
+    return {
+      result: 'skip',
+      reason:
+        'no imports for Datadog or OpenTelemetry instrumentation found in source files',
+    };
+  }
+
+  const confused = hasDDTraceImport && hasOpenTelemetryImport;
+
+  if (confused) {
+    log.warn(
+      'Found imports for both Datadog and OpenTelemetry instrumentation in source files, unsure which to patch',
+    );
+  }
+
+  const commandsToAdd = [
+    hasDDTraceImport ? '--import dd-trace/initialize.mjs' : '',
+    hasOpenTelemetryImport
+      ? '--experimental-loader @opentelemetry/instrumentation/hook.mjs'
+      : '',
+  ].filter(Boolean);
+
+  const patched = dockerFiles
+    .map(({ filePath, content }) => {
+      if (filePath.includes('dev-deps')) {
+        return null;
+      }
+
+      const cmd = /^CMD\s+(.+)$/m.exec(content)?.[1];
+
+      if (!cmd) {
+        return null;
+      }
+
+      // check if CMD is in shell or exec form
+      const isShellForm = !cmd.startsWith('[');
+
+      if (isShellForm) {
+        // first arg is node
+        if (cmd.startsWith('node ')) {
+          const patchedCmd = cmd.replace(
+            'node ',
+            `node ${commandsToAdd.join(' ')} `,
+          );
+          return { filePath, content: content.replace(cmd, patchedCmd) };
+        }
+
+        return {
+          filePath,
+          content: content.replace(cmd, `${commandsToAdd.join(' ')} ${cmd}`),
+        };
+      }
+
+      const flags = commandsToAdd
+        .map((f) => f.split(' '))
+        .flat()
+        .map((f) => `"${f}"`)
+        .join(', ');
+
+      if (/^\s*\[\s*"node"\s*[,\]]/.test(cmd)) {
+        const patchedCmd = cmd.replace(
+          /^(\s*\[\s*"node"\s*)([,\]])/,
+          `$1, ${flags}$2`,
+        );
+
+        return { filePath, content: content.replace(cmd, patchedCmd) };
+      }
+
+      const patchedCmd = cmd.replace(/^\s*\[/, `[${flags}, `);
+      return { filePath, content: content.replace(cmd, patchedCmd) };
+    })
+    .filter((patch) => patch !== null);
+
+  if (!patched.length) {
+    return {
+      result: 'skip',
+      reason: 'no CMD instructions found in Dockerfiles to patch',
+    };
+  }
+
+  if (mode === 'lint') {
+    return {
+      result: 'apply',
+    };
+  }
+
+  await Promise.all(
+    patched.map(({ filePath, content }) =>
+      fs.promises.writeFile(filePath, content, 'utf-8'),
+    ),
+  );
+
+  return {
+    result: 'apply',
+  };
+};
+
+export const tryPatchInstrumentation: PatchFunction = async (opts) => {
+  try {
+    return await patchInstrumentation(opts);
+  } catch (err) {
+    log.warn(
+      'Failed to patch Datadog or OpenTelemetry instrumentation, skipping',
+    );
+    log.subtle(inspect(err));
+    return { result: 'skip', reason: 'due to an error' };
+  }
+};

--- a/template/express-rest-api/Dockerfile
+++ b/template/express-rest-api/Dockerfile
@@ -29,4 +29,4 @@ ARG PORT=8001
 ENV PORT=${PORT}
 EXPOSE ${PORT}
 
-CMD ["--import", "./lib/tracing.js", "./lib/listen.js"]
+CMD ["--experimental-loader", "@opentelemetry/instrumentation/hook.mjs", "--import", "./lib/tracing.js", "./lib/listen.js"]

--- a/template/express-rest-api/package.json
+++ b/template/express-rest-api/package.json
@@ -23,6 +23,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "~2.7.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "~0.216.0",
+    "@opentelemetry/instrumentation": "~0.216.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.71.0",
     "@opentelemetry/instrumentation-http": "~0.216.0",
     "@opentelemetry/propagator-b3": "^2.0.0",

--- a/template/koa-rest-api/Dockerfile
+++ b/template/koa-rest-api/Dockerfile
@@ -29,4 +29,4 @@ ARG PORT=8001
 ENV PORT=${PORT}
 EXPOSE ${PORT}
 
-CMD ["--import", "./lib/tracing.js", "./lib/listen.js"]
+CMD ["--experimental-loader", "@opentelemetry/instrumentation/hook.mjs", "--import", "./lib/tracing.js", "./lib/listen.js"]

--- a/template/koa-rest-api/package.json
+++ b/template/koa-rest-api/package.json
@@ -25,6 +25,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "~2.7.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "~0.216.0",
+    "@opentelemetry/instrumentation": "~0.216.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.71.0",
     "@opentelemetry/instrumentation-http": "~0.216.0",
     "@opentelemetry/propagator-b3": "^2.0.0",


### PR DESCRIPTION
https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/nodejs/#esm-applications-only-import-the-loader

and

https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md