### PR TITLE
Increase base Fargate task size

### DIFF
--- a/.changeset/three-dolls-look.md
+++ b/.changeset/three-dolls-look.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/\*-rest-api: Increase base gantry instance size.
+template/\*-rest-api: Increase base Fargate task size

--- a/.changeset/three-dolls-look.md
+++ b/.changeset/three-dolls-look.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/\*-rest-api: Increase base gantry instance size.

--- a/template/express-rest-api/gantry.apply.yml
+++ b/template/express-rest-api/gantry.apply.yml
@@ -119,8 +119,8 @@ autoScaling:
         ComparisonOperator: LessThanThreshold
 
 
-cpu: 256
-memory: 512
+cpu: 512
+memory: 1024
 
 deployment:
   smokeTest:

--- a/template/koa-rest-api/gantry.apply.yml
+++ b/template/koa-rest-api/gantry.apply.yml
@@ -118,8 +118,8 @@ autoScaling:
         Threshold: 0
         ComparisonOperator: LessThanThreshold
 
-cpu: 256
-memory: 512
+cpu: 512
+memory: 1024
 
 deployment:
   smokeTest:


### PR DESCRIPTION
These are potentially slightly under provisioned as a default since there have been various instances of these not being updated when the systems are given production traffic... 

There's the trade off between maybe spending more than required at a baseline for new services that don't see much traffic vs the cost of this being a contributing factor to future incidents. 

Also worth mentioning that this will not affect existing services, as this is not enough cause to start modifying consumers provisioned resources 😅 

