### PR TITLE
Add `.npmrc` to templates

### DIFF
--- a/.changeset/flat-spoons-give.md
+++ b/.changeset/flat-spoons-give.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+template/\*: Sets `@seek:registry` in `.npmrc` to SEEK's private registry in templates typically used for internal projects.

--- a/.changeset/flat-spoons-give.md
+++ b/.changeset/flat-spoons-give.md
@@ -2,4 +2,4 @@
 'skuba': patch
 ---
 
-template/\*: Sets `@seek:registry` in `.npmrc` to SEEK's private registry in templates typically used for internal projects.
+template/\*: Sets `@seek:registry` in `.npmrc` to SEEK's private registry.

--- a/template/express-rest-api/.npmrc
+++ b/template/express-rest-api/.npmrc
@@ -1,0 +1,1 @@
+@seek:registry=https://npm.cloudsmith.io/seek/npm/

--- a/template/greeter/.npmrc
+++ b/template/greeter/.npmrc
@@ -1,0 +1,1 @@
+@seek:registry=https://npm.cloudsmith.io/seek/npm/

--- a/template/koa-rest-api/.npmrc
+++ b/template/koa-rest-api/.npmrc
@@ -1,0 +1,1 @@
+@seek:registry=https://npm.cloudsmith.io/seek/npm/

--- a/template/lambda-sqs-worker-cdk/.npmrc
+++ b/template/lambda-sqs-worker-cdk/.npmrc
@@ -1,0 +1,1 @@
+@seek:registry=https://npm.cloudsmith.io/seek/npm/

--- a/template/private-npm-package/.npmrc
+++ b/template/private-npm-package/.npmrc
@@ -1,0 +1,1 @@
+@seek:registry=https://npm.cloudsmith.io/seek/npm/


### PR DESCRIPTION
@72636c @samchungy and I are unsure if this is something we want or not. 

Current state any new project will not get the new `.npmrc` file and will not be compliant

Adding it to the templates breaks the integration tests (which is easy to hack around) but means any external consumers would have to remove this file before it is usable, and I think it would break during the install in the init 🤔 