### PR TITLE
Remove manual `npm` install

### DIFF
--- a/.changeset/huge-bobcats-relate.md
+++ b/.changeset/huge-bobcats-relate.md
@@ -1,5 +1,0 @@
----
-'skuba': patch
----
-
-test

--- a/.changeset/huge-bobcats-relate.md
+++ b/.changeset/huge-bobcats-relate.md
@@ -1,0 +1,5 @@
+---
+'skuba': patch
+---
+
+test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install latest npm
-        run: npm install -g npm@11.18.0
-
       - name: Publish to npm
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
@@ -76,9 +73,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      - name: Install latest npm
-        run: npm install -g npm@11.18.0
 
       - name: Publish to npm
         uses: seek-oss/changesets-snapshot@9063bfcb495100964ee0912c5bcb30c4c434c1b3 # v0.3.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install latest npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Publish to npm
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
@@ -78,7 +78,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install latest npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.18.0
 
       - name: Publish to npm
         uses: seek-oss/changesets-snapshot@9063bfcb495100964ee0912c5bcb30c4c434c1b3 # v0.3.2


### PR DESCRIPTION
https://github.com/npm/cli/releases/tag/v12.0.0 results in 
```
error an error occurred while publishing ____: undefined You cannot publish over the previously published versions: ___.
```
https://github.com/seek-oss/skuba/actions/runs/29468573373/job/87526909796