### PR TITLE
Bump isomorphic-git to 1.37.6

### DIFF
--- a/.changeset/perky-plants-shake.md
+++ b/.changeset/perky-plants-shake.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+migrate: Fix `yarn` package install scripts in ESM migration

--- a/.changeset/plain-memes-end.md
+++ b/.changeset/plain-memes-end.md
@@ -1,0 +1,6 @@
+---
+'@skuba-lib/api': patch
+'skuba': patch
+---
+
+deps: isomorphic-git 1.37.6

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "ignore": "^7.0.0",
     "import-meta-resolve": "^4.2.0",
     "is-installed-globally": "^0.4.0",
-    "isomorphic-git": "^1.11.1",
+    "isomorphic-git": "^1.37.6",
     "latest-version": "^9.0.0",
     "lodash.mergewith": "^4.6.2",
     "minimist": "^1.2.6",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -63,7 +63,7 @@
     "@octokit/types": "^16.0.0",
     "fs-extra": "^11.0.0",
     "ignore": "^7.0.0",
-    "isomorphic-git": "^1.11.1",
+    "isomorphic-git": "^1.37.6",
     "zod": "^4.3.5"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       isomorphic-git:
-        specifier: ^1.11.1
+        specifier: ^1.37.6
         version: 1.37.6
       latest-version:
         specifier: ^9.0.0
@@ -281,7 +281,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.5
       isomorphic-git:
-        specifier: ^1.11.1
+        specifier: ^1.37.6
         version: 1.37.6
       zod:
         specifier: ^4.3.5

--- a/src/cli/migrate/esm/patchInstrumentation.ts
+++ b/src/cli/migrate/esm/patchInstrumentation.ts
@@ -207,7 +207,9 @@ export const patchInstrumentation: PatchFunction = async ({
       await rootExec(
         packageManager.command,
         'install',
-        '--frozen-lockfile=false',
+        ...(packageManager.command === 'pnpm'
+          ? ['--frozen-lockfile=false']
+          : []),
         '--prefer-offline',
         '--ignore-scripts',
       );

--- a/src/cli/migrate/esm/vitest/vitest.ts
+++ b/src/cli/migrate/esm/vitest/vitest.ts
@@ -314,7 +314,7 @@ export const migrateToVitest = async (opts: {
     await rootExec(
       packageManager.command,
       'install',
-      '--frozen-lockfile=false',
+      ...(packageManager.command === 'pnpm' ? ['--frozen-lockfile=false'] : []),
       '--prefer-offline',
       '--ignore-scripts',
     );

--- a/src/cli/migrate/nodeVersion/upgrade.ts
+++ b/src/cli/migrate/nodeVersion/upgrade.ts
@@ -206,7 +206,7 @@ export const upgradeInfraPackages = async (
     await exec(
       packageManager.command,
       'install',
-      '--frozen-lockfile=false',
+      ...(packageManager.command === 'pnpm' ? ['--frozen-lockfile=false'] : []),
       '--prefer-offline',
     );
   } catch (error) {


### PR DESCRIPTION
Bumps the version of isomorphic git for consumers who aren't doing lock file maintenance to an ESM compatible version