### PR TITLE
init: allow custom Renovate presets

### DIFF
--- a/.changeset/calm-pandas-renovate.md
+++ b/.changeset/calm-pandas-renovate.md
@@ -1,0 +1,7 @@
+---
+'skuba': minor
+---
+
+init: Add a Renovate preset option
+
+`skuba init` now lets projects customise the Renovate preset generated in `.github/renovate.json5`. It defaults to `github>seek-oss/rynovate` to preserve the existing behaviour.

--- a/src/cli/init/getConfig.ts
+++ b/src/cli/init/getConfig.ts
@@ -194,11 +194,12 @@ export const getTemplateConfig = async (
   }
 };
 
-const baseToTemplateData = async ({
+export const baseToTemplateData = async ({
   ownerName,
   platformName,
   repoName,
   defaultBranch,
+  renovatePreset,
 }: BaseFields) => {
   const [orgName, teamName] = ownerName.split('/');
 
@@ -213,6 +214,7 @@ const baseToTemplateData = async ({
     ownerName,
     repoName,
     defaultBranch,
+    renovatePreset,
     // Use standalone username in `teamName` contexts
     teamName: teamName ?? orgName,
 
@@ -226,7 +228,7 @@ const baseToTemplateData = async ({
 };
 
 export const configureFromPrompt = async (): Promise<InitConfig> => {
-  const { ownerName, platformName, repoName, defaultBranch } =
+  const { ownerName, platformName, repoName, defaultBranch, renovatePreset } =
     await runForm<BaseFields>(BASE_PROMPT_PROPS);
   log.plain(styleText('cyan', repoName), 'by', styleText('cyan', ownerName));
 
@@ -235,6 +237,7 @@ export const configureFromPrompt = async (): Promise<InitConfig> => {
     platformName,
     repoName,
     defaultBranch,
+    renovatePreset,
   });
 
   const destinationDir = repoName;

--- a/src/cli/init/prompts.test.ts
+++ b/src/cli/init/prompts.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { BASE_PROMPT_PROPS } from './prompts.js';
+import { DEFAULT_RENOVATE_PRESET } from './types.js';
+
+describe('BASE_PROMPT_PROPS', () => {
+  it('defaults the Renovate preset to Rynovate', () => {
+    expect(
+      BASE_PROMPT_PROPS.choices.find(({ name }) => name === 'renovatePreset'),
+    ).toMatchObject({
+      message: 'Renovate preset',
+      initial: DEFAULT_RENOVATE_PRESET,
+      allowInitial: true,
+    });
+  });
+});

--- a/src/cli/init/prompts.ts
+++ b/src/cli/init/prompts.ts
@@ -3,6 +3,7 @@ import { input, select } from '@inquirer/prompts';
 import { pathExists } from '../../utils/fs.js';
 import { TEMPLATE_NAMES_WITH_BYO } from '../../utils/template.js';
 
+import { DEFAULT_RENOVATE_PRESET } from './types.js';
 import {
   PLATFORM_OPTIONS,
   type Platform,
@@ -85,6 +86,14 @@ const BASE_CHOICES = [
     name: 'defaultBranch',
     message: 'Default Branch',
     initial: 'main',
+    allowInitial: true,
+    validate: (value: unknown) =>
+      typeof value === 'string' && value.length > 0 ? true : 'Required',
+  },
+  {
+    name: 'renovatePreset',
+    message: 'Renovate preset',
+    initial: DEFAULT_RENOVATE_PRESET,
     allowInitial: true,
     validate: (value: unknown) =>
       typeof value === 'string' && value.length > 0 ? true : 'Required',

--- a/src/cli/init/renovatePreset.test.ts
+++ b/src/cli/init/renovatePreset.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { createEjsRenderer } from '../../utils/copy.js';
+import { readBaseTemplateFile } from '../../utils/template.js';
+
+import { baseToTemplateData } from './getConfig.js';
+
+describe('Renovate preset template', () => {
+  it('includes the configured preset in template data', async () => {
+    const renovatePreset = 'github>my-org/renovate-config';
+
+    await expect(
+      baseToTemplateData({
+        ownerName: 'my-org/my-team',
+        repoName: 'my-repo',
+        platformName: 'arm64',
+        defaultBranch: 'main',
+        renovatePreset,
+      }),
+    ).resolves.toMatchObject({ renovatePreset });
+  });
+
+  it('renders the configured preset', async () => {
+    const renovatePreset = 'github>my-org/renovate-config';
+    const template = await readBaseTemplateFile('.github/renovate.json5');
+
+    expect(createEjsRenderer({ renovatePreset })('renovate.json5', template))
+      .toBe(`{
+  extends: ['${renovatePreset}'],
+}
+`);
+  });
+});

--- a/src/cli/init/types.test.ts
+++ b/src/cli/init/types.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_RENOVATE_PRESET, initConfigInputSchema } from './types.js';
+
+const config = {
+  destinationDir: 'my-repo',
+  templateComplete: true,
+  templateData: {
+    ownerName: 'my-org/my-team',
+    repoName: 'my-repo',
+    platformName: 'arm64',
+    defaultBranch: 'main',
+  },
+  templateName: 'greeter',
+} as const;
+
+describe('initConfigInputSchema', () => {
+  it('defaults the Renovate preset to Rynovate', () => {
+    expect(initConfigInputSchema.parse(config).templateData).toMatchObject({
+      renovatePreset: DEFAULT_RENOVATE_PRESET,
+    });
+  });
+
+  it('accepts a custom Renovate preset', () => {
+    const renovatePreset = 'github>my-org/renovate-config';
+
+    expect(
+      initConfigInputSchema.parse({
+        ...config,
+        templateData: { ...config.templateData, renovatePreset },
+      }).templateData,
+    ).toMatchObject({ renovatePreset });
+  });
+});

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -3,6 +3,8 @@ import * as z from 'zod/v4';
 import { projectTypeSchema } from '../../utils/manifest.js';
 import { packageManagerSchema } from '../../utils/packageManager.js';
 
+export const DEFAULT_RENOVATE_PRESET = 'github>seek-oss/rynovate';
+
 export interface Input {
   /**
    * Whether to enable verbose debug logging.
@@ -44,6 +46,13 @@ export const initConfigInputSchema = z.object({
         .string()
         .describe("The repository's default branch.")
         .meta({ examples: ['main', 'master'] }),
+      renovatePreset: z
+        .string()
+        .default(DEFAULT_RENOVATE_PRESET)
+        .describe('Renovate preset for the generated project to extend.')
+        .meta({
+          examples: [DEFAULT_RENOVATE_PRESET, 'github>my-org/renovate-config'],
+        }),
     })
     .catchall(
       z

--- a/template/base/.github/renovate.json5
+++ b/template/base/.github/renovate.json5
@@ -1,3 +1,3 @@
 {
-  extends: ['github>seek-oss/rynovate'],
+  extends: ['<%- renovatePreset %>'],
 }


### PR DESCRIPTION
## Summary

- add a Renovate preset field to the interactive `skuba init` form
- expose the same field in non-interactive configuration with the existing Rynovate preset as its default
- render the selected preset into the generated Renovate config

## Motivation

The base template currently hardcodes `github>seek-oss/rynovate`, so projects cannot select an organisation-specific preset during initialisation. This keeps the current default while allowing projects to extend their own preset.

Credit to @samchungy for identifying the missing initialisation option and the expected default behaviour.

Fixes #1994.

## Validation

- `pnpm test` (70 test files, 849 tests)
- `pnpm build`
- `pnpm exec tsc --noEmit`
- focused ESLint and Prettier checks on the changed files