### PR TITLE
lint: allow skuba.template.js in template repositories

### DIFF
--- a/.changeset/fresh-templates-pass.md
+++ b/.changeset/fresh-templates-pass.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+lint: Allow `skuba.template.js` in template repositories
+
+The `no-skuba-template-js` internal lint now distinguishes source template repositories from generated projects using the `package.json#skuba` metadata written by `skuba init`.

--- a/src/cli/lint/internalLints/noSkubaTemplateJs.test.ts
+++ b/src/cli/lint/internalLints/noSkubaTemplateJs.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { pathExists } from '../../../utils/fs.js';
 import { log } from '../../../utils/logging.js';
+import { getConsumerManifest } from '../../../utils/manifest.js';
 
 import { noSkubaTemplateJs } from './noSkubaTemplateJs.js';
 
@@ -12,8 +13,19 @@ const stdout = () => stdoutMock.mock.calls.flat(1).join('');
 vi.mock('../../../utils/fs.js', () => ({
   pathExists: vi.fn(),
 }));
+vi.mock('../../../utils/manifest.js');
 
 beforeEach(() => {
+  vi.mocked(getConsumerManifest).mockResolvedValue({
+    packageJson: {
+      skuba: { version: '1.0.0' },
+      _id: 'test',
+      name: 'test',
+      readme: '',
+      version: '1.0.0',
+    },
+    path: '/project/package.json',
+  });
   vi.spyOn(console, 'log').mockImplementation((...args) =>
     stdoutMock(`${args.join(' ')}\n`),
   );
@@ -29,6 +41,27 @@ describe('noSkubaTemplateJs', () => {
     ${'format'}
     ${'lint'}
   `('$mode mode', ({ mode }) => {
+    it('should report ok in a template repository', async () => {
+      vi.mocked(getConsumerManifest).mockResolvedValueOnce({
+        packageJson: {
+          _id: 'test',
+          name: 'test-template',
+          readme: '',
+          version: '1.0.0',
+        },
+        path: '/template/package.json',
+      });
+      vi.mocked(pathExists).mockResolvedValueOnce(true);
+
+      await expect(noSkubaTemplateJs(mode, log)).resolves.toEqual({
+        ok: true,
+        fixable: false,
+      });
+
+      expect(stdout()).toBe('');
+      expect(pathExists).not.toHaveBeenCalled();
+    });
+
     it('should report ok if skuba.template.js does not exist, and output nothing', async () => {
       vi.mocked(pathExists).mockResolvedValueOnce(false);
 

--- a/src/cli/lint/internalLints/noSkubaTemplateJs.ts
+++ b/src/cli/lint/internalLints/noSkubaTemplateJs.ts
@@ -16,6 +16,11 @@ export const noSkubaTemplateJs = async (
     return { ok: true, fixable: false };
   }
 
+  if (manifest.packageJson.skuba === undefined) {
+    // Source template repositories intentionally retain skuba.template.js.
+    return { ok: true, fixable: false };
+  }
+
   const templateConfigPath = path.join(
     path.dirname(manifest.path),
     'skuba.template.js',


### PR DESCRIPTION
## Summary

- allow `no-skuba-template-js` to pass in source template repositories that do not have `package.json#skuba` metadata
- preserve the existing incomplete-template error for generated projects
- cover both lint and format modes and add a patch changeset

Fixes #1379.

Good catch by @72636c: source templates intentionally retain `skuba.template.js`, while generated projects receive `package.json#skuba` metadata during `skuba init`.

## Root cause

The internal lint treated the presence of `skuba.template.js` as evidence of an incomplete generated project in every repository. That same file is expected in source template repositories, so linting skuba's templates produced a false positive.

The rule now uses the consumer manifest metadata written during project initialisation to distinguish generated projects from source templates before checking for the template file.

## Compatibility

There is no API change. Generated projects with `package.json#skuba` continue to fail lint when a leftover `skuba.template.js` is present; source template repositories without that metadata now pass.

## Checks

- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `pnpm test` (67 files, 846 tests)
- `pnpm exec vitest run src/cli/lint/internalLints/noSkubaTemplateJs.test.ts` (6 tests)
- `pnpm --filter '!./template/**' test:ci`
- `pnpm test:template greeter`
- `pnpm test:template oss-npm-package`

The full root `pnpm test:ci` run passed 867 of 869 tests locally. Two `format.int.test.ts` snapshots differed only in ANSI colour codes under the local terminal and Node 24.14.0; the repository targets Node 24.18 and CI will provide the authoritative integration result.