### PR TITLE
fix import path for aws-lambda-nodejs

### DIFF
--- a/.changeset/swift-keys-admire.md
+++ b/.changeset/swift-keys-admire.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-fix import statement
+migrate: fix `aws-cdk-lib/aws-lambda-nodejs` import statement

--- a/.changeset/swift-keys-admire.md
+++ b/.changeset/swift-keys-admire.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+fix import statement

--- a/src/cli/migrate/esm/migrateLambdas.ts
+++ b/src/cli/migrate/esm/migrateLambdas.ts
@@ -94,7 +94,7 @@ const migrateCdkLambdas = async (
               startPos: insertPos,
               endPos: insertPos,
               insertedText:
-                "import { OutputFormat } from 'aws-cdk-lib/aws-lambda_nodejs';\n",
+                "import { OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';\n",
             });
           }
         } else {


### PR DESCRIPTION
## Summary

Fixes a typo in the ESM migration code that generated an incorrect import path for `OutputFormat`. The path used an underscore (`aws-lambda_nodejs`) instead of a hyphen (`aws-lambda-nodejs`), which would produce a broken import in migrated CDK stacks.

## Change

In `src/cli/migrate/esm/migrateLambdas.ts`, the auto-inserted import statement:

```diff
- import { OutputFormat } from 'aws-cdk-lib/aws-lambda_nodejs';
+ import { OutputFormat } from 'aws-cdk-lib/aws-lambda-nodejs';
