### PR TITLE
Use legible logo for AI agents

### DIFF
--- a/.changeset/quiet-banners-rest.md
+++ b/.changeset/quiet-banners-rest.md
@@ -1,0 +1,10 @@
+---
+'skuba': patch
+---
+
+Use a legible logo when running under an AI agent
+
+skuba prints a multi-line ASCII art banner at startup which AI agents are unable to read.
+It now detects when it's running under an AI agent and replaces the ASCII art with the word `skuba` inlined on the version line.
+
+Interactive (human) usage is unchanged.

--- a/.changeset/quiet-banners-rest.md
+++ b/.changeset/quiet-banners-rest.md
@@ -2,9 +2,8 @@
 'skuba': patch
 ---
 
-Use a legible logo when running under an AI agent
+help, init: Use a legible logo when running under an AI agent
 
-skuba prints a multi-line ASCII art banner at startup which AI agents are unable to read.
-It now detects when it's running under an AI agent and replaces the ASCII art with the word `skuba` inlined on the version line.
+skuba prints a multi-line ASCII art banner at startup which AI agents are unable to read. It now detects when it's running under an AI agent and replaces the ASCII art with the word `skuba` inlined on the version line.
 
 Interactive (human) usage is unchanged.

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "rolldown": "^1.1.0",
     "semantic-release": "^25.0.2",
     "simple-git": "^3.36.0",
+    "std-env": "^4.1.0",
     "ts-dedent": "^2.2.0",
     "tsconfig-seek": "2.0.0",
     "tsdown": "~0.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       simple-git:
         specifier: ^3.36.0
         version: 3.36.0
+      std-env:
+        specifier: ^4.1.0
+        version: 4.1.0
       ts-dedent:
         specifier: ^2.2.0
         version: 2.3.0

--- a/src/utils/logo.ts
+++ b/src/utils/logo.ts
@@ -1,5 +1,7 @@
 import { styleText } from 'node:util';
 
+import { isAgent } from 'std-env';
+
 import { log } from './logging.js';
 import { detectPackageManager } from './packageManager.js';
 import { getSkubaVersionInfo } from './version.js';
@@ -20,8 +22,12 @@ export const showLogoAndVersionInfo = async () => {
     detectPackageManager(),
   ]);
 
-  log.plain(LOGO);
+  if (!isAgent) {
+    log.plain(LOGO);
+  }
+
   log.subtle(
+    ...(isAgent ? ['skuba'] : []),
     log.bold(versionInfo.local),
     '|',
     'latest',


### PR DESCRIPTION
skuba prints an ASCII art banner at startup which takes up about 5 lines of output. I'm personally quite fond of it and think it's great for interactive use.

However, I queried 7 different models showing them the ASCII art, and none of them were able to read it (including Opus 4.8). This is concerning as the model might think it's being given some important information it's not able to decode.

AI coding agents also love piping command output through `head` or `tail` to protect their context window, so freeing up 5 lines makes it more likely they can read large output on the first try (e.g. the schema outputs from #2482).

This uses the same `std-env` library that `vitest` uses for agent detection, and switches from the ASCII art logo to just inlining the word "skuba" on our version line.
