### PR TITLE
fix(lint): preserve `pnpm install --prod` in monorepo

### DIFF
--- a/.changeset/fix-prune-prod-monorepo-workaround.md
+++ b/.changeset/fix-prune-prod-monorepo-workaround.md
@@ -1,0 +1,9 @@
+---
+'skuba': patch
+---
+
+lint: Preserve `pnpm install --prod` after `pnpm prune --prod` in Dockerfiles
+
+The `pnpm install --prod` → `pnpm prune --prod` patch introduced in [#2326](https://github.com/seek-oss/skuba/pull/2326) now leaves a `RUN pnpm install … --prod` line untouched when it is immediately preceded by `RUN pnpm prune --prod`.
+
+This protects the monorepo workaround for [pnpm/pnpm#8307](https://github.com/pnpm/pnpm/issues/8307), where `pnpm prune --prod` alone does not correctly remove dev dependencies and a follow-up `pnpm install --prod` is required.

--- a/src/cli/lint/internalLints/upgrade/patches/15.3.0/patchDockerfilePruneProd.test.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/15.3.0/patchDockerfilePruneProd.test.ts
@@ -155,4 +155,80 @@ describe('patchDockerfilePruneProd', () => {
       reason: 'no dockerfiles to patch',
     } satisfies PatchReturnType);
   });
+
+  it('should skip dockerfiles where pnpm install --prod is preceded by pnpm prune --prod (monorepo workaround)', async () => {
+    vi.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
+    vi.mocked(fs.promises.readFile).mockResolvedValueOnce(
+      [
+        'FROM ${BASE_IMAGE} AS build',
+        'RUN pnpm install --offline',
+        'RUN pnpm exec nx build ${CONTEXT_APP}',
+        'RUN pnpm prune --prod',
+        'RUN pnpm install --offline --prod',
+      ].join('\n'),
+    );
+
+    await expect(
+      tryPatchDockerfilePruneProd({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual({
+      result: 'skip',
+      reason: 'no dockerfiles to patch',
+    } satisfies PatchReturnType);
+
+    expect(fs.promises.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should skip lint when pnpm install --prod is preceded by pnpm prune --prod (monorepo workaround)', async () => {
+    vi.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
+    vi.mocked(fs.promises.readFile).mockResolvedValueOnce(
+      'FROM ${BASE_IMAGE} AS build\nRUN pnpm prune --prod\nRUN pnpm install --offline --prod',
+    );
+
+    await expect(
+      tryPatchDockerfilePruneProd({
+        mode: 'lint',
+      } as PatchConfig),
+    ).resolves.toEqual({
+      result: 'skip',
+      reason: 'no dockerfiles to patch',
+    } satisfies PatchReturnType);
+
+    expect(fs.promises.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should only replace standalone pnpm install --prod lines and leave monorepo pair intact in the same Dockerfile', async () => {
+    vi.mocked(fg).mockResolvedValueOnce(['Dockerfile']);
+    vi.mocked(fs.promises.readFile).mockResolvedValueOnce(
+      [
+        'FROM ${BASE_IMAGE} AS build',
+        'RUN pnpm install --prod',
+        'COPY . .',
+        'RUN pnpm prune --prod',
+        'RUN pnpm install --offline --prod',
+      ].join('\n'),
+    );
+
+    await expect(
+      tryPatchDockerfilePruneProd({
+        mode: 'format',
+      } as PatchConfig),
+    ).resolves.toEqual({
+      result: 'apply',
+    } satisfies PatchReturnType);
+
+    expect(fs.promises.writeFile).toHaveBeenCalledWith(
+      'Dockerfile',
+      [
+        'FROM ${BASE_IMAGE} AS build',
+        'RUN pnpm prune --prod',
+        'COPY . .',
+        'RUN pnpm prune --prod',
+        'RUN pnpm install --offline --prod',
+      ].join('\n'),
+      'utf8',
+    );
+    expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/cli/lint/internalLints/upgrade/patches/15.3.0/patchDockerfilePruneProd.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/15.3.0/patchDockerfilePruneProd.ts
@@ -6,8 +6,41 @@ import fs from 'fs-extra';
 import { log } from '../../../../../../utils/logging.js';
 import type { PatchFunction, PatchReturnType } from '../../index.js';
 
-const pnpmInstallProdTestRegex = /^RUN (CI=true )?pnpm install.*--prod/m;
-const pnpmInstallProdReplaceRegex = /^RUN (CI=true )?pnpm install.*--prod/gm;
+const pnpmInstallProdLineRegex = /^RUN (CI=true )?pnpm install.*--prod/;
+const pnpmPruneProdLine = 'RUN pnpm prune --prod';
+
+/**
+ * Rewrites a Dockerfile's contents, replacing `RUN pnpm install … --prod`
+ * lines with `RUN pnpm prune --prod`, except when the install line is
+ * immediately preceded by `RUN pnpm prune --prod`.
+ *
+ * The preceded case is an intentional monorepo workaround for
+ * https://github.com/pnpm/pnpm/issues/8307, where `pnpm prune --prod` alone
+ * does not correctly prune dev dependencies and a follow-up
+ * `pnpm install --prod` is required.
+ *
+ * Returns `null` when no changes are required.
+ */
+const rewriteDockerfile = (contents: string): string | null => {
+  const lines = contents.split('\n');
+  let changed = false;
+
+  const updatedLines = lines.map((line, index) => {
+    if (!pnpmInstallProdLineRegex.test(line)) {
+      return line;
+    }
+
+    const previousLine = index > 0 ? lines[index - 1] : '';
+    if (previousLine?.startsWith(pnpmPruneProdLine)) {
+      return line;
+    }
+
+    changed = true;
+    return pnpmPruneProdLine;
+  });
+
+  return changed ? updatedLines.join('\n') : null;
+};
 
 export const patchDockerfilePruneProd = async (
   mode: 'lint' | 'format',
@@ -30,12 +63,14 @@ export const patchDockerfilePruneProd = async (
       return {
         file,
         contents,
+        updatedContents: rewriteDockerfile(contents),
       };
     }),
   );
 
-  const dockerfilesToPatch = dockerfiles.filter(({ contents }) =>
-    pnpmInstallProdTestRegex.test(contents),
+  const dockerfilesToPatch = dockerfiles.filter(
+    (entry): entry is typeof entry & { updatedContents: string } =>
+      entry.updatedContents !== null,
   );
 
   if (dockerfilesToPatch.length === 0) {
@@ -52,11 +87,7 @@ export const patchDockerfilePruneProd = async (
   }
 
   await Promise.all(
-    dockerfilesToPatch.map(async ({ file, contents }) => {
-      const updatedContents = contents.replace(
-        pnpmInstallProdReplaceRegex,
-        'RUN pnpm prune --prod',
-      );
+    dockerfilesToPatch.map(async ({ file, updatedContents }) => {
       await fs.promises.writeFile(file, updatedContents, 'utf8');
     }),
   );


### PR DESCRIPTION
## Summary

The `pnpm install --prod` → `pnpm prune --prod` patch added in #2326 currently rewrites **every** `RUN … pnpm install … --prod` line, including ones that are intentionally placed **after** a `RUN pnpm prune --prod` line as a monorepo workaround for [pnpm/pnpm#8307](https://github.com/pnpm/pnpm/issues/8307).

In a pnpm workspace / monorepo, `pnpm prune --prod` alone does not correctly remove dev dependencies (see the linked pnpm issue), so the established workaround is:

```dockerfile
RUN pnpm prune --prod
RUN pnpm install --offline --prod
```

Running `skuba format` against a Dockerfile using this pattern destroys the workaround by replacing the second line with another `RUN pnpm prune --prod`, leaving the image without proper dev-dep pruning.

This PR makes the patch monorepo-safe: a `RUN … pnpm install … --prod` line is only rewritten when the **immediately preceding** line is **not** `RUN pnpm prune --prod`.

## Changes

- `src/cli/lint/internalLints/upgrade/patches/15.3.0/patchDockerfilePruneProd.ts`
  - Replaced the single-shot `String.replace()` with a line-by-line rewrite that inspects the previous line before deciding to substitute.
  - Returns `null` from `rewriteDockerfile` when no changes are required, so a Dockerfile already in the safe pattern is correctly skipped.
- `src/cli/lint/internalLints/upgrade/patches/15.3.0/patchDockerfilePruneProd.test.ts` — new test cases:
  - Skips when `pnpm install --prod` is preceded by `pnpm prune --prod` (format mode).
  - Skips when `pnpm install --prod` is preceded by `pnpm prune --prod` (lint mode).
  - Mixed Dockerfile: rewrites a standalone `pnpm install --prod` while leaving the monorepo pair intact.
- `.changeset/fix-prune-prod-monorepo-workaround.md` — patch bump changeset.

## Test plan

- [x] `pnpm test` (all 997 unit tests pass, including 10 in `patchDockerfilePruneProd.test.ts`)
- [x] `pnpm lint` (clean)
- [x] `pnpm format` (clean, no further changes)

## Related

- Originating regression: `seek/ca-profile-api` Dockerfile uses the monorepo workaround pattern and was repeatedly broken by `skuba format`.
- Alternative under discussion: #2381 removes the patch entirely. This PR offers a more surgical alternative that keeps the prune benefit for single-package repos while leaving the monorepo workaround intact.

Made with [Cursor](https://cursor.com)