### PR TITLE
Try to fix CI failure in #2480

### DIFF
--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -63,8 +63,10 @@ pnpm add --save-dev "${skuba_tar}"
 
 directory="./tmp-${template}"
 
+set +e
 echo "--- skuba init ${template}"
-pnpm exec skuba init << EOF
+skuba_init_log=$(mktemp)
+pnpm exec skuba init << EOF 2>&1 | tee "${skuba_init_log}"
 {
   "destinationDir": "${directory}",
   "templateComplete": true,
@@ -88,6 +90,20 @@ pnpm exec skuba init << EOF
   "templateName": "${template}"
 }
 EOF
+
+result=${PIPESTATUS[0]}
+
+# Continue if `skuba init` choked on `pnpm install`.
+# A changeset versioning PR will initially fail to install the new version from
+# the remote registry; the subsequent local tar install should weed out other
+# installation issues.
+if [[ $result -ne 0 && $(cat "${skuba_init_log}") != *"Failed to install dependencies"* ]]; then
+    rm "${skuba_init_log}"
+    exit 1
+fi
+
+rm "${skuba_init_log}"
+set -e
 
 cd "${directory}" || exit 1
 

--- a/scripts/test-template.sh
+++ b/scripts/test-template.sh
@@ -26,20 +26,20 @@ pnpm build
 
 echo '--- pnpm pack'
 # Aaron Moat is sure there's a better way to do this
-skuba_lib_api_tar="$(pwd)/packages/api/$(cd packages/api && pnpm pack | grep -o 'skuba-lib-api-.*\.tgz')"
-eslint_plugin_skuba_tar="$(pwd)/packages/eslint-plugin-skuba/$(cd packages/eslint-plugin-skuba && pnpm pack | grep -o 'eslint-plugin-skuba-.*\.tgz')"
-vitest_koa_mocks_tar="$(pwd)/packages/vitest-koa-mocks/$(cd packages/vitest-koa-mocks && pnpm pack | grep -o 'skuba-lib-vitest-koa-mocks-.*\.tgz')"
-pnpm_plugin_skuba_tar="$(pwd)/packages/pnpm-plugin-skuba/$(cd packages/pnpm-plugin-skuba && pnpm pack | grep -o 'pnpm-plugin-skuba-.*\.tgz')"
+skuba_lib_api_tar="$(pwd)/packages/api/$(cd packages/api && pnpm pack | grep -Eo '^skuba-lib-api-[0-9].*\.tgz')"
+eslint_plugin_skuba_tar="$(pwd)/packages/eslint-plugin-skuba/$(cd packages/eslint-plugin-skuba && pnpm pack | grep -Eo '^eslint-plugin-skuba-[0-9].*\.tgz')"
+vitest_koa_mocks_tar="$(pwd)/packages/vitest-koa-mocks/$(cd packages/vitest-koa-mocks && pnpm pack | grep -Eo '^skuba-lib-vitest-koa-mocks-[0-9].*\.tgz')"
+pnpm_plugin_skuba_tar="$(pwd)/packages/pnpm-plugin-skuba/$(cd packages/pnpm-plugin-skuba && pnpm pack | grep -Eo '^pnpm-plugin-skuba-[0-9].*\.tgz')"
 jq ".dependencies[\"eslint-plugin-skuba\"] = \"file:${eslint_plugin_skuba_tar}\"" packages/eslint-config-skuba/package.json > packages/eslint-config-skuba/package.json.tmp
 mv packages/eslint-config-skuba/package.json packages/eslint-config-skuba/package.json.bak
 mv packages/eslint-config-skuba/package.json.tmp packages/eslint-config-skuba/package.json
-eslint_config_skuba_tar="$(pwd)/packages/eslint-config-skuba/$(cd packages/eslint-config-skuba && pnpm pack | grep -o 'eslint-config-skuba-.*\.tgz')"
+eslint_config_skuba_tar="$(pwd)/packages/eslint-config-skuba/$(cd packages/eslint-config-skuba && pnpm pack | grep -Eo '^eslint-config-skuba-[0-9].*\.tgz')"
 mv packages/eslint-config-skuba/package.json.bak packages/eslint-config-skuba/package.json
 
 jq ".dependencies[\"eslint-config-skuba\"] = \"file:${eslint_config_skuba_tar}\" | .dependencies[\"@skuba-lib/api\"] = \"file:${skuba_lib_api_tar}\" | .dependencies[\"@skuba-lib/vitest-koa-mocks\"] = \"file:${vitest_koa_mocks_tar}\" | .dependencies[\"pnpm-plugin-skuba\"] = \"file:${pnpm_plugin_skuba_tar}\"" package.json > package.json.tmp
 mv package.json package.json.bak
 mv package.json.tmp package.json
-skuba_tar="$(pwd)/$(pnpm pack | grep -o 'skuba-.*\.tgz')"
+skuba_tar="$(pwd)/$(pnpm pack | grep -Eo '^skuba-[0-9].*\.tgz')"
 mv package.json.bak package.json
 
 skuba_temp_directory='tmp-skuba'


### PR DESCRIPTION
I haven't quite figured out why this would be newly failing; errant thought is whether we could have pnpm cache understand to pull `skuba@16.3.0` from the local `skuba-16.3.0.tgz` somehow.

https://github.com/seek-oss/skuba/actions/runs/28345437072/job/83967722579#step:5:954