### PR TITLE
Update editor guidance

### DIFF
--- a/docs/deep-dives/editors.md
+++ b/docs/deep-dives/editors.md
@@ -27,7 +27,8 @@ parent: Deep dives
          "source.fixAll.eslint": "explicit"
        },
        "editor.defaultFormatter": "esbenp.prettier-vscode"
-     }
+     },
+     "typescript.tsdk": "./node_modules/typescript/lib"
    }
    ```
 


### PR DESCRIPTION
I was using TypeScript 6.0.0 features and I was going crazy because I couldn't figure out why my IDE was not accepting the new TypeScript syntax. Turns out it's because Cursor is just so far behind on Vscode features. This just sets Vscode to use the local workspace's TypeScript version.

<img width="561" height="153" alt="image" src="https://github.com/user-attachments/assets/6182ed0b-2797-45e2-8355-50e4b774ffad" />
