### PR TITLE
pin aws-cdk-lib to ~2.252.0 to avoid issues with 2.253.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,7 +584,7 @@ importers:
         specifier: ^2.1010.0
         version: 2.1120.0
       aws-cdk-lib:
-        specifier: ^2.232.1
+        specifier: ~2.252.0
         version: 2.252.0(constructs@10.6.0)
       aws-sdk-client-mock:
         specifier: ^4.0.0

--- a/template/lambda-sqs-worker-cdk/package.json
+++ b/template/lambda-sqs-worker-cdk/package.json
@@ -34,7 +34,7 @@
     "@types/chance": "^1.1.3",
     "@types/node": "^24.10.2",
     "aws-cdk": "^2.1010.0",
-    "aws-cdk-lib": "^2.232.1",
+    "aws-cdk-lib": "~2.252.0",
     "aws-sdk-client-mock": "^4.0.0",
     "aws-sdk-client-mock-vitest": "^7.0.0",
     "chance": "^1.1.8",


### PR DESCRIPTION
Undo once:

https://github.com/DataDog/datadog-cdk-constructs/pull/600
or
https://github.com/DataDog/datadog-cdk-constructs/pull/601

are merged.