### PR TITLE
Update `eslint-config-seek dep to 15.0.6`

### DIFF
--- a/.changeset/great-cougars-go.md
+++ b/.changeset/great-cougars-go.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+Update `eslint-config-seek` dep to `15.0.6`

--- a/.changeset/ready-games-knock.md
+++ b/.changeset/ready-games-knock.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-skuba': patch
+---
+
+Update `eslint-config-seek` dep to `15.0.6`

--- a/packages/eslint-config-skuba/package.json
+++ b/packages/eslint-config-skuba/package.json
@@ -40,7 +40,7 @@
     "test:ci": "echo \"No tests\""
   },
   "dependencies": {
-    "eslint-config-seek": "15.0.5",
+    "eslint-config-seek": "15.0.6",
     "eslint-plugin-skuba": "workspace:*",
     "eslint-plugin-yml": "^3.0.0",
     "typescript-eslint": "^8.59.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
   packages/eslint-config-skuba:
     dependencies:
       eslint-config-seek:
-        specifier: 15.0.5
-        version: 15.0.5(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
+        specifier: 15.0.6
+        version: 15.0.6(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
       eslint-plugin-skuba:
         specifier: workspace:*
         version: link:../eslint-plugin-skuba
@@ -2913,8 +2913,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-seek@15.0.5:
-    resolution: {integrity: sha512-RV96LgapTurM9imjk/Ttxxi3r3dOAYYQ4IG2guBRhNSrgT8jyD/OTGvgHpvoZKnCu5zKedTo0G+k3sJmrze1Kg==}
+  eslint-config-seek@15.0.6:
+    resolution: {integrity: sha512-f6qj/YQa00p8bH8G+mzFIun8s7X67E6H+TpQAfDJ69umt7UvoauqNsuFbipNAATJOynvz5nCRxYR873j6nhvsA==}
     engines: {node: '>=22.21.1'}
     peerDependencies:
       eslint: '>=9.22.0'
@@ -8890,7 +8890,7 @@ snapshots:
     dependencies:
       eslint: 10.5.0(jiti@2.7.0)
 
-  eslint-config-seek@15.0.5(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9):
+  eslint-config-seek@15.0.6(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/utils@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9):
     dependencies:
       '@vitest/eslint-plugin': 1.6.20(@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)
       eslint: 10.5.0(jiti@2.7.0)


### PR DESCRIPTION
Skuba uses `vitest/valid-title` rule [here](https://github.com/seek-oss/skuba/blob/65b90382f2e81347b3516713fac1c2c9a85b78b1/packages/eslint-config-skuba/src/index.ts#L74) which is available in later versions of `@vitest/eslint-plugin` (at least >1.6.6)

However, `eslint-config-seek@15.0.5` was only bringing in at the minimum `^1.5.2`.
This means some codebases could be stuck in earlier versions of `@vitest/eslint-plugin` without manual dep bump or lockfile refresh.

This PR bumps `eslint-config-seek` to `15.0.6` which brings in `@vitest/eslint-plugin^1.6.20` which should fix this issue.