### PR TITLE
Allow re-runs of the Vitest migration

### DIFF
--- a/.changeset/light-experts-fetch.md
+++ b/.changeset/light-experts-fetch.md
@@ -1,0 +1,11 @@
+---
+'skuba': patch
+---
+
+migration: Allow re-runs of the Vitest migration via the ESM migration with `SKUBA_FORCE_MIGRATE_VITEST=true`
+
+This is useful when migrating a larger project that may have frequent upstream changes that need to be pulled in.
+
+```shell
+SKUBA_FORCE_MIGRATE_VITEST=true skuba migrate esm
+```

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -206,6 +206,12 @@ You will need to manually install `vitest` and `@vitest/coverage-istanbul` as de
 pnpm add -DE vitest @vitest/coverage-istanbul
 ```
 
+To re-run the Vitest migration, you will need to set the `SKUBA_FORCE_MIGRATE_VITEST` environment variable to `true`:
+
+```shell
+SKUBA_FORCE_MIGRATE_VITEST=true skuba migrate esm
+```
+
 ### Migration changes
 
 The following changes are made:

--- a/src/cli/migrate/esm/vitest/vitest.test.ts
+++ b/src/cli/migrate/esm/vitest/vitest.test.ts
@@ -78,7 +78,8 @@ export default defineConfig({
       }),
     ).resolves.toEqual({
       result: 'skip',
-      reason: 'vitest is already configured in this project',
+      reason:
+        'vitest is already configured in this project, re-run the migration with SKUBA_FORCE_MIGRATE_VITEST=true to skip this check',
     } satisfies PatchReturnType);
   });
 

--- a/src/cli/migrate/esm/vitest/vitest.ts
+++ b/src/cli/migrate/esm/vitest/vitest.ts
@@ -140,10 +140,14 @@ export const migrateToVitest = async (opts: {
     ignore: ['**/.git', '**/node_modules'],
   });
 
-  if (vitestConfigFiles.length > 0) {
+  if (
+    vitestConfigFiles.length > 0 &&
+    process.env.SKUBA_FORCE_MIGRATE_VITEST !== 'true'
+  ) {
     return {
       result: 'skip',
-      reason: 'vitest is already configured in this project',
+      reason:
+        'vitest is already configured in this project, re-run the migration with SKUBA_FORCE_MIGRATE_VITEST=true to skip this check',
     };
   }
 
@@ -265,7 +269,7 @@ export const migrateToVitest = async (opts: {
         )
         .replaceAll('eslint-disable jest', 'eslint-disable vitest')
         .replaceAll('Mock<any, any>', 'Mock')
-        .replaceAll('advanceTimers: true', 'shouldAdvanceTimers: true');
+        .replaceAll('advanceTimers: true', 'shouldAdvanceTime: true');
 
       if (finalUpdated !== content) {
         return fs.promises.writeFile(file, finalUpdated, 'utf8');


### PR DESCRIPTION
Came up as a bit of a pain point of needing to pull changes in from other people's merges in Hirer Graph