### PR TITLE
init: Make non-interactive mode discoverable

### DIFF
--- a/.changeset/brave-foxes-march.md
+++ b/.changeset/brave-foxes-march.md
@@ -2,7 +2,6 @@
 'skuba': patch
 ---
 
-init: Clean up the partially initialised directory when non-interactive templating fails
+init: Clean up partially-initialised directory when non-interactive templating fails
 
-When `skuba init` reads its config from stdin and the provided `templateData` is missing required fields, or the template's templating cannot be skipped, it now deletes the directory it created before exiting.
-Previously this left a broken project behind that had to be manually removed before retrying.
+When `skuba init` reads its config from stdin and the provided `templateData` is missing required fields or templating cannot be skipped, it now deletes the directory it created before exiting. Previously this left a broken project behind that had to be manually removed before retrying.

--- a/.changeset/brave-foxes-march.md
+++ b/.changeset/brave-foxes-march.md
@@ -1,0 +1,8 @@
+---
+'skuba': patch
+---
+
+init: Clean up the partially initialised directory when non-interactive templating fails
+
+When `skuba init` reads its config from stdin and the provided `templateData` is missing required fields, or the template's templating cannot be skipped, it now deletes the directory it created before exiting.
+Previously this left a broken project behind that had to be manually removed before retrying.

--- a/.changeset/sweet-otters-call.md
+++ b/.changeset/sweet-otters-call.md
@@ -1,0 +1,9 @@
+---
+'skuba': minor
+---
+
+init: Make non-interactive mode discoverable
+
+`skuba init` now accepts a `--non-interactive` flag that forces it to read JSON config from stdin, regardless of whether stdin is a TTY.
+Running it without piping any input prints the expected JSON Schema, including a description and example for each field, so the required config is discoverable without trial and error.
+A `skuba init --help` (`-h`) option has also been added to document this usage.

--- a/.changeset/sweet-otters-call.md
+++ b/.changeset/sweet-otters-call.md
@@ -4,6 +4,4 @@
 
 init: Make non-interactive mode discoverable
 
-`skuba init` now accepts a `--non-interactive` flag that forces it to read JSON config from stdin, regardless of whether stdin is a TTY.
-Running it without piping any input prints the expected JSON Schema, including a description and example for each field, so the required config is discoverable without trial and error.
-A `skuba init --help` (`-h`) option has also been added to document this usage.
+`skuba init` now accepts a `--non-interactive` flag that forces it to read JSON config from stdin, regardless of whether stdin is a TTY. Running it without piping any input prints the expected JSON Schema, including a description and example for each field, so the required config is discoverable without trial and error. A `skuba init --help` (`-h`) option has also been added to document this usage.

--- a/docs/cli/init.md
+++ b/docs/cli/init.md
@@ -20,9 +20,11 @@ Creates a new local project from a starter [template].
 and only requires a connection to the public npm registry.
 Most of its built-in templates start you off with a [Buildkite pipeline] that should be ready to go once you push your repository to GitHub and configure Buildkite.
 
-| Option    | Description                 |
-| :-------- | :-------------------------- |
-| `--debug` | Enable debug console output |
+| Option              | Description                                      |
+| :------------------ | :----------------------------------------------- |
+| `--debug`           | Enable debug console output                      |
+| `--non-interactive` | Read JSON config from stdin instead of prompting |
+| `--help`, `-h`      | Show help for the command                        |
 
 ### Interactive walkthrough
 
@@ -92,10 +94,10 @@ git push --set-upstream origin main
 
 You can now proceed to the [next steps](#next-steps).
 
-### Unattended execution
+### Non-interactive execution
 
 `skuba init` is interactive by default.
-For unattended execution, pipe in JSON:
+For non-interactive execution, pipe in JSON:
 
 ```shell
 skuba init << EOF
@@ -106,12 +108,18 @@ skuba init << EOF
     "ownerName": "my-org/my-team",
     "prodBuildkiteQueueName": "123456789012:cicd",
     "platformName": "arm64",
-    "repoName": "tmp-greeter"
+    "repoName": "tmp-greeter",
+    "defaultBranch": "main"
   },
   "templateName": "greeter"
 }
 EOF
 ```
+
+`skuba init` reads this JSON automatically when stdin is not a TTY.
+
+Pass `--non-interactive` to require piped input and never fall back to an interactive prompt.
+If stdin is a TTY, `skuba init --non-interactive` prints the expected JSON Schema and exits instead of prompting.
 
 --
 

--- a/src/cli/help/index.ts
+++ b/src/cli/help/index.ts
@@ -1,8 +1,9 @@
 import { showHelp } from '../../utils/help.js';
 import { showLogoAndVersionInfo } from '../../utils/logo.js';
 
-export const help = async () => {
+export const help = async (args = process.argv.slice(2)) => {
   await showLogoAndVersionInfo();
 
-  showHelp();
+  // `skuba help <command>` leaves the command as the sole remaining argument.
+  await showHelp(args[0]);
 };

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -31,6 +31,7 @@ import {
   getTemplateName,
   shouldContinue,
 } from './prompts.js';
+import { readJSONFromStdIn } from './readJSONFromStdIn.js';
 import { type InitConfig, initConfigInputSchema } from './types.js';
 
 export const runForm = async <T = Record<string, string>>(props: {
@@ -304,50 +305,13 @@ export const configureFromPrompt = async (): Promise<InitConfig> => {
   };
 };
 
-export const readJSONFromStdIn = async () => {
-  let text = '';
-
-  await new Promise((resolve) =>
-    process.stdin
-      .on('data', (chunk) => (text += chunk.toString()))
-      .once('end', resolve),
-  );
-
-  text = text.trim();
-
-  if (text === '') {
-    log.err('No data from stdin.');
-    process.exit(1);
-  }
-
-  let value: unknown;
-
-  try {
-    value = JSON.parse(text) as unknown;
-  } catch {
-    log.err('Invalid JSON from stdin.');
-    process.exit(1);
-  }
-
-  return value;
-};
-
 const configureFromPipe = async (): Promise<InitConfig> => {
-  const value = await readJSONFromStdIn();
-
-  const result = initConfigInputSchema.safeParse(value);
-
-  if (!result.success) {
-    log.err('Invalid data from stdin:');
-    log.err(result.error);
-    process.exit(1);
-  }
-
-  const { destinationDir, templateComplete, templateName } = result.data;
+  const config = await readJSONFromStdIn(initConfigInputSchema);
+  const { destinationDir, templateComplete, templateName } = config;
 
   const templateData = {
-    ...(await baseToTemplateData(result.data.templateData)),
-    ...result.data.templateData,
+    ...(await baseToTemplateData(config.templateData)),
+    ...config.templateData,
   };
 
   await createDirectory(destinationDir);
@@ -358,11 +322,13 @@ const configureFromPipe = async (): Promise<InitConfig> => {
   if (!templateComplete) {
     if (noSkip) {
       log.err('Templating for', log.bold(templateName), 'cannot be skipped.');
+      // Remove the partially-created project; it's not salvageable
+      await fs.remove(destinationDir);
       process.exit(1);
     }
 
     return {
-      ...result.data,
+      ...config,
       entryPoint,
       packageManager,
       templateData: {
@@ -380,14 +346,37 @@ const configureFromPipe = async (): Promise<InitConfig> => {
   const missing = required.filter((name) => !provided.has(name));
 
   if (missing.length > 0) {
-    log.err('This template uses the following information:');
+    log.err(
+      'This template requires the following additional fields in',
+      `${log.bold('templateData')}:`,
+    );
     log.newline();
-    missing.forEach((name) => log.err(`- ${name}`));
+    for (const { name, message, initial } of fields) {
+      if (missing.includes(name)) {
+        log.err(`- ${log.bold(name)}`);
+        if (initial) {
+          log.err(`  ${message}`, log.dim(`(e.g. ${initial})`));
+        } else {
+          log.err(`  ${message}`);
+        }
+        log.newline();
+      }
+    }
+
+    log.err(
+      'Provide these fields, or set',
+      log.bold('templateComplete: false'),
+      'to scaffold them as placeholders and resume later by running',
+      log.bold('skuba init'),
+      'in the new directory.',
+    );
+
+    await fs.remove(destinationDir);
     process.exit(1);
   }
 
   return {
-    ...result.data,
+    ...config,
     entryPoint,
     packageManager,
     templateData,
@@ -395,5 +384,5 @@ const configureFromPipe = async (): Promise<InitConfig> => {
   };
 };
 
-export const getConfig = () =>
-  process.stdin.isTTY ? configureFromPrompt() : configureFromPipe();
+export const getConfig = ({ nonInteractive }: { nonInteractive: boolean }) =>
+  nonInteractive ? configureFromPipe() : configureFromPrompt();

--- a/src/cli/init/help.ts
+++ b/src/cli/init/help.ts
@@ -1,0 +1,32 @@
+import { log } from '../../utils/logging.js';
+
+export const logInitHelp = () => {
+  log.plain(log.bold('skuba init'));
+  log.newline();
+  log.plain(
+    'Creates a new local project from a starter template, or resumes templating.',
+  );
+  log.newline();
+  log.plain(
+    'Shows an interactive form on a TTY; otherwise reads JSON config from stdin.',
+  );
+  log.newline();
+  log.plain(log.bold('Usage'));
+  log.plain('  skuba init [--debug] [--non-interactive]');
+  log.newline();
+  log.plain(log.bold('Options'));
+  log.plain('  --debug              Enable debug console output.');
+  log.plain(
+    '  --non-interactive    Read JSON config from stdin instead of prompting.',
+  );
+  log.plain(
+    '                       Run with no input to print the expected JSON Schema.',
+  );
+  log.plain('  --help, -h           Show this help text.');
+  log.newline();
+  log.plain(log.bold('Resuming templating'));
+  log.plain(
+    'Running `skuba init` inside a project with a `skuba.template.js` in its root',
+  );
+  log.plain('resumes templating its remaining fields.');
+};

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -36,11 +36,6 @@ import { writePackageJson } from './writePackageJson.js';
 import * as Git from '@skuba-lib/api/git';
 
 export const init = async (args = process.argv.slice(2)) => {
-  if (hasHelpFlag(args)) {
-    logInitHelp();
-    return;
-  }
-
   const opts: Input = {
     debug: hasDebugFlag(args),
   };
@@ -50,6 +45,11 @@ export const init = async (args = process.argv.slice(2)) => {
   const nonInteractive = hasNonInteractiveFlag(args) || !process.stdin.isTTY;
 
   const skubaVersionInfo = await showLogoAndVersionInfo();
+
+  if (hasHelpFlag(args)) {
+    logInitHelp();
+    return;
+  }
 
   const consumerManifest = await getConsumerManifest();
   if (

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -3,7 +3,11 @@ import { inspect } from 'util';
 
 import fs from 'fs-extra';
 
-import { hasDebugFlag } from '../../utils/args.js';
+import {
+  hasDebugFlag,
+  hasHelpFlag,
+  hasNonInteractiveFlag,
+} from '../../utils/args.js';
 import { copyFiles, createEjsRenderer } from '../../utils/copy.js';
 import { createInclusionFilter } from '../../utils/dir.js';
 import { createExec, ensureCommands } from '../../utils/exec.js';
@@ -23,6 +27,7 @@ import { tryPatchRenovateConfig } from '../lint/internalLints/patchRenovateConfi
 
 import { getConfig } from './getConfig.js';
 import { initialiseRepo } from './git.js';
+import { logInitHelp } from './help.js';
 import { installPnpmPlugin } from './installPnpmPlugin.js';
 import { resumeTemplating } from './resumeTemplating.js';
 import type { Input } from './types.js';
@@ -31,9 +36,18 @@ import { writePackageJson } from './writePackageJson.js';
 import * as Git from '@skuba-lib/api/git';
 
 export const init = async (args = process.argv.slice(2)) => {
+  if (hasHelpFlag(args)) {
+    logInitHelp();
+    return;
+  }
+
   const opts: Input = {
     debug: hasDebugFlag(args),
   };
+
+  // Force reading from stdin when `--non-interactive` is passed, otherwise fall
+  // back to whether stdin is a TTY.
+  const nonInteractive = hasNonInteractiveFlag(args) || !process.stdin.isTTY;
 
   const skubaVersionInfo = await showLogoAndVersionInfo();
 
@@ -44,7 +58,7 @@ export const init = async (args = process.argv.slice(2)) => {
       path.join(path.dirname(consumerManifest.path), TEMPLATE_CONFIG_FILENAME),
     ))
   ) {
-    await resumeTemplating({ manifest: consumerManifest });
+    await resumeTemplating({ manifest: consumerManifest, nonInteractive });
     return;
   }
 
@@ -56,7 +70,7 @@ export const init = async (args = process.argv.slice(2)) => {
     templateData,
     templateName,
     type,
-  } = await getConfig();
+  } = await getConfig({ nonInteractive });
 
   await ensureCommands(packageManager);
 

--- a/src/cli/init/readJSONFromStdIn.test.ts
+++ b/src/cli/init/readJSONFromStdIn.test.ts
@@ -1,0 +1,101 @@
+import { Readable } from 'stream';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as z from 'zod/v4';
+
+import { log } from '../../utils/logging.js';
+
+import { readJSONFromStdIn } from './readJSONFromStdIn.js';
+
+const schema = z.object({
+  name: z.string().describe('a name'),
+});
+
+const realStdin = process.stdin;
+
+const setStdin = (
+  chunks: string[],
+  { isTTY = false }: { isTTY?: boolean } = {},
+) => {
+  const stream = Readable.from(chunks);
+  Object.defineProperty(stream, 'isTTY', { value: isTTY, configurable: true });
+  Object.defineProperty(process, 'stdin', {
+    value: stream,
+    configurable: true,
+  });
+};
+
+const mockExit = () =>
+  vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('process.exit');
+  });
+
+afterEach(() => {
+  Object.defineProperty(process, 'stdin', {
+    value: realStdin,
+    configurable: true,
+  });
+  vi.restoreAllMocks();
+});
+
+describe('readJSONFromStdIn', () => {
+  it('returns the parsed data for valid input', async () => {
+    setStdin([JSON.stringify({ name: 'hello' })]);
+
+    await expect(readJSONFromStdIn(schema)).resolves.toEqual({ name: 'hello' });
+  });
+
+  it('prints the schema and exits when stdin is a TTY', async () => {
+    // A TTY means nothing was piped in; we should bail rather than hang.
+    setStdin([], { isTTY: true });
+    const err = vi.spyOn(log, 'err').mockReturnValue(undefined);
+    const exit = mockExit();
+
+    await expect(readJSONFromStdIn(schema)).rejects.toThrow('process.exit');
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(err).toHaveBeenCalledWith(
+      'No data piped to stdin. Expected JSON satisfying the following schema:',
+    );
+  });
+
+  it('prints the schema and exits on empty input', async () => {
+    setStdin([]);
+    const err = vi.spyOn(log, 'err').mockReturnValue(undefined);
+    const exit = mockExit();
+
+    await expect(readJSONFromStdIn(schema)).rejects.toThrow('process.exit');
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(err).toHaveBeenCalledWith(
+      'No data from stdin. Expected JSON satisfying the following schema:',
+    );
+  });
+
+  it('prints the schema and exits on invalid JSON', async () => {
+    setStdin(['this is not json']);
+    const err = vi.spyOn(log, 'err').mockReturnValue(undefined);
+    const exit = mockExit();
+
+    await expect(readJSONFromStdIn(schema)).rejects.toThrow('process.exit');
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(err).toHaveBeenCalledWith(
+      // Don't assert the precise syntax error
+      expect.stringMatching(
+        /^Invalid JSON from stdin: .+\. Expected JSON satisfying the following schema:$/,
+      ),
+    );
+  });
+
+  it('exits when the input does not match the schema', async () => {
+    setStdin([JSON.stringify({ name: 123 })]);
+    const err = vi.spyOn(log, 'err').mockReturnValue(undefined);
+    const exit = mockExit();
+
+    await expect(readJSONFromStdIn(schema)).rejects.toThrow('process.exit');
+
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(err).toHaveBeenCalledWith('Invalid data from stdin:');
+  });
+});

--- a/src/cli/init/readJSONFromStdIn.ts
+++ b/src/cli/init/readJSONFromStdIn.ts
@@ -1,0 +1,66 @@
+import type * as z from 'zod/v4';
+
+import { log } from '../../utils/logging.js';
+
+/** Prints a JSON Schema of our expected input format to stdout. */
+const printInputSchemaHint = (schema: z.ZodType, detail: string) => {
+  log.err(
+    log.bold(`${detail}. Expected JSON satisfying the following schema:`),
+  );
+  log.err(JSON.stringify(schema.toJSONSchema(), null, 2));
+};
+
+/**
+ * Reads JSON from stdin and validates it against the provided Zod schema.
+ *
+ * If the input is not provided or invalid, we use the Zod schema to help guide
+ * the user towards the correct input format.
+ */
+export const readJSONFromStdIn = async <T extends z.ZodType>(
+  schema: T,
+): Promise<z.infer<T>> => {
+  // A TTY means nothing has been piped in, so reading would block indefinitely
+  // waiting for EOF. Bail out with the expected schema instead of hanging.
+  if (process.stdin.isTTY) {
+    printInputSchemaHint(schema, 'No data piped to stdin');
+    process.exit(1);
+  }
+
+  let text = '';
+
+  await new Promise((resolve) =>
+    process.stdin
+      .on('data', (chunk) => (text += chunk.toString()))
+      .once('end', resolve),
+  );
+
+  text = text.trim();
+
+  if (text === '') {
+    printInputSchemaHint(schema, 'No data from stdin');
+    process.exit(1);
+  }
+
+  let rawInput: unknown;
+
+  try {
+    rawInput = JSON.parse(text) as unknown;
+  } catch (err) {
+    const detail =
+      err instanceof SyntaxError
+        ? `Invalid JSON from stdin: ${err.message}`
+        : 'Invalid JSON from stdin';
+
+    printInputSchemaHint(schema, detail);
+    process.exit(1);
+  }
+
+  const parseResult = schema.safeParse(rawInput);
+  if (!parseResult.success) {
+    log.err(log.bold('Invalid data from stdin:'));
+    log.err(parseResult.error);
+    process.exit(1);
+  }
+
+  return parseResult.data;
+};

--- a/src/cli/init/resumeTemplating.int.test.ts
+++ b/src/cli/init/resumeTemplating.int.test.ts
@@ -8,15 +8,11 @@ import type { ReadResult } from '../configure/types.js';
 
 import { resumeTemplating } from './resumeTemplating.js';
 
-vi.mock('./getConfig.js', async (importActual) => {
-  const actual = await importActual<typeof import('./getConfig.js')>();
-  return {
-    ...actual,
-    readJSONFromStdIn: vi.fn(),
-  };
-});
+vi.mock('./readJSONFromStdIn.js', () => ({
+  readJSONFromStdIn: vi.fn(),
+}));
 
-const { readJSONFromStdIn } = await import('./getConfig.js');
+const { readJSONFromStdIn } = await import('./readJSONFromStdIn.js');
 
 const TEMP_ROOT = path.join(
   import.meta.dirname,
@@ -26,8 +22,6 @@ const TEMP_ROOT = path.join(
   'integration',
   'resume-templating',
 );
-
-const isTTY = process.stdin.isTTY;
 
 let tempDir: string;
 
@@ -67,12 +61,9 @@ const skubaTemplateJs = `export default {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // Force the non-interactive (stdin) path.
-  process.stdin.isTTY = false;
 });
 
 afterEach(async () => {
-  process.stdin.isTTY = isTTY;
   await fs.remove(TEMP_ROOT);
 });
 
@@ -89,7 +80,7 @@ describe('resumeTemplating', () => {
       'src/app.ts': "export const queue = '<%- prodBuildkiteQueueName %>';\n",
     });
 
-    await resumeTemplating({ manifest });
+    await resumeTemplating({ manifest, nonInteractive: true });
 
     await expect(
       fs.promises.readFile(path.join(tempDir, 'src/app.ts'), 'utf8'),
@@ -106,7 +97,7 @@ describe('resumeTemplating', () => {
       'skuba.template.js': `export default { fields: [], packageManager: 'pnpm' };\n`,
     });
 
-    await resumeTemplating({ manifest });
+    await resumeTemplating({ manifest, nonInteractive: true });
 
     expect(readJSONFromStdIn).not.toHaveBeenCalled();
     await expect(

--- a/src/cli/init/resumeTemplating.ts
+++ b/src/cli/init/resumeTemplating.ts
@@ -16,21 +16,49 @@ import { hasStringProp } from '../../utils/validation.js';
 import { formatPackage } from '../configure/processing/package.js';
 import type { ReadResult } from '../configure/types.js';
 
-import { getTemplateConfig, readJSONFromStdIn, runForm } from './getConfig.js';
+import { getTemplateConfig, runForm } from './getConfig.js';
+import { readJSONFromStdIn } from './readJSONFromStdIn.js';
 
 interface Props {
   manifest: ReadResult;
+
+  /** Whether to read template data as JSON from stdin. */
+  nonInteractive: boolean;
 }
 
-const templateDataSchema = z.object({
-  templateData: z.record(z.string(), z.string()),
-});
+/**
+ * Builds a schema for the template's remaining fields.
+ *
+ * Each field is required, described with its prompt message, and given its
+ * initial value as an example. `readJSONFromStdIn` will dump this schema to the
+ * console to inform users of the template-specific fields.
+ */
+const getTemplateDataSchema = (templateConfig: TemplateConfig) =>
+  z.object({
+    templateData: z
+      .object(
+        Object.fromEntries(
+          templateConfig.fields.map(
+            ({ name, message, initial }) =>
+              [
+                name,
+                z.string().meta({
+                  description: message,
+                  examples: initial ? [initial] : undefined,
+                }),
+              ] as const,
+          ),
+        ),
+      )
+      .describe(
+        "Values for the template's remaining fields, keyed by the field names declared in `skuba.template.js`.",
+      ),
+  });
 
 const getTemplateDataFromStdIn = async (
   templateConfig: TemplateConfig,
 ): Promise<Record<string, string>> => {
-  const config = await readJSONFromStdIn();
-  const data = templateDataSchema.parse(config);
+  const data = await readJSONFromStdIn(getTemplateDataSchema(templateConfig));
 
   templateConfig.fields.forEach((field) => {
     const value = data.templateData[field.name];
@@ -46,7 +74,10 @@ const getTemplateDataFromStdIn = async (
   return data.templateData;
 };
 
-export const resumeTemplating = async ({ manifest }: Props): Promise<void> => {
+export const resumeTemplating = async ({
+  manifest,
+  nonInteractive,
+}: Props): Promise<void> => {
   const destinationRoot = path.dirname(manifest.path);
 
   const templateConfig = await getTemplateConfig(destinationRoot);
@@ -61,16 +92,16 @@ export const resumeTemplating = async ({ manifest }: Props): Promise<void> => {
     : 'template';
 
   log.newline();
-  const templateData = process.stdin.isTTY
-    ? await runForm({
+  const templateData = nonInteractive
+    ? await getTemplateDataFromStdIn(templateConfig)
+    : await runForm({
         choices: templateConfig.fields,
         message: styleText(
           'bold',
           `Complete ${styleText('cyan', templateName)}:`,
         ),
         name: 'customAnswers',
-      })
-    : await getTemplateDataFromStdIn(templateConfig);
+      });
 
   const updatedPackageJson = await formatPackage(manifest.packageJson);
   const packageJsonFilepath = path.join(destinationRoot, 'package.json');

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -15,17 +15,56 @@ export interface Input {
 export type InitConfigInput = z.infer<typeof initConfigInputSchema>;
 
 export const initConfigInputSchema = z.object({
-  destinationDir: z.string(),
-  templateComplete: z.boolean(),
+  destinationDir: z
+    .string()
+    .describe(
+      'Directory to create the new project in, relative to the current working directory.',
+    ),
+  templateComplete: z
+    .boolean()
+    .describe(
+      'Whether all of the template fields are provided. If unsure, set to `false` and run `skuba init` in the new directory to resume the templating process.',
+    ),
   templateData: z
     .object({
-      ownerName: z.string(),
-      repoName: z.string(),
-      platformName: z.union([z.literal('amd64'), z.literal('arm64')]),
-      defaultBranch: z.string(),
+      ownerName: z
+        .string()
+        .describe(
+          'Repository owner in `org/team` form. `orgName` and `teamName` are derived from this.',
+        )
+        .meta({ examples: ['SEEK-Jobs/my-team'] }),
+      repoName: z
+        .string()
+        .describe('Name of the repository to create, without the org prefix.')
+        .meta({ examples: ['my-repo'] }),
+      platformName: z
+        .union([z.literal('amd64'), z.literal('arm64')])
+        .describe("Target CPU architecture for the project's compute."),
+      defaultBranch: z
+        .string()
+        .describe("The repository's default branch.")
+        .meta({ examples: ['main', 'master'] }),
     })
-    .catchall(z.string()),
-  templateName: z.string(),
+    .catchall(
+      z
+        .string()
+        .describe(
+          "Additional template-specific fields, keyed by the field names declared in the template's `skuba.template.js`.",
+        ),
+    ),
+  templateName: z
+    .string()
+    .describe(
+      'Built-in template name, or a `github:`, `seek:`, or `local:` prefixed template reference.',
+    )
+    .meta({
+      examples: [
+        'greeter',
+        'github:my-org/my-template',
+        'seek:my-private-template',
+        'local:./path/to/template',
+      ],
+    }),
 });
 
 export type InitConfig = z.infer<typeof initConfigSchema>;

--- a/src/cli/migrate/index.ts
+++ b/src/cli/migrate/index.ts
@@ -1,3 +1,4 @@
+import { hasHelpFlag } from '../../utils/args.js';
 import { log } from '../../utils/logging.js';
 
 import { addFileExtensions } from './esm/addFileExtensions.js';
@@ -58,7 +59,7 @@ export const migrations = {
   'file-extensions': () => addFileExtensions({ mode: 'format' }),
 } satisfies Record<string, () => Promise<unknown>>;
 
-const logAvailableMigrations = () => {
+export const logAvailableMigrations = () => {
   log.ok('Available migrations:');
   Object.keys(migrations).forEach((migration) => {
     log.ok(`- ${migration}`);
@@ -73,7 +74,7 @@ export const migrate = async (args = process.argv.slice(2)) => {
     return;
   }
 
-  if (args.includes('--help') || args.includes('-h') || args[0] === 'help') {
+  if (hasHelpFlag(args)) {
     logAvailableMigrations();
     return;
   }

--- a/src/skuba.ts
+++ b/src/skuba.ts
@@ -78,7 +78,7 @@ const skuba = async () => {
 
   log.err(log.bold(commandName), 'is not recognised as a command.');
   await showLogoAndVersionInfo();
-  showHelp();
+  await showHelp();
 
   process.exitCode = 1;
   return;

--- a/src/utils/args.test.ts
+++ b/src/utils/args.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, test } from 'vitest';
 
 import {
   hasDebugFlag,
+  hasHelpFlag,
+  hasNonInteractiveFlag,
   hasSerialFlag,
   parseProcessArgs,
   parseRunArgs,
@@ -19,6 +21,37 @@ describe('hasDebugFlag', () => {
     ${'matching arg among others'} | ${['something', '--debug', 'else']} | ${true}
   `('$description => $expected', ({ args, expected }) =>
     expect(hasDebugFlag(args)).toBe(expected),
+  );
+});
+
+describe('hasHelpFlag', () => {
+  test.each`
+    description                    | args                               | expected
+    ${'no args'}                   | ${[]}                              | ${false}
+    ${'unrelated args'}            | ${['something', 'else']}           | ${false}
+    ${'single dash'}               | ${['-help']}                       | ${false}
+    ${'matching --help'}           | ${['--help']}                      | ${true}
+    ${'matching -h'}               | ${['-h']}                          | ${true}
+    ${'matching help command'}     | ${['help']}                        | ${true}
+    ${'help not at start'}         | ${['something', 'help']}           | ${false}
+    ${'matching arg among others'} | ${['something', '--help', 'else']} | ${true}
+  `('$description => $expected', ({ args, expected }) =>
+    expect(hasHelpFlag(args)).toBe(expected),
+  );
+});
+
+describe('hasNonInteractiveFlag', () => {
+  test.each`
+    description                    | args                                          | expected
+    ${'no args'}                   | ${[]}                                         | ${false}
+    ${'unrelated args'}            | ${['something', 'else']}                      | ${false}
+    ${'single dash'}               | ${['-non-interactive']}                       | ${false}
+    ${'matching lowercase arg'}    | ${['--non-interactive']}                      | ${true}
+    ${'matching uppercase arg'}    | ${['--NON-INTERACTIVE']}                      | ${true}
+    ${'matching spongebob arg'}    | ${['--nOn-InTeRaCtIvE']}                      | ${true}
+    ${'matching arg among others'} | ${['something', '--non-interactive', 'else']} | ${true}
+  `('$description => $expected', ({ args, expected }) =>
+    expect(hasNonInteractiveFlag(args)).toBe(expected),
   );
 });
 

--- a/src/utils/args.ts
+++ b/src/utils/args.ts
@@ -5,6 +5,12 @@ import { COMMAND_ALIASES } from './command.js';
 export const hasDebugFlag = (args = process.argv) =>
   args.some((arg) => arg.toLocaleLowerCase() === '--debug');
 
+export const hasHelpFlag = (args = process.argv) =>
+  args.includes('--help') || args.includes('-h') || args[0] === 'help';
+
+export const hasNonInteractiveFlag = (args = process.argv) =>
+  args.some((arg) => arg.toLocaleLowerCase() === '--non-interactive');
+
 export const hasSerialFlag = (args = process.argv, env = process.env) =>
   args.some((arg) => arg.toLocaleLowerCase() === '--serial') ||
   Boolean(

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -1,7 +1,22 @@
 import { COMMAND_LIST } from './command.js';
 import { log } from './logging.js';
 
-export const showHelp = () => {
+export const showHelp = async (command?: string) => {
+  switch (command) {
+    case 'init': {
+      const { logInitHelp } = await import('../cli/init/help.js');
+      logInitHelp();
+      return;
+    }
+    case 'migrate': {
+      const { logAvailableMigrations } =
+        await import('../cli/migrate/index.js');
+
+      logAvailableMigrations();
+      return;
+    }
+  }
+
   log.plain(log.bold('Available commands:'));
 
   COMMAND_LIST.forEach((item) => log.plain(item));


### PR DESCRIPTION
We have an unattended mode originally implemented for integration tests. When trying to get an AI coding agent to use skuba directly, it stumbles over the interactive prompt and eventually brute forces the unattended mode, but trips over a few things:

- `skuba init` has no help text

- Schema errors fail field-by-field with no descriptions/examples, requiring a huge amount of iterations to basically brute force the result.

- When we set `templateComplete` and don't pass all of the fields, we leave a broken repository behind that needs to be deleted before the next iteration. The AI coding agent will eventually figure this out as well, but it's at least one extra turn it loses.

With a few (hopefully) non-breaking changes, we can make this much more discoverable: This:

- Rebrands "unattended" mode to "non-interactive" mode which is the more conventional name an agent would be looking for (this only appeared in docs, not code)

- Adds support for `skuba init --help`, based on the existing `skuba migrate --help` support.

  This accepts a number of variants (`skuba init help`, `skuba help init` etc.) because Claude seems to try exactly one combination and give up if it doesn't get help text back.

- Adds an explicit `--non-interactive` flag to force non-interactive mode, regardless if we're attached to a TTY.

- Prints our JSON schema when we receive no input at all, and documents that as a feature of `--non-interactive`

- Add descriptions to our Zod schema to document the purpose of the values, and add `defaultBranch` to our Markdown example.

- Dynamically build a Zod schema for our `templateData` when resuming templating, so we dump all the fields with descriptions/examples at once.

- When template fields are missing with `templateComplete: false`, more explicitly document where they should be passed, and delete the partially initialised directory we created.
