### PR TITLE
Adjust import types patch insertion logic

### DIFF
--- a/.changeset/proud-months-smash.md
+++ b/.changeset/proud-months-smash.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+migrate: Attempt to avoid displacing eslint-disable-next-line import-x/order lines in ESM migration

--- a/src/cli/migrate/esm/vitest/postFixVitestMigration.test.ts
+++ b/src/cli/migrate/esm/vitest/postFixVitestMigration.test.ts
@@ -245,6 +245,12 @@ const someModule = vi.importActual<typeof import('./someModule')>('./someModule'
   describe('migrateJestTypes', () => {
     it('adds imports for Mock, MockedFunction, MockedClass, MockedObject, and MockInstance when those types are used', async () => {
       const content = `import { vi } from 'vitest';
+// eslint-disable-next-line import-x/order -- don't move
+import { mockLogger } from './mockLogger.js';
+
+import * as z from 'zod';
+import { SomeClass } from './someClass.js';
+import { someFunction } from '#src/someFunction.js';
 
 type MyMock = jest.Mock;
 type MyMockedFunction = jest.MockedFunction<() => void>;
@@ -255,17 +261,25 @@ type MySpy = jest.SpyInstance;
 type MySpiedFunction = jest.SpiedFunction<() => void>;
 `;
 
-      await expect(run(content)).resolves.toBe(`import { vi } from 'vitest';
-import type { Mock, MockedFunction, MockedClass, MockedObject, MockInstance } from 'vitest';
+      await expect(run(content)).resolves.toMatchInlineSnapshot(`
+        "// eslint-disable-next-line import-x/order -- don't move
+        import { mockLogger } from './mockLogger.js';
 
-type MyMock = Mock;
-type MyMockedFunction = MockedFunction<() => void>;
-type MyMockedClass = MockedClass<typeof SomeClass>;
-type MyMockedObject = MockedObject<{ foo: string }>;
-type MyMockInstance = MockInstance<{ bar: number }>;
-type MySpy = MockInstance;
-type MySpiedFunction = Mock<() => void>;
-`);
+        import { vi } from 'vitest';
+        import * as z from 'zod';
+        import type { Mock, MockedFunction, MockedClass, MockedObject, MockInstance } from 'vitest';
+        import { SomeClass } from './someClass.js';
+        import { someFunction } from '#src/someFunction.js';
+
+        type MyMock = Mock;
+        type MyMockedFunction = MockedFunction<() => void>;
+        type MyMockedClass = MockedClass<typeof SomeClass>;
+        type MyMockedObject = MockedObject<{ foo: string }>;
+        type MyMockInstance = MockInstance<{ bar: number }>;
+        type MySpy = MockInstance;
+        type MySpiedFunction = Mock<() => void>;
+        "
+      `);
     });
   });
 

--- a/src/cli/migrate/esm/vitest/postFixVitestMigration.test.ts
+++ b/src/cli/migrate/esm/vitest/postFixVitestMigration.test.ts
@@ -266,8 +266,8 @@ type MySpiedFunction = jest.SpiedFunction<() => void>;
         import { mockLogger } from './mockLogger.js';
 
         import { vi } from 'vitest';
-        import * as z from 'zod';
         import type { Mock, MockedFunction, MockedClass, MockedObject, MockInstance } from 'vitest';
+        import * as z from 'zod';
         import { SomeClass } from './someClass.js';
         import { someFunction } from '#src/someFunction.js';
 

--- a/src/cli/migrate/esm/vitest/postFixVitestMigration.ts
+++ b/src/cli/migrate/esm/vitest/postFixVitestMigration.ts
@@ -293,7 +293,19 @@ const getTypeImportEdits = (root: SgNode, imports: string[]): Edit[] => {
     return [];
   }
 
-  const lastImport =
+  const importPlacement =
+    root.find({
+      rule: {
+        kind: 'import_statement',
+        has: {
+          kind: 'string',
+          has: {
+            kind: 'string_fragment',
+            regex: '^vitest$',
+          },
+        },
+      },
+    }) ??
     root.find({
       rule: {
         kind: 'import_statement',
@@ -321,62 +333,6 @@ const getTypeImportEdits = (root: SgNode, imports: string[]): Edit[] => {
           reverse: true,
         },
       },
-    }) ??
-    root.find({
-      rule: {
-        kind: 'import_statement',
-        inside: {
-          kind: 'program',
-        },
-        nthChild: {
-          ofRule: {
-            kind: 'import_statement',
-            has: {
-              kind: 'string',
-              has: {
-                kind: 'string_fragment',
-                not: {
-                  any: [
-                    {
-                      regex: '^(@|#)',
-                    },
-                  ],
-                },
-              },
-            },
-          },
-          position: 1,
-          reverse: true,
-        },
-      },
-    }) ??
-    root.find({
-      rule: {
-        kind: 'import_statement',
-        inside: {
-          kind: 'program',
-        },
-        nthChild: {
-          ofRule: {
-            kind: 'import_statement',
-            has: {
-              kind: 'string',
-              has: {
-                kind: 'string_fragment',
-                not: {
-                  any: [
-                    {
-                      regex: '^#',
-                    },
-                  ],
-                },
-              },
-            },
-          },
-          position: 1,
-          reverse: true,
-        },
-      },
     });
   root.find({
     rule: {
@@ -394,14 +350,14 @@ const getTypeImportEdits = (root: SgNode, imports: string[]): Edit[] => {
     },
   });
 
-  if (!lastImport) {
+  if (!importPlacement) {
     return [];
   }
 
   return [
     {
-      startPos: lastImport.range().end.index + 1, // newline
-      endPos: lastImport.range().end.index + 1,
+      startPos: importPlacement.range().end.index + 1, // newline
+      endPos: importPlacement.range().end.index + 1,
       insertedText: `import type { ${imports.join(', ')} } from 'vitest';\n`,
     },
   ];
@@ -507,7 +463,6 @@ export const postFixVitestMigration = async (file: string, content: string) => {
     ...jestTypeEdits,
     ...spyInstanceTypeEdits,
     ...spiedFunctionEdits,
-    ...getTypeImportEdits(astRoot, Array.from(jestTypeImports)),
     ...getViMockedPrototypeEdits(astRoot),
     ...getBadMockImplementationEdits(astRoot),
   ];
@@ -519,8 +474,24 @@ export const postFixVitestMigration = async (file: string, content: string) => {
     };
   }
 
+  const updated = astRoot.commitEdits(edits);
+
+  if (!jestTypeImports.size) {
+    return {
+      updated,
+      hasLifeCyclesToCheck,
+    };
+  }
+
+  const astAfterEdits = (await parseAsync('TypeScript', updated)).root();
+
+  const typeImportEdits = getTypeImportEdits(
+    astAfterEdits,
+    Array.from(jestTypeImports),
+  );
+
   return {
-    updated: astRoot.commitEdits(edits),
+    updated: astAfterEdits.commitEdits(typeImportEdits),
     hasLifeCyclesToCheck,
   };
 };

--- a/src/cli/migrate/esm/vitest/postFixVitestMigration.ts
+++ b/src/cli/migrate/esm/vitest/postFixVitestMigration.ts
@@ -293,7 +293,92 @@ const getTypeImportEdits = (root: SgNode, imports: string[]): Edit[] => {
     return [];
   }
 
-  const lastImport = root.find({
+  const lastImport =
+    root.find({
+      rule: {
+        kind: 'import_statement',
+        inside: {
+          kind: 'program',
+        },
+        nthChild: {
+          ofRule: {
+            kind: 'import_statement',
+            has: {
+              kind: 'string',
+              has: {
+                kind: 'string_fragment',
+                not: {
+                  any: [
+                    {
+                      regex: '^(@|#|\\.)',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          position: 1,
+          reverse: true,
+        },
+      },
+    }) ??
+    root.find({
+      rule: {
+        kind: 'import_statement',
+        inside: {
+          kind: 'program',
+        },
+        nthChild: {
+          ofRule: {
+            kind: 'import_statement',
+            has: {
+              kind: 'string',
+              has: {
+                kind: 'string_fragment',
+                not: {
+                  any: [
+                    {
+                      regex: '^(@|#)',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          position: 1,
+          reverse: true,
+        },
+      },
+    }) ??
+    root.find({
+      rule: {
+        kind: 'import_statement',
+        inside: {
+          kind: 'program',
+        },
+        nthChild: {
+          ofRule: {
+            kind: 'import_statement',
+            has: {
+              kind: 'string',
+              has: {
+                kind: 'string_fragment',
+                not: {
+                  any: [
+                    {
+                      regex: '^#',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          position: 1,
+          reverse: true,
+        },
+      },
+    });
+  root.find({
     rule: {
       kind: 'import_statement',
       inside: {


### PR DESCRIPTION
Ugh

import-x has this kinda buggy behavior if you have duplicate imports in your code which aren't sorted behind the correct imports where it nukes any `// eslint-disable-next-line import-x/order` line causing issues for our migrations :( because the `'#src/mockLogger.js'` then gets sorted amongst the regular imports and the logger is left unmocked

eg.
```ts
// eslint-disable-next-line import-x/order -- contains mocks
import {testLogger} from '#src/mockLogger.js';

import { vi } from 'vitest';
import thing from 'thing';

import { logger } from '#src/logger.js';
import type { Mock } from 'vitest';
```

But if you moved `import type { Mock } from 'vitest';` above any `#src/` imports it's fine 🤷 

Running format completely nukes the `// eslint-disable-next-line import-x/order` comment and gets lost in the weeds for our consumers migrating. This causes pain because you only realize this was done after the tests fail.

So the workaround I've got going is just double parse the AST and attempt to insert the `vitest` line directly under the existing vitest import so we don't have issues.