### PR TITLE
fix: skip GitHub integrations without Git metadata

### DIFF
--- a/.changeset/tidy-git-checks-skip.md
+++ b/.changeset/tidy-git-checks-skip.md
@@ -1,0 +1,7 @@
+---
+'skuba': patch
+---
+
+cli: Skip GitHub integrations when no Git repository is available
+
+Lint and test annotations and CI autofixes now exit with a concise warning instead of logging Git errors when the working directory has no `.git` metadata.

--- a/.changeset/tidy-git-checks-skip.md
+++ b/.changeset/tidy-git-checks-skip.md
@@ -2,6 +2,6 @@
 'skuba': patch
 ---
 
-cli: Skip GitHub integrations when no Git repository is available
+lint/test: Skip GitHub autofixes and annotations when no Git repository is available
 
 Lint and test annotations and CI autofixes now exit with a concise warning instead of logging Git errors when the working directory has no `.git` metadata.

--- a/src/cli/lint/annotate/github/index.test.ts
+++ b/src/cli/lint/annotate/github/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
+import { log } from '../../../../utils/logging.js';
 import type { ESLintOutput } from '../../../adapter/eslint.js';
 import type { PrettierOutput } from '../../../adapter/prettier.js';
 import type { StreamInterceptor } from '../../../lint/external.js';
@@ -11,9 +12,11 @@ import { createTscAnnotations } from './tsc.js';
 
 import { createGitHubAnnotations } from './index.js';
 
+import * as Git from '@skuba-lib/api/git';
 import * as GitHub from '@skuba-lib/api/github';
 
 vi.mock('../../../../utils/logging');
+vi.mock('@skuba-lib/api/git');
 vi.mock('@skuba-lib/api/github', async () => ({
   ...(await vi.importActual('@skuba-lib/api/github')),
   createCheckRun: vi.fn(),
@@ -131,6 +134,7 @@ beforeEach(() => {
   process.env.GITHUB_TOKEN = 'Hello from GITHUB_TOKEN';
   process.env.GITHUB_WORKFLOW = 'Test';
 
+  vi.mocked(Git.findRoot).mockResolvedValue(process.cwd());
   vi.mocked(createEslintAnnotations).mockReturnValue(mockEslintAnnotations);
   vi.mocked(createPrettierAnnotations).mockReturnValue(mockPrettierAnnotations);
   vi.mocked(createTscAnnotations).mockReturnValue(mockTscAnnotations);
@@ -159,6 +163,23 @@ it('should return immediately if the required environment variables are not set'
   );
 
   expect(GitHub.createCheckRun).not.toHaveBeenCalled();
+});
+
+it('should return immediately if there is no Git repository', async () => {
+  vi.mocked(Git.findRoot).mockResolvedValueOnce(null);
+
+  await createGitHubAnnotations(
+    internalOutput,
+    eslintOutput,
+    prettierOutput,
+    tscOk,
+    tscOutputStream,
+  );
+
+  expect(GitHub.createCheckRun).not.toHaveBeenCalled();
+  expect(log.warn).toHaveBeenCalledWith(
+    'GitHub annotations skipped because no .git directory was found.',
+  );
 });
 
 it('should call createEslintAnnotations with the ESLint output', async () => {

--- a/src/cli/lint/annotate/github/index.ts
+++ b/src/cli/lint/annotate/github/index.ts
@@ -1,3 +1,4 @@
+import { log } from '../../../../utils/logging.js';
 import type { ESLintOutput } from '../../../adapter/eslint.js';
 import type { PrettierOutput } from '../../../adapter/prettier.js';
 import type { StreamInterceptor } from '../../../lint/external.js';
@@ -8,6 +9,7 @@ import { createInternalAnnotations } from './internal.js';
 import { createPrettierAnnotations } from './prettier.js';
 import { createTscAnnotations } from './tsc.js';
 
+import * as Git from '@skuba-lib/api/git';
 import * as GitHub from '@skuba-lib/api/github';
 
 export const createGitHubAnnotations = async (
@@ -18,6 +20,11 @@ export const createGitHubAnnotations = async (
   tscOutputStream: StreamInterceptor,
 ) => {
   if (!GitHub.enabledFromEnvironment()) {
+    return;
+  }
+
+  if (!(await Git.findRoot({ dir: process.cwd() }))) {
+    log.warn('GitHub annotations skipped because no .git directory was found.');
     return;
   }
 

--- a/src/cli/lint/autofix.test.ts
+++ b/src/cli/lint/autofix.test.ts
@@ -53,6 +53,8 @@ beforeEach(async () => {
   delete process.env.BUILDKITE_BRANCH;
   delete process.env.BUILDKITE_PIPELINE_DEFAULT_BRANCH;
   delete process.env.GITHUB_ACTIONS;
+  delete process.env.GITHUB_HEAD_REF;
+  delete process.env.GITHUB_REF_NAME;
   delete process.env.GITHUB_REF_PROTECTED;
 
   process.env.CI = 'true';

--- a/src/cli/lint/autofix.test.ts
+++ b/src/cli/lint/autofix.test.ts
@@ -119,6 +119,17 @@ describe('autofix', () => {
       expectNoAutofix();
     });
 
+    it('bails when there is no Git repository', async () => {
+      vol.reset();
+
+      await expect(autofix(params)).resolves.toBeUndefined();
+
+      expectNoAutofix();
+      expect(stdout()).toContain(
+        'Autofix skipped because no .git directory was found.',
+      );
+    });
+
     it('bails on the master branch', async () => {
       await git.branch({ fs, dir, ref: 'master', checkout: true });
 
@@ -429,6 +440,17 @@ describe('autofix', () => {
       await expect(autofix(params)).resolves.toBeUndefined();
 
       expectNoAutofix();
+    });
+
+    it('bails when there is no Git repository', async () => {
+      vol.reset();
+
+      await expect(autofix(params)).resolves.toBeUndefined();
+
+      expectNoAutofix();
+      expect(stdout()).toContain(
+        'Autofix skipped because no .git directory was found.',
+      );
     });
 
     it('bails on the master branch', async () => {

--- a/src/cli/lint/autofix.ts
+++ b/src/cli/lint/autofix.ts
@@ -243,6 +243,11 @@ export const autofix = async (params: AutofixParameters): Promise<void> => {
     return;
   }
 
+  if (isCiEnv() && !(await Git.findRoot({ dir }))) {
+    log.warn('Autofix skipped because no .git directory was found.');
+    return;
+  }
+
   let currentBranch;
   try {
     currentBranch = await Git.currentBranch({ dir });

--- a/src/cli/test/annotate.test.ts
+++ b/src/cli/test/annotate.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { log } from '../../utils/logging.js';
+
+import { createGitHubAnnotations } from './annotate.js';
+
+import * as Git from '@skuba-lib/api/git';
+import * as GitHub from '@skuba-lib/api/github';
+
+vi.mock('@skuba-lib/api/git');
+vi.mock('../../utils/logging');
+vi.mock('@skuba-lib/api/github', async () => ({
+  ...(await vi.importActual('@skuba-lib/api/github')),
+  createCheckRun: vi.fn(),
+}));
+
+beforeEach(() => {
+  process.env.CI = 'true';
+  process.env.GITHUB_TOKEN = 'Hello from GITHUB_TOKEN';
+
+  vi.mocked(Git.findRoot).mockResolvedValue(process.cwd());
+});
+
+afterEach(() => {
+  delete process.env.CI;
+  delete process.env.GITHUB_TOKEN;
+
+  vi.resetAllMocks();
+});
+
+it('creates a test check run in a Git repository', async () => {
+  await createGitHubAnnotations(true);
+
+  expect(GitHub.createCheckRun).toHaveBeenCalledOnce();
+});
+
+it('returns immediately if there is no Git repository', async () => {
+  vi.mocked(Git.findRoot).mockResolvedValueOnce(null);
+
+  await createGitHubAnnotations(true);
+
+  expect(GitHub.createCheckRun).not.toHaveBeenCalled();
+  expect(log.warn).toHaveBeenCalledWith(
+    'GitHub annotations skipped because no .git directory was found.',
+  );
+});

--- a/src/cli/test/annotate.ts
+++ b/src/cli/test/annotate.ts
@@ -1,8 +1,16 @@
+import { log } from '../../utils/logging.js';
+
 import * as Buildkite from '@skuba-lib/api/buildkite';
+import * as Git from '@skuba-lib/api/git';
 import * as GitHub from '@skuba-lib/api/github';
 
 export const createGitHubAnnotations = async (isOk: boolean) => {
   if (!GitHub.enabledFromEnvironment()) {
+    return;
+  }
+
+  if (!(await Git.findRoot({ dir: process.cwd() }))) {
+    log.warn('GitHub annotations skipped because no .git directory was found.');
     return;
   }
 


### PR DESCRIPTION
## Summary

- skip GitHub lint and test annotations when the working directory has no Git repository
- stop CI autofix before formatting or Git operations in the same environment
- cover GitHub Actions, other CI systems, and both check-run paths

Fixes #828.

Sharp eye on this container edge case, @72636c; the original logs identified all three integration paths that needed the same guard.

## Root cause

GitHub reporting was enabled from CI and token variables alone, while autofix treated failed Git branch and commit lookups as non-blocking. In containers where the source was copied without `.git` metadata, those paths continued into repository operations and emitted caught Git errors.

Each Git-dependent integration now checks `Git.findRoot` first. If no repository is available, it returns with a concise warning before constructing annotations, calling GitHub, running formatters, or collecting changed files.

## Compatibility

Normal repositories keep the existing annotation and autofix behavior. Local non-CI autofix remains unchanged. Buildkite annotations are independent of the GitHub guard and continue to run. In a CI workspace without Git metadata, GitHub check reporting and autofix are intentionally disabled.

## Checks

- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `pnpm test` (68 files, 849 tests)
- `pnpm exec vitest run src/cli/lint/annotate/github/index.test.ts src/cli/test/annotate.test.ts src/cli/lint/autofix.test.ts` (51 tests)
- `pnpm --filter '!./template/**' test:ci`
- `pnpm test:template greeter`
- `pnpm test:template oss-npm-package`
- built-code smoke test from a temporary directory without Git metadata

The full root `CI=true pnpm --silent skuba test` run passed 870 of 872 tests locally. Two `format.int.test.ts` snapshots differed only in ANSI colour codes under the local terminal and Node 24.14.0; the repository targets Node 24.18 and CI will provide the authoritative integration result.