### PR TITLE
Update pnpm-workspace processing logic

### DIFF
--- a/.changeset/fancy-ghosts-say.md
+++ b/.changeset/fancy-ghosts-say.md
@@ -1,5 +1,7 @@
 ---
-'skuba': patch
+'skuba': minor
 ---
 
-lint: Update `pnpm-workspace.yaml` lint to handle more formats
+lint: Remove stale managed entries from `pnpm-workspace.yaml`
+
+This update removes entries with `# Managed by skuba` annotations from `pnpm-workspace.yaml` that no longer match skuba's managed configuration, cleans up any orphaned empty sections left behind, and runs `pnpm install` to update the lockfile when managed `overrides` are added or changed.

--- a/.changeset/fancy-ghosts-say.md
+++ b/.changeset/fancy-ghosts-say.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+lint: Update `pnpm-workspace.yaml` lint to handle more formats

--- a/.changeset/fiery-hounds-remain.md
+++ b/.changeset/fiery-hounds-remain.md
@@ -3,6 +3,6 @@
 'skuba': patch
 ---
 
-lint: Add pnpm override for `fflate` in `@arethetypeswrong/core`
+lint: Add managed pnpm override for `fflate` in `@arethetypeswrong/core`
 
 This should resolve any `Cannot read properties of undefined (reading 'filename')` issue running `skuba build-package`

--- a/.changeset/fiery-hounds-remain.md
+++ b/.changeset/fiery-hounds-remain.md
@@ -1,0 +1,8 @@
+---
+'pnpm-plugin-skuba': patch
+'skuba': patch
+---
+
+lint: Add pnpm override for `fflate` in `@arethetypeswrong/core`
+
+This should resolve any `Cannot read properties of undefined (reading 'filename')` issue running `skuba build-package`

--- a/packages/pnpm-plugin-skuba/pnpmfile.cjs
+++ b/packages/pnpm-plugin-skuba/pnpmfile.cjs
@@ -53,6 +53,9 @@ const defaultConfig = {
   strictDepBuilds: false,
   trustPolicy: 'off',
   trustPolicyExclude: ['semver@6.3.1'], // dependency of eslint-plugin-react
+  overrides: {
+    '@arethetypeswrong/core@0.18.2>fflate': '0.8.2',
+  },
 };
 
 module.exports = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@arethetypeswrong/core@0.18.2>fflate': 0.8.2
   skuba: workspace:*
   skuba-dive: workspace:*
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ minimumReleaseAgeExclude:
   - tsconfig-seek # Managed by skuba
 
 overrides:
+  '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
   skuba: workspace:*
   skuba-dive: workspace:*
 packageManagerStrictVersion: true # Managed by skuba

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
@@ -84,6 +84,8 @@ describe('patchPnpmWorkspace', () => {
       trustPolicy: off # Managed by skuba
       trustPolicyExclude:
         - semver@6.3.1 # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       "
     `);
   });
@@ -159,6 +161,8 @@ trustPolicyExclude:
       packageManagerStrictVersion: true # Managed by skuba
       strictDepBuilds: false # Managed by skuba
       trustPolicy: off # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       # This is a comment
       allowBuilds:
         '@datadog/native-appsec': true # Managed by skuba
@@ -260,6 +264,8 @@ trustPolicyExclude:
       packageManagerStrictVersion: true # Managed by skuba
       strictDepBuilds: false # Managed by skuba
       trustPolicy: off # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       blockExoticSubdeps: true # Managed by skuba
       publicHoistPattern:
         - '@arethetypeswrong/core' # Managed by skuba
@@ -355,6 +361,8 @@ packageManagerStrictVersion: false`,
       trustPolicy: off # Managed by skuba
       trustPolicyExclude:
         - semver@6.3.1 # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       blockExoticSubdeps: true # Managed by skuba
       ignorePatchFailures: false # Managed by skuba
       strictDepBuilds: false # Managed by skuba
@@ -415,6 +423,8 @@ allowBuilds:
       packageManagerStrictVersion: true # Managed by skuba
       strictDepBuilds: false # Managed by skuba
       trustPolicy: off # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       publicHoistPattern:
         - '@arethetypeswrong/core' # Managed by skuba
         - '@eslint/*' # Managed by skuba
@@ -455,7 +465,11 @@ allowBuilds:
   '@ast-grep/lang-yaml': true # Managed by skuba
   not-managed-anymore: true # Managed by skuba
   # Managed by skuba
-  not-managed-either: true # Managed by skuba`,
+  not-managed-either: true # Managed by skuba
+someOtherSection:
+  someOtherOption: true # Managed by skuba
+somelistSection:
+  - some-item # Managed by skuba`,
     });
 
     const result = await patchPnpmWorkspace('format');
@@ -489,6 +503,8 @@ allowBuilds:
       trustPolicy: off # Managed by skuba
       trustPolicyExclude:
         - semver@6.3.1 # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       minimumReleaseAge: 4320 # Managed by skuba
       minimumReleaseAgeExclude:
         - '@skuba-lib/*' # Managed by skuba

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
@@ -9,6 +9,8 @@ vi.mock('../../../utils/exec.js', () => ({
   createExec: vi.fn().mockImplementation(() => vi.fn()),
 }));
 
+vi.mock('../../../utils/logging.js');
+
 vi.mock('fs-extra', () => ({
   ...memfs.fs,
   default: memfs.fs,

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
@@ -181,7 +181,6 @@ trustPolicyExclude:
         some-package: false # Inline comment
         '@ast-grep/lang-json': true # Managed by skuba
         '@ast-grep/lang-yaml': true # Managed by skuba
-        # Managed by skuba
       # Another comment
       publicHoistPattern:
         - '@arethetypeswrong/core' # Managed by skuba
@@ -202,9 +201,7 @@ trustPolicyExclude:
       trustPolicyExclude:
         - some-package@1.0.0 # Comment after list item
         # Comment on empty list item
-        # Managed by skuba
         - semver@6.3.1 # Managed by skuba
-        # Managed by skuba
       "
     `);
   });
@@ -470,6 +467,8 @@ allowBuilds:
   not-managed-anymore: true # Managed by skuba
   # Managed by skuba
   not-managed-either: true # Managed by skuba
+  some-option: true
+  # Managed by skuba
 someOtherSection:
   someOtherOption: true # Managed by skuba
 somelistSection:
@@ -520,7 +519,6 @@ somelistSection:
         - skuba-dive # Managed by skuba
         - tsconfig-seek # Managed by skuba
         - '@seek/*' # Managed by skuba
-      # Managed by skuba
       allowBuilds:
         '@datadog/native-appsec': true # Managed by skuba
         '@datadog/native-iast-taint-tracking': true # Managed by skuba
@@ -533,7 +531,7 @@ somelistSection:
         unrs-resolver: true # Managed by skuba
         '@ast-grep/lang-json': true # Managed by skuba
         '@ast-grep/lang-yaml': true # Managed by skuba
-        # Managed by skuba
+        some-option: true
       "
     `);
   });

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
@@ -5,6 +5,10 @@ import { patchPnpmWorkspace } from './patchPnpmWorkspace.js';
 
 const volToJson = () => vol.toJSON(process.cwd(), undefined, true);
 
+vi.mock('../../../utils/exec.js', () => ({
+  createExec: vi.fn().mockImplementation(() => vi.fn()),
+}));
+
 vi.mock('fs-extra', () => ({
   ...memfs.fs,
   default: memfs.fs,

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.test.ts
@@ -245,7 +245,22 @@ trustPolicyExclude:
     });
 
     expect(volToJson()['pnpm-workspace.yaml']).toMatchInlineSnapshot(`
-      "blockExoticSubdeps: true # Managed by skuba
+      "ignorePatchFailures: false # Managed by skuba
+      minimumReleaseAge: 4320 # Managed by skuba
+      minimumReleaseAgeExclude:
+        - '@seek/*' # Managed by skuba
+        - '@skuba-lib/*' # Managed by skuba
+        - eslint-config-seek # Managed by skuba
+        - eslint-config-skuba # Managed by skuba
+        - eslint-plugin-skuba # Managed by skuba
+        - pnpm-plugin-skuba # Managed by skuba
+        - skuba # Managed by skuba
+        - skuba-dive # Managed by skuba
+        - tsconfig-seek # Managed by skuba
+      packageManagerStrictVersion: true # Managed by skuba
+      strictDepBuilds: false # Managed by skuba
+      trustPolicy: off # Managed by skuba
+      blockExoticSubdeps: true # Managed by skuba
       publicHoistPattern:
         - '@arethetypeswrong/core' # Managed by skuba
         - '@eslint/*' # Managed by skuba
@@ -299,7 +314,48 @@ packageManagerStrictVersion: false`,
     });
 
     expect(volToJson()['pnpm-workspace.yaml']).toMatchInlineSnapshot(`
-      "blockExoticSubdeps: true # Managed by skuba
+      "allowBuilds:
+        '@ast-grep/lang-json': true # Managed by skuba
+        '@ast-grep/lang-yaml': true # Managed by skuba
+        '@datadog/native-appsec': true # Managed by skuba
+        '@datadog/native-iast-taint-tracking': true # Managed by skuba
+        '@datadog/native-metrics': true # Managed by skuba
+        '@datadog/pprof': true # Managed by skuba
+        dd-trace: true # Managed by skuba
+        esbuild: true # Managed by skuba
+        protobufjs: true # Managed by skuba
+        unix-dgram: true # Managed by skuba
+        unrs-resolver: true # Managed by skuba
+      minimumReleaseAge: 4320 # Managed by skuba
+      minimumReleaseAgeExclude:
+        - '@seek/*' # Managed by skuba
+        - '@skuba-lib/*' # Managed by skuba
+        - eslint-config-seek # Managed by skuba
+        - eslint-config-skuba # Managed by skuba
+        - eslint-plugin-skuba # Managed by skuba
+        - pnpm-plugin-skuba # Managed by skuba
+        - skuba # Managed by skuba
+        - skuba-dive # Managed by skuba
+        - tsconfig-seek # Managed by skuba
+      publicHoistPattern:
+        - '@arethetypeswrong/core' # Managed by skuba
+        - '@eslint/*' # Managed by skuba
+        - '@types*' # Managed by skuba
+        - '@vitest/*' # Managed by skuba
+        - esbuild # Managed by skuba
+        - eslint # Managed by skuba
+        - eslint-config-skuba # Managed by skuba
+        - prettier # Managed by skuba
+        - publint # Managed by skuba
+        - rolldown # Managed by skuba
+        - tsconfig-seek # Managed by skuba
+        - tsdown # Managed by skuba
+        - typescript # Managed by skuba
+        - vitest # Managed by skuba
+      trustPolicy: off # Managed by skuba
+      trustPolicyExclude:
+        - semver@6.3.1 # Managed by skuba
+      blockExoticSubdeps: true # Managed by skuba
       ignorePatchFailures: false # Managed by skuba
       strictDepBuilds: false # Managed by skuba
       packageManagerStrictVersion: true # Managed by skuba"
@@ -331,7 +387,19 @@ allowBuilds:
     });
 
     expect(volToJson()['pnpm-workspace.yaml']).toMatchInlineSnapshot(`
-      "blockExoticSubdeps: true # Managed by skuba
+      "allowBuilds:
+        '@ast-grep/lang-json': true # Managed by skuba
+        '@ast-grep/lang-yaml': true # Managed by skuba
+        '@datadog/native-appsec': true # Managed by skuba
+        '@datadog/native-iast-taint-tracking': true # Managed by skuba
+        '@datadog/native-metrics': true # Managed by skuba
+        '@datadog/pprof': true # Managed by skuba
+        dd-trace: true # Managed by skuba
+        esbuild: true # Managed by skuba
+        protobufjs: true # Managed by skuba
+        unix-dgram: true # Managed by skuba
+        unrs-resolver: true # Managed by skuba
+      blockExoticSubdeps: true # Managed by skuba
       ignorePatchFailures: false # Managed by skuba
       minimumReleaseAge: 4320 # Managed by skuba
       minimumReleaseAgeExclude:
@@ -368,26 +436,13 @@ allowBuilds:
         - semver@6.3.1 # Managed by skuba
         - some-package@1.0.0
         - semver@5.7.2 || 6.3.1
-      allowBuilds:
-        '@ast-grep/lang-json': true # Managed by skuba
-        '@ast-grep/lang-yaml': true # Managed by skuba
-        '@datadog/native-appsec': true # Managed by skuba
-        '@datadog/native-iast-taint-tracking': true # Managed by skuba
-        '@datadog/native-metrics': true # Managed by skuba
-        '@datadog/pprof': true # Managed by skuba
-        dd-trace: true # Managed by skuba
-        esbuild: true # Managed by skuba
-        protobufjs: true # Managed by skuba
-        unix-dgram: true # Managed by skuba
-        unrs-resolver: true # Managed by skuba
       "
     `);
   });
 
   it('should remove skuba-managed items that are no longer in the default config', async () => {
     vol.fromJSON({
-      'pnpm-workspace.yaml': `
-removedOption: true # Managed by skuba
+      'pnpm-workspace.yaml': `removedOption: true # Managed by skuba
 minimumReleaseAge: 4320 # Managed by skuba
 anotherRemovedOption: abcd # Managed by skuba
 minimumReleaseAgeExclude:
@@ -400,8 +455,7 @@ allowBuilds:
   '@ast-grep/lang-yaml': true # Managed by skuba
   not-managed-anymore: true # Managed by skuba
   # Managed by skuba
-  not-managed-either: true # Managed by skuba
-`,
+  not-managed-either: true # Managed by skuba`,
     });
 
     const result = await patchPnpmWorkspace('format');
@@ -413,7 +467,29 @@ allowBuilds:
     });
 
     expect(volToJson()['pnpm-workspace.yaml']).toMatchInlineSnapshot(`
-      "minimumReleaseAge: 4320 # Managed by skuba
+      "blockExoticSubdeps: true # Managed by skuba
+      ignorePatchFailures: false # Managed by skuba
+      packageManagerStrictVersion: true # Managed by skuba
+      publicHoistPattern:
+        - '@arethetypeswrong/core' # Managed by skuba
+        - '@eslint/*' # Managed by skuba
+        - '@types*' # Managed by skuba
+        - '@vitest/*' # Managed by skuba
+        - esbuild # Managed by skuba
+        - eslint # Managed by skuba
+        - eslint-config-skuba # Managed by skuba
+        - prettier # Managed by skuba
+        - publint # Managed by skuba
+        - rolldown # Managed by skuba
+        - tsconfig-seek # Managed by skuba
+        - tsdown # Managed by skuba
+        - typescript # Managed by skuba
+        - vitest # Managed by skuba
+      strictDepBuilds: false # Managed by skuba
+      trustPolicy: off # Managed by skuba
+      trustPolicyExclude:
+        - semver@6.3.1 # Managed by skuba
+      minimumReleaseAge: 4320 # Managed by skuba
       minimumReleaseAgeExclude:
         - '@skuba-lib/*' # Managed by skuba
         - eslint-config-seek # Managed by skuba

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.ts
@@ -233,7 +233,58 @@ const applyDeleteEdits = async (
     },
   });
 
-  if (!nodesToDelete.length) {
+  const commentNodes = astRoot.findAll({
+    rule: {
+      kind: 'comment',
+      regex: '^# Managed by skuba$',
+      any: [
+        {
+          inside: {
+            kind: 'block_mapping_pair',
+            inside: {
+              kind: 'block_mapping',
+              inside: {
+                kind: 'block_node',
+                inside: {
+                  kind: 'document',
+                },
+              },
+            },
+          },
+        },
+        {
+          follows: {
+            kind: 'comment',
+          },
+        },
+      ],
+    },
+  });
+
+  const deleteCommentEdits = commentNodes
+    .map((node) => {
+      const previousNode = node.prev();
+      const nodeRange = node.range();
+
+      // This can match against valid nodes as we can't check line numbers in the AST
+      if (previousNode?.range().start.line === nodeRange.start.line) {
+        return undefined;
+      }
+
+      const endPos =
+        source.at(nodeRange.end.index) === '\n'
+          ? nodeRange.end.index + 1
+          : nodeRange.end.index;
+
+      return {
+        startPos: nodeRange.start.index - nodeRange.start.column,
+        endPos,
+        insertedText: '',
+      };
+    })
+    .filter((edit) => edit !== undefined);
+
+  if (!nodesToDelete.length && !deleteCommentEdits.length) {
     return {
       updatedSource: source,
       updatedAstRoot: astRoot,
@@ -248,11 +299,21 @@ const applyDeleteEdits = async (
     const startPos = nodeRange.start.index - column;
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the node has a next sibling
-    const commentNodeEndIndex = node.next()!.range().end.index;
+    const commentNode = node.next()!;
+    const commentNodeRange = commentNode.range();
+    const commentNodeEndIndex = commentNodeRange.end.index;
     const endPos =
       source.at(commentNodeEndIndex) === '\n'
         ? commentNodeEndIndex + 1
         : commentNodeEndIndex;
+
+    if (commentNodeRange.start.line !== nodeRange.start.line) {
+      return {
+        insertedText: '',
+        startPos: commentNodeRange.start.index - commentNodeRange.start.column,
+        endPos,
+      };
+    }
 
     return {
       insertedText: '',
@@ -261,7 +322,10 @@ const applyDeleteEdits = async (
     };
   });
 
-  const updatedSource = astRoot.commitEdits(deleteEdits);
+  const updatedSource = astRoot.commitEdits([
+    ...deleteEdits,
+    ...deleteCommentEdits,
+  ]);
   const updatedAstRoot = (await parseAsync('yaml', updatedSource)).root();
 
   // check if there are any orphaned sections

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { inspect } from 'util';
 
-import { type SgNode, parseAsync } from '@ast-grep/napi';
+import { type Edit, type SgNode, parseAsync } from '@ast-grep/napi';
 import fs from 'fs-extra';
 
 import { log } from '../../../utils/logging.js';
@@ -34,6 +34,40 @@ const wrapOptionalQuotesRegex = (value: string): string =>
 
 const removeOptionalQuotes = (value: string): string =>
   value.replace(/^(['"])(.*)\1$/s, '$2');
+
+const buildManagedCommentEdits = (
+  node: SgNode,
+  insertedText: string,
+  matchRegex: RegExp,
+  source: string,
+): Edit[] => {
+  const nodeRange = node.range();
+  const maybeManagedComment = node.next();
+
+  if (maybeManagedComment?.kind() !== 'comment') {
+    return [
+      {
+        insertedText,
+        startPos: nodeRange.start.index,
+        endPos: nodeRange.end.index,
+      },
+    ];
+  }
+
+  const commentRange = maybeManagedComment.range();
+  const content = source.slice(nodeRange.start.index, commentRange.end.index);
+  if (matchRegex.test(content)) {
+    return [];
+  }
+
+  return [
+    {
+      insertedText,
+      startPos: nodeRange.start.index,
+      endPos: commentRange.end.index,
+    },
+  ];
+};
 
 const applyDeleteEdits = async (
   source: string,
@@ -353,38 +387,16 @@ export const patchPnpmWorkspace = async (
       const rawKey = section.field('key')!.text();
       const key = removeOptionalQuotes(rawKey);
       const value = defaultConfig[key as keyof typeof defaultConfig];
-      const sectionRange = section.range();
 
       if (isSimpleValue(value)) {
-        const maybeManagedComment = section.next();
-        if (maybeManagedComment?.kind() !== 'comment') {
-          return [
-            {
-              insertedText: `${rawKey}: ${value} # Managed by skuba`,
-              startPos: sectionRange.start.index,
-              endPos: sectionRange.end.index,
-            },
-          ];
-        }
-        const commentRange = maybeManagedComment.range();
-        const content = updatedSource.slice(
-          sectionRange.start.index,
-          commentRange.end.index,
+        return buildManagedCommentEdits(
+          section,
+          `${rawKey}: ${value} # Managed by skuba`,
+          new RegExp(
+            `^${wrapOptionalQuotesRegex(escapeRegex(key))}: ${escapeRegex(String(value))} # Managed by skuba$`,
+          ),
+          updatedSource,
         );
-        const matchRegex = new RegExp(
-          `^${wrapOptionalQuotesRegex(escapeRegex(key))}: ${escapeRegex(String(value))} # Managed by skuba$`,
-        );
-        if (matchRegex.test(content)) {
-          return [];
-        }
-
-        return [
-          {
-            insertedText: `${rawKey}: ${value} # Managed by skuba`,
-            startPos: sectionRange.start.index,
-            endPos: commentRange.end.index,
-          },
-        ];
       }
 
       if (Array.isArray(value)) {
@@ -418,44 +430,21 @@ export const patchPnpmWorkspace = async (
             endPos: blockStartPos,
           }));
 
-        const existingItemsEdits = existingItems.map((existingItem) => {
+        const existingItemsEdits = existingItems.flatMap((existingItem) => {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the item has a child
           const existingRawValue = existingItem.child(1)!.text();
           const existingValue = removeOptionalQuotes(existingRawValue);
-          const existingItemRange = existingItem.range();
-          const maybeManagedComment = existingItem.next();
-          if (maybeManagedComment?.kind() !== 'comment') {
-            return [
-              {
-                insertedText: `- ${existingRawValue} # Managed by skuba`,
-                startPos: existingItemRange.start.index,
-                endPos: existingItemRange.end.index,
-              },
-            ];
-          }
-
-          const commentRange = maybeManagedComment.range();
-          const content = updatedSource.slice(
-            existingItemRange.start.index,
-            commentRange.end.index,
+          return buildManagedCommentEdits(
+            existingItem,
+            `- ${existingRawValue} # Managed by skuba`,
+            new RegExp(
+              `^- ${wrapOptionalQuotesRegex(escapeRegex(existingValue))} # Managed by skuba$`,
+            ),
+            updatedSource,
           );
-          const matchRegex = new RegExp(
-            `^- ${wrapOptionalQuotesRegex(escapeRegex(existingValue))} # Managed by skuba$`,
-          );
-          if (matchRegex.test(content)) {
-            return [];
-          }
-
-          return [
-            {
-              insertedText: `- ${existingRawValue} # Managed by skuba`,
-              startPos: existingItemRange.start.index,
-              endPos: commentRange.end.index,
-            },
-          ];
         });
 
-        return [...newItemsEdits, ...existingItemsEdits.flat()];
+        return [...newItemsEdits, ...existingItemsEdits];
       }
 
       const existingObjectValues = section.findAll({
@@ -490,49 +479,24 @@ export const patchPnpmWorkspace = async (
           endPos: blockStartPos,
         }));
 
-      const existingObjectValuesEdits = existingObjectValues.map(
+      const existingObjectValuesEdits = existingObjectValues.flatMap(
         (existingObjectValue) => {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the item has a key
           const existingRawKey = existingObjectValue.field('key')!.text();
           const existingKey = removeOptionalQuotes(existingRawKey);
-          const existingObjectValueRange = existingObjectValue.range();
-          const maybeManagedComment = existingObjectValue.next();
-
           const configValue = value[existingKey as keyof typeof value];
-
-          if (maybeManagedComment?.kind() !== 'comment') {
-            return [
-              {
-                insertedText: `${existingRawKey}: ${configValue} # Managed by skuba`,
-                startPos: existingObjectValueRange.start.index,
-                endPos: existingObjectValueRange.end.index,
-              },
-            ];
-          }
-
-          const commentRange = maybeManagedComment.range();
-          const content = updatedSource.slice(
-            existingObjectValueRange.start.index,
-            commentRange.end.index,
+          return buildManagedCommentEdits(
+            existingObjectValue,
+            `${existingRawKey}: ${configValue} # Managed by skuba`,
+            new RegExp(
+              `^${wrapOptionalQuotesRegex(escapeRegex(existingKey))}: ${escapeRegex(String(configValue))} # Managed by skuba$`,
+            ),
+            updatedSource,
           );
-          const matchRegex = new RegExp(
-            `^${wrapOptionalQuotesRegex(escapeRegex(existingKey))}: ${escapeRegex(String(configValue))} # Managed by skuba$`,
-          );
-          if (matchRegex.test(content)) {
-            return [];
-          }
-
-          return [
-            {
-              insertedText: `${existingRawKey}: ${configValue} # Managed by skuba`,
-              startPos: existingObjectValueRange.start.index,
-              endPos: commentRange.end.index,
-            },
-          ];
         },
       );
 
-      return [...newObjectValuesEdits, ...existingObjectValuesEdits.flat()];
+      return [...newObjectValuesEdits, ...existingObjectValuesEdits];
     })
     .flat();
 

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.ts
@@ -14,6 +14,8 @@ import { registerAstGrepLanguages } from './registerAstGrepLanguages.js';
 import { Git } from '@skuba-lib/api';
 import { defaultConfig } from 'pnpm-plugin-skuba';
 
+const lockFileUpdateTriggers = ['overrides'];
+
 const isSimpleValue = (value: unknown) =>
   typeof value === 'boolean' ||
   typeof value === 'number' ||
@@ -656,7 +658,6 @@ export const patchPnpmWorkspace = async (
   );
 
   const finalAst = (await parseAsync('yaml', finalSource)).root();
-  const lockFileUpdateTriggers = ['overrides'];
 
   const hasChanged = lockFileUpdateTriggers.some((trigger) => {
     const finalSection = finalAst.find({

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.ts
@@ -147,6 +147,32 @@ const applyDeleteEdits = async (
             },
           },
         })),
+        {
+          kind: 'block_sequence_item',
+          precedes: {
+            kind: 'comment',
+            regex: '# Managed by skuba',
+          },
+          has: {
+            kind: 'flow_node',
+          },
+          inside: {
+            kind: 'block_sequence',
+            inside: {
+              kind: 'block_node',
+              inside: {
+                kind: 'block_mapping_pair',
+                has: {
+                  kind: 'flow_node',
+                  field: 'key',
+                  not: {
+                    regex: `^${wrapOptionalQuotesRegex(arrayValues.map(([key]) => escapeRegex(key)).join('|'))}$`,
+                  },
+                },
+              },
+            },
+          },
+        },
         ...objectValues.map(([key, value]) => ({
           kind: 'block_mapping_pair',
           has: {
@@ -175,6 +201,33 @@ const applyDeleteEdits = async (
             },
           },
         })),
+        {
+          kind: 'block_mapping_pair',
+          has: {
+            kind: 'flow_node',
+            field: 'key',
+          },
+          precedes: {
+            kind: 'comment',
+            regex: '^# Managed by skuba$',
+          },
+          inside: {
+            kind: 'block_mapping',
+            inside: {
+              kind: 'block_node',
+              inside: {
+                kind: 'block_mapping_pair',
+                has: {
+                  kind: 'flow_node',
+                  field: 'key',
+                  not: {
+                    regex: `^${wrapOptionalQuotesRegex(objectValues.map(([key]) => escapeRegex(key)).join('|'))}$`,
+                  },
+                },
+              },
+            },
+          },
+        },
       ],
     },
   });
@@ -487,7 +540,7 @@ export const patchPnpmWorkspace = async (
           const configValue = value[existingKey as keyof typeof value];
           return buildManagedCommentEdits(
             existingObjectValue,
-            `${existingRawKey}: ${configValue} # Managed by skuba`,
+            `${existingRawKey}: ${configValue as string | boolean | number} # Managed by skuba`,
             new RegExp(
               `^${wrapOptionalQuotesRegex(escapeRegex(existingKey))}: ${escapeRegex(String(configValue))} # Managed by skuba$`,
             ),

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { inspect } from 'util';
 
-import { type Edit, type SgNode, parseAsync } from '@ast-grep/napi';
+import { type SgNode, parseAsync } from '@ast-grep/napi';
 import fs from 'fs-extra';
 
 import { log } from '../../../utils/logging.js';
@@ -18,9 +18,6 @@ const isSimpleValue = (value: unknown) =>
   typeof value === 'number' ||
   typeof value === 'string';
 
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
 // Quote strings that begin with YAML reserved indicator characters (@ and `)
 const quoteYamlStringValue = (value: string): string => {
   if (/^[@`]/.test(value)) {
@@ -29,49 +26,226 @@ const quoteYamlStringValue = (value: string): string => {
   return value;
 };
 
-const mapConfigToYamlValue = (
-  key: string,
-  value: (typeof defaultConfig)[keyof typeof defaultConfig],
-): string => {
-  if (isSimpleValue(value)) {
-    const yamlValue =
-      typeof value === 'string' ? quoteYamlStringValue(value) : value;
-    return `${key}: ${yamlValue} # Managed by skuba`;
+const escapeRegex = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const wrapOptionalQuotesRegex = (value: string): string =>
+  `['"]?(${value})['"]?`;
+
+const removeOptionalQuotes = (value: string): string =>
+  value.replace(/^(['"])(.*)\1$/s, '$2');
+
+const applyDeleteEdits = async (
+  source: string,
+  astRoot: SgNode,
+): Promise<{
+  updatedSource: string;
+  updatedAstRoot: SgNode;
+}> => {
+  const {
+    simpleValues = [],
+    arrayValues = [],
+    objectValues = [],
+  } = Object.groupBy(Object.entries(defaultConfig), ([, value]) => {
+    if (isSimpleValue(value)) {
+      return 'simpleValues';
+    }
+    if (Array.isArray(value)) {
+      return 'arrayValues';
+    }
+    return 'objectValues';
+  }) as {
+    simpleValues: Array<[string, string | boolean | number]>;
+    arrayValues: Array<[string, string[]]>;
+    objectValues: Array<[string, Record<string, boolean>]>;
+  };
+
+  const nodesToDelete = astRoot.findAll({
+    rule: {
+      any: [
+        {
+          kind: 'block_mapping_pair',
+          precedes: {
+            kind: 'comment',
+            regex: '# Managed by skuba',
+          },
+          has: {
+            kind: 'flow_node',
+            field: 'key',
+            not: {
+              regex: `^${wrapOptionalQuotesRegex(simpleValues.map(([key]) => escapeRegex(key)).join('|'))}$`,
+            },
+          },
+          inside: {
+            kind: 'block_mapping',
+            inside: {
+              kind: 'block_node',
+              inside: {
+                kind: 'document',
+              },
+            },
+          },
+        },
+        ...arrayValues.map(([key, value]) => ({
+          kind: 'block_sequence_item',
+          precedes: {
+            kind: 'comment',
+            regex: '# Managed by skuba',
+          },
+          has: {
+            kind: 'flow_node',
+            not: {
+              regex: `^${wrapOptionalQuotesRegex(value.map((v) => escapeRegex(v)).join('|'))}$`,
+            },
+          },
+          inside: {
+            kind: 'block_sequence',
+            inside: {
+              kind: 'block_node',
+              inside: {
+                kind: 'block_mapping_pair',
+                has: {
+                  kind: 'flow_node',
+                  field: 'key',
+                  regex: `^${wrapOptionalQuotesRegex(escapeRegex(key))}$`,
+                },
+              },
+            },
+          },
+        })),
+        ...objectValues.map(([key, value]) => ({
+          kind: 'block_mapping_pair',
+          has: {
+            kind: 'flow_node',
+            field: 'key',
+            not: {
+              regex: `^${wrapOptionalQuotesRegex(Object.keys(value).map(escapeRegex).join('|'))}$`,
+            },
+          },
+          precedes: {
+            kind: 'comment',
+            regex: '^# Managed by skuba$',
+          },
+          inside: {
+            kind: 'block_mapping',
+            inside: {
+              kind: 'block_node',
+              inside: {
+                kind: 'block_mapping_pair',
+                has: {
+                  kind: 'flow_node',
+                  field: 'key',
+                  regex: `^${wrapOptionalQuotesRegex(escapeRegex(key))}$`,
+                },
+              },
+            },
+          },
+        })),
+      ],
+    },
+  });
+
+  if (!nodesToDelete.length) {
+    return {
+      updatedSource: source,
+      updatedAstRoot: astRoot,
+    };
   }
 
-  if (Array.isArray(value)) {
-    return `${key}:\n${value.map((item) => `  - ${quoteYamlStringValue(item)} # Managed by skuba`).join('\n')}`;
+  const deleteEdits = nodesToDelete.map((node) => {
+    const nodeRange = node.range();
+
+    const column = nodeRange.start.column;
+    // delete the whole line including any characters before the column, eg. whitespace or list operators
+    const startPos = nodeRange.start.index - column;
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the node has a next sibling
+    const commentNodeEndIndex = node.next()!.range().end.index;
+    const endPos =
+      source.at(commentNodeEndIndex) === '\n'
+        ? commentNodeEndIndex + 1
+        : commentNodeEndIndex;
+
+    return {
+      insertedText: '',
+      startPos,
+      endPos,
+    };
+  });
+
+  const updatedSource = astRoot.commitEdits(deleteEdits);
+  const updatedAstRoot = (await parseAsync('yaml', updatedSource)).root();
+
+  // check if there are any orphaned sections
+  // eg. section is now empty after deleting the last array item or object key
+  const orphanedSections = updatedAstRoot.findAll({
+    rule: {
+      any: [
+        {
+          kind: 'block_mapping_pair',
+          inside: {
+            kind: 'block_mapping',
+            inside: {
+              kind: 'block_node',
+              inside: {
+                kind: 'document',
+              },
+            },
+          },
+          all: [
+            {
+              not: {
+                has: {
+                  kind: 'flow_node',
+                  field: 'value',
+                },
+              },
+            },
+            {
+              not: {
+                has: {
+                  kind: 'block_node',
+                  field: 'value',
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  if (!orphanedSections.length) {
+    return {
+      updatedSource,
+      updatedAstRoot,
+    };
   }
 
-  return `${key}:\n${Object.entries(value)
-    .map(
-      ([subKey, subValue]) =>
-        `  ${quoteYamlStringValue(subKey)}: ${subValue} # Managed by skuba`,
-    )
-    .join('\n')}`;
-};
+  const deleteSectionEdits = orphanedSections.map((node) => {
+    const nodeRange = node.range();
 
-const findEndOfLine = (node: SgNode, pnpmWorkspaceFile: string): SgNode => {
-  const maybeComment = node.next();
-  if (
-    node &&
-    maybeComment?.kind() === 'comment' &&
-    // Check if # Managed by skuba is on the same line as the block_mapping_pair. A comment on a new line and a comment on the same line both appear in the AST
-    // as a comment node immediately following the block_mapping_pair, so we need to check the text to see if it's a comment for the line or a separate line.
-    // eg. The following lines appear as [block_mapping_pair, comment, comment]
-    // someLine: value # Managed by skuba
-    // # Managed by skuba
-    /^[^\n]*# Managed by skuba$/.test(
-      pnpmWorkspaceFile.substring(
-        node.range().start.index,
-        maybeComment.range().end.index,
-      ),
-    )
-  ) {
-    return maybeComment;
-  }
+    const column = nodeRange.start.column;
+    const startPos = nodeRange.start.index - column;
+    const endPos =
+      updatedSource.at(nodeRange.end.index) === '\n'
+        ? nodeRange.end.index + 1
+        : nodeRange.end.index;
 
-  return node;
+    return {
+      insertedText: '',
+      startPos,
+      endPos,
+    };
+  });
+
+  const prunedSource = updatedAstRoot.commitEdits(deleteSectionEdits);
+  const prunedAstRoot = (await parseAsync('yaml', prunedSource)).root();
+
+  return {
+    updatedSource: prunedSource,
+    updatedAstRoot: prunedAstRoot,
+  };
 };
 
 export const patchPnpmWorkspace = async (
@@ -105,232 +279,269 @@ export const patchPnpmWorkspace = async (
   }
 
   registerAstGrepLanguages();
+  const astRoot = (await parseAsync('yaml', pnpmWorkspaceFile)).root();
 
-  const ast = await parseAsync('yaml', pnpmWorkspaceFile);
-  const edits: Edit[] = [];
+  const { updatedSource, updatedAstRoot } = await applyDeleteEdits(
+    pnpmWorkspaceFile,
+    astRoot,
+  );
+  const startOfDocument = updatedAstRoot.range().start.index;
 
-  const blockMapping = ast.root().find({ rule: { kind: 'block_mapping' } });
-
-  const blockMappingPairs = blockMapping
-    ?.children()
-    .filter((child) => child.kind() === 'block_mapping_pair');
-
-  blockMappingPairs?.forEach((pair) => {
-    const key = pair.field('key')?.text();
-    if (key && key in defaultConfig) {
-      return;
-    }
-
-    const endOfLine = findEndOfLine(pair, pnpmWorkspaceFile);
-    const value = pair.field('value');
-    if (value && endOfLine.kind() === 'comment') {
-      edits.push({
-        startPos: pair.range().start.index,
-        endPos: endOfLine.range().end.index + 1, // include the newline after the comment
-        insertedText: '',
-      });
-    }
+  const existingSections = updatedAstRoot.findAll({
+    rule: {
+      kind: 'block_mapping_pair',
+      inside: {
+        kind: 'block_mapping',
+        inside: {
+          kind: 'block_node',
+          inside: {
+            kind: 'document',
+          },
+        },
+      },
+      has: {
+        kind: 'flow_node',
+        field: 'key',
+        regex: `^${wrapOptionalQuotesRegex(
+          Object.keys(defaultConfig).map(escapeRegex).join('|'),
+        )}$`,
+      },
+    },
   });
 
-  const newKeyTexts: string[] = [];
+  const existingSectionsSet = new Set(
+    existingSections.map((section) =>
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the section has a key
+      removeOptionalQuotes(section.field('key')!.text()),
+    ),
+  );
 
-  Object.entries(defaultConfig).forEach(([key, value]) => {
-    const node = blockMappingPairs?.find(
-      (pair) => (pair.field('key')?.text() ?? '') === key,
-    );
-
-    if (!node) {
-      newKeyTexts.push(mapConfigToYamlValue(key, value));
-    } else if (isSimpleValue(value)) {
-      const yamlValue =
-        typeof value === 'string' ? quoteYamlStringValue(value) : value;
-      const managedText = `${key}: ${yamlValue} # Managed by skuba`;
-
-      const endOfLineIndex = findEndOfLine(node, pnpmWorkspaceFile).range().end
-        .index;
-
-      const lineText = pnpmWorkspaceFile.substring(
-        node.range().start.index,
-        endOfLineIndex,
-      );
-      if (lineText !== managedText) {
-        edits.push({
-          startPos: node.range().start.index,
-          endPos: endOfLineIndex,
-          insertedText: managedText,
-        });
+  const addSectionEdits = Object.entries(defaultConfig)
+    .filter(([key]) => !existingSectionsSet.has(key))
+    .map(([key, value]) => {
+      if (isSimpleValue(value)) {
+        return {
+          insertedText: `${quoteYamlStringValue(key)}: ${value} # Managed by skuba\n`,
+          startPos: startOfDocument,
+          endPos: startOfDocument,
+        };
       }
-    } else if (Array.isArray(value)) {
-      const seqItems = node.findAll({ rule: { kind: 'block_sequence_item' } });
 
-      seqItems.forEach((item) => {
-        const itemValue = item
-          .children()
-          .find((child) => child.kind() === 'flow_node')
-          ?.text()
-          ?.replace(/^['"]|['"]$/g, '');
-
-        if (!itemValue || value.includes(itemValue)) {
-          return;
-        }
-
-        const endOfLine = findEndOfLine(item, pnpmWorkspaceFile);
-        if (endOfLine.kind() === 'comment') {
-          edits.push({
-            startPos: item.range().start.index - 2, // include the two spaces before the dash
-            endPos: endOfLine.range().end.index + 1, // include the newline after the comment
-            insertedText: '',
-          });
-        }
-      });
-
-      const missingValues = value
-        .map((v) => {
-          const quotedV = quoteYamlStringValue(v);
-          const seqItem = seqItems.find((item) =>
-            new RegExp(`^- ${escapeRegExp(quotedV)}(?:\\s|$)`).test(
-              item.text(),
-            ),
-          );
-
-          if (!seqItem) {
-            return v;
-          }
-
-          const endOfLineIndex = findEndOfLine(
-            seqItem,
-            pnpmWorkspaceFile,
-          ).range().end.index;
-
-          const lineText = pnpmWorkspaceFile.substring(
-            seqItem.range().start.index,
-            endOfLineIndex,
-          );
-
-          const expectedLineText = `- ${quotedV} # Managed by skuba`;
-          if (lineText !== expectedLineText) {
-            edits.push({
-              startPos: seqItem.range().start.index,
-              endPos: endOfLineIndex,
-              insertedText: expectedLineText,
-            });
-          }
-          return;
-        })
-        .filter((v) => v !== undefined);
-
-      const itemsToAdd = missingValues
-        .map((v) => `\n  - ${quoteYamlStringValue(v)} # Managed by skuba`)
-        .join('');
-
-      // eg. trustPolicyExclude
-      const keyNode = node.field('key');
-
-      if (itemsToAdd && keyNode) {
-        const position = keyNode.range().end.index + 1; // colon
-
-        edits.push({
-          startPos: position,
-          endPos: position,
-          insertedText: `${itemsToAdd}`,
-        });
+      if (Array.isArray(value)) {
+        return {
+          insertedText: `${quoteYamlStringValue(key)}:\n${value.map((v) => `  - ${quoteYamlStringValue(v)} # Managed by skuba\n`).join('')}`,
+          startPos: startOfDocument,
+          endPos: startOfDocument,
+        };
       }
-    } else {
-      const valueNode = node.field('value') ?? node;
-      const mappingItems = valueNode.findAll({
-        rule: { kind: 'block_mapping_pair' },
-      });
 
-      mappingItems.forEach((item) => {
-        const itemKey = item
-          .field('key')
-          ?.text()
-          .replace(/^['"]|['"]$/g, '');
-
-        if (!itemKey || itemKey in value) {
-          return;
-        }
-
-        const endOfLine = findEndOfLine(item, pnpmWorkspaceFile);
-        if (endOfLine.kind() === 'comment') {
-          edits.push({
-            startPos: item.range().start.index - 2, // include the two spaces before the key
-            endPos: endOfLine.range().end.index + 1, // include the newline after the comment
-            insertedText: '',
-          });
-        }
-      });
-
-      const missingKeys = Object.entries(value)
-        .map(([subKey, subValue]) => {
-          const quotedSubKey = quoteYamlStringValue(subKey);
-          const mappingItem = mappingItems.find((item) =>
-            new RegExp(`^${escapeRegExp(quotedSubKey)}:`).test(item.text()),
-          );
-
-          if (!mappingItem) {
-            return [subKey, subValue] as const;
-          }
-
-          const expectedText = `${quotedSubKey}: ${subValue} # Managed by skuba`;
-          const endOfLineIndex = findEndOfLine(
-            mappingItem,
-            pnpmWorkspaceFile,
-          ).range().end.index;
-
-          const itemLineText = pnpmWorkspaceFile.substring(
-            mappingItem.range().start.index,
-            endOfLineIndex,
-          );
-          if (itemLineText !== expectedText) {
-            edits.push({
-              startPos: mappingItem.range().start.index,
-              endPos: endOfLineIndex,
-              insertedText: expectedText,
-            });
-          }
-          return;
-        })
-        .filter((entry) => entry !== undefined);
-
-      const itemsToAdd = missingKeys
-        .map(
-          ([subKey, subValue]) =>
-            `\n  ${quoteYamlStringValue(subKey)}: ${subValue} # Managed by skuba`,
-        )
-        .join('');
-
-      // eg. allowBuilds
-      const keyNode = node.field('key');
-
-      if (itemsToAdd && keyNode) {
-        const position = keyNode.range().end.index + 1; // colon
-        edits.push({
-          startPos: position,
-          endPos: position,
-          insertedText: `${itemsToAdd}`,
-        });
-      }
-    }
-  });
-
-  if (newKeyTexts.length > 0) {
-    edits.push({
-      startPos: ast.root().range().start.index,
-      endPos: ast.root().range().start.index,
-      insertedText: `${newKeyTexts.join('\n')}\n`,
+      return {
+        insertedText: `${quoteYamlStringValue(key)}:\n${Object.entries(value)
+          .map(
+            ([k, v]) =>
+              `  ${quoteYamlStringValue(k)}: ${v} # Managed by skuba\n`,
+          )
+          .join('')}`,
+        startPos: startOfDocument,
+        endPos: startOfDocument,
+      };
     });
-  }
 
-  if (edits.length === 0) {
-    return {
-      ok: true,
-      fixable: false,
-      annotations: [],
-    };
-  }
+  const updateSectionEdits = existingSections
+    .map((section) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the section has a key
+      const rawKey = section.field('key')!.text();
+      const key = removeOptionalQuotes(rawKey);
+      const value = defaultConfig[key as keyof typeof defaultConfig];
+      const sectionRange = section.range();
 
-  if (mode === 'lint') {
+      if (isSimpleValue(value)) {
+        const maybeManagedComment = section.next();
+        if (maybeManagedComment?.kind() !== 'comment') {
+          return [
+            {
+              insertedText: `${rawKey}: ${value} # Managed by skuba`,
+              startPos: sectionRange.start.index,
+              endPos: sectionRange.end.index,
+            },
+          ];
+        }
+        const commentRange = maybeManagedComment.range();
+        const content = updatedSource.slice(
+          sectionRange.start.index,
+          commentRange.end.index,
+        );
+        const matchRegex = new RegExp(
+          `^${wrapOptionalQuotesRegex(escapeRegex(key))}: ${escapeRegex(String(value))} # Managed by skuba$`,
+        );
+        if (matchRegex.test(content)) {
+          return [];
+        }
+
+        return [
+          {
+            insertedText: `${rawKey}: ${value} # Managed by skuba`,
+            startPos: sectionRange.start.index,
+            endPos: commentRange.end.index,
+          },
+        ];
+      }
+
+      if (Array.isArray(value)) {
+        const existingItems = section.findAll({
+          rule: {
+            kind: 'block_sequence_item',
+            has: {
+              kind: 'flow_node',
+              regex: `^${wrapOptionalQuotesRegex(value.map((v) => escapeRegex(v)).join('|'))}$`,
+            },
+          },
+        });
+
+        const existingItemsSet = new Set(
+          existingItems.map((item) =>
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the item has a child
+            removeOptionalQuotes(item.child(1)!.text()),
+          ),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the section has a value
+        const blockValue = section.field('value')!;
+        const blockValueRange = blockValue.range();
+        const blockStartPos =
+          blockValueRange.start.index - blockValueRange.start.column;
+        const newItemsEdits = value
+          .filter((item) => !existingItemsSet.has(item))
+          .map((item) => ({
+            insertedText: `  - ${quoteYamlStringValue(item)} # Managed by skuba\n`,
+            startPos: blockStartPos,
+            endPos: blockStartPos,
+          }));
+
+        const existingItemsEdits = existingItems.map((existingItem) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the item has a child
+          const existingRawValue = existingItem.child(1)!.text();
+          const existingValue = removeOptionalQuotes(existingRawValue);
+          const existingItemRange = existingItem.range();
+          const maybeManagedComment = existingItem.next();
+          if (maybeManagedComment?.kind() !== 'comment') {
+            return [
+              {
+                insertedText: `- ${existingRawValue} # Managed by skuba`,
+                startPos: existingItemRange.start.index,
+                endPos: existingItemRange.end.index,
+              },
+            ];
+          }
+
+          const commentRange = maybeManagedComment.range();
+          const content = updatedSource.slice(
+            existingItemRange.start.index,
+            commentRange.end.index,
+          );
+          const matchRegex = new RegExp(
+            `^- ${wrapOptionalQuotesRegex(escapeRegex(existingValue))} # Managed by skuba$`,
+          );
+          if (matchRegex.test(content)) {
+            return [];
+          }
+
+          return [
+            {
+              insertedText: `- ${existingRawValue} # Managed by skuba`,
+              startPos: existingItemRange.start.index,
+              endPos: commentRange.end.index,
+            },
+          ];
+        });
+
+        return [...newItemsEdits, ...existingItemsEdits.flat()];
+      }
+
+      const existingObjectValues = section.findAll({
+        rule: {
+          kind: 'block_mapping_pair',
+          has: {
+            kind: 'flow_node',
+            field: 'key',
+            regex: `^${wrapOptionalQuotesRegex(Object.keys(value).map(escapeRegex).join('|'))}$`,
+          },
+        },
+      });
+
+      const existingObjectValuesSet = new Set(
+        existingObjectValues.map((item) =>
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the item has a key
+          removeOptionalQuotes(item.field('key')!.text()),
+        ),
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the section has a value
+      const blockNodeValue = section.field('value')!;
+      const blockValueRange = blockNodeValue.range();
+      const blockStartPos =
+        blockValueRange.start.index - blockValueRange.start.column;
+
+      const newObjectValuesEdits = Object.entries(value)
+        .filter(([objKey]) => !existingObjectValuesSet.has(objKey))
+        .map(([objKey, objValue]) => ({
+          insertedText: `  ${quoteYamlStringValue(objKey)}: ${objValue} # Managed by skuba\n`,
+          startPos: blockStartPos,
+          endPos: blockStartPos,
+        }));
+
+      const existingObjectValuesEdits = existingObjectValues.map(
+        (existingObjectValue) => {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- we know the item has a key
+          const existingRawKey = existingObjectValue.field('key')!.text();
+          const existingKey = removeOptionalQuotes(existingRawKey);
+          const existingObjectValueRange = existingObjectValue.range();
+          const maybeManagedComment = existingObjectValue.next();
+
+          const configValue = value[existingKey as keyof typeof value];
+
+          if (maybeManagedComment?.kind() !== 'comment') {
+            return [
+              {
+                insertedText: `${existingRawKey}: ${configValue} # Managed by skuba`,
+                startPos: existingObjectValueRange.start.index,
+                endPos: existingObjectValueRange.end.index,
+              },
+            ];
+          }
+
+          const commentRange = maybeManagedComment.range();
+          const content = updatedSource.slice(
+            existingObjectValueRange.start.index,
+            commentRange.end.index,
+          );
+          const matchRegex = new RegExp(
+            `^${wrapOptionalQuotesRegex(escapeRegex(existingKey))}: ${escapeRegex(String(configValue))} # Managed by skuba$`,
+          );
+          if (matchRegex.test(content)) {
+            return [];
+          }
+
+          return [
+            {
+              insertedText: `${existingRawKey}: ${configValue} # Managed by skuba`,
+              startPos: existingObjectValueRange.start.index,
+              endPos: commentRange.end.index,
+            },
+          ];
+        },
+      );
+
+      return [...newObjectValuesEdits, ...existingObjectValuesEdits.flat()];
+    })
+    .flat();
+
+  const finalSource = updatedAstRoot.commitEdits([
+    ...addSectionEdits,
+    ...updateSectionEdits,
+  ]);
+
+  if (mode === 'lint' && finalSource !== pnpmWorkspaceFile) {
     return {
       ok: false,
       fixable: true,
@@ -344,11 +555,9 @@ export const patchPnpmWorkspace = async (
     };
   }
 
-  const newSource = ast.root().commitEdits(edits);
-
   await fs.promises.writeFile(
     path.join(dir, 'pnpm-workspace.yaml'),
-    newSource,
+    finalSource,
     'utf8',
   );
 

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.ts
@@ -553,6 +553,18 @@ export const patchPnpmWorkspace = async (
     })
     .flat();
 
+  if (
+    !addSectionEdits.length &&
+    !updateSectionEdits.length &&
+    pnpmWorkspaceFile === updatedSource
+  ) {
+    return {
+      ok: true,
+      fixable: false,
+      annotations: [],
+    };
+  }
+
   const finalSource = updatedAstRoot.commitEdits([
     ...addSectionEdits,
     ...updateSectionEdits,

--- a/src/cli/lint/internalLints/patchPnpmWorkspace.ts
+++ b/src/cli/lint/internalLints/patchPnpmWorkspace.ts
@@ -4,6 +4,7 @@ import { inspect } from 'util';
 import { type Edit, type SgNode, parseAsync } from '@ast-grep/napi';
 import fs from 'fs-extra';
 
+import { createExec } from '../../../utils/exec.js';
 import { log } from '../../../utils/logging.js';
 import { detectPackageManager } from '../../../utils/packageManager.js';
 import type { InternalLintResult } from '../internal.js';
@@ -589,6 +590,65 @@ export const patchPnpmWorkspace = async (
     finalSource,
     'utf8',
   );
+
+  const finalAst = (await parseAsync('yaml', finalSource)).root();
+  const lockFileUpdateTriggers = ['overrides'];
+
+  const hasChanged = lockFileUpdateTriggers.some((trigger) => {
+    const finalSection = finalAst.find({
+      rule: {
+        kind: 'block_mapping_pair',
+        has: {
+          kind: 'flow_node',
+          field: 'key',
+          regex: `^${wrapOptionalQuotesRegex(escapeRegex(trigger))}$`,
+        },
+        inside: {
+          kind: 'block_mapping',
+          inside: {
+            kind: 'block_node',
+            inside: {
+              kind: 'document',
+            },
+          },
+        },
+      },
+    });
+
+    const existingSection = astRoot.find({
+      rule: {
+        kind: 'block_mapping_pair',
+        has: {
+          kind: 'flow_node',
+          field: 'key',
+          regex: `^${wrapOptionalQuotesRegex(escapeRegex(trigger))}$`,
+        },
+        inside: {
+          kind: 'block_mapping',
+          inside: {
+            kind: 'block_node',
+            inside: {
+              kind: 'document',
+            },
+          },
+        },
+      },
+    });
+
+    return existingSection?.text() !== finalSection?.text();
+  });
+
+  if (hasChanged) {
+    log.subtle(
+      'pnpm-workspace.yaml was updated, running `pnpm install` to update lockfile...',
+    );
+    await createExec({ cwd: dir })(
+      'pnpm',
+      'install',
+      '--no-frozen-lockfile',
+      '--prefer-offline',
+    );
+  }
 
   return {
     ok: true,

--- a/src/cli/lint/internalLints/upgrade/patches/15.0.1/removePnpmPlugin.test.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/15.0.1/removePnpmPlugin.test.ts
@@ -144,6 +144,8 @@ describe('removePnpmPlugin', () => {
       trustPolicy: off # Managed by skuba
       trustPolicyExclude:
         - semver@6.3.1 # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       ",
       }
     `);
@@ -214,6 +216,8 @@ configDependencies:
       trustPolicy: off # Managed by skuba
       trustPolicyExclude:
         - semver@6.3.1 # Managed by skuba
+      overrides:
+        '@arethetypeswrong/core@0.18.2>fflate': 0.8.2 # Managed by skuba
       packages:
         - .
       ",

--- a/src/cli/lint/internalLints/upgrade/patches/15.0.1/removePnpmPlugin.test.ts
+++ b/src/cli/lint/internalLints/upgrade/patches/15.0.1/removePnpmPlugin.test.ts
@@ -7,7 +7,11 @@ import type { PatchConfig, PatchReturnType } from '../../index.js';
 
 import { removePnpmPlugin } from './removePnpmPlugin.js';
 
-vi.mock('../../../../../../utils/exec.js');
+vi.mock('../../../../../../utils/exec.js', () => ({
+  exec: vi.fn(),
+  createExec: vi.fn().mockImplementation(() => vi.fn()),
+}));
+
 vi.mock('fs-extra', () => ({
   default: memfs.fs,
   ...memfs.fs,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,10 @@
     "rootDir": ".",
     "customConditions": ["@seek/skuba/source"],
     "declaration": true,
-    "lib": ["ES2023"],
+    "lib": ["ES2024"],
     "outDir": "lib",
     "removeComments": false,
-    "target": "ES2023",
+    "target": "ES2024",
     "moduleResolution": "Node16",
     "module": "node20"
   },


### PR DESCRIPTION
> tl;dr: I was a noob and didn't know how to use `@ast-grep` effectively and have made the patch better.

Bit of a hack until https://github.com/arethetypeswrong/arethetypeswrong.github.io/issues/258 is resolved to unblock our repos

This was initially a hack to quickly resolve our issues but I've re-written it completely to handle more scenarios.

Basically this whole script does:

1. Look for lines with `# Managed by skuba` to delete which don't match our config.
2. Delete any sections which may be left orphaned after deleting.
3. Add missing managed sections
4. Update existing sections.
5. Run `pnpm install` if we've added an override to update the lockfile