### PR TITLE
Add custom vitest config for oss template

### DIFF
--- a/template/oss-npm-package/tsdown.config.mts
+++ b/template/oss-npm-package/tsdown.config.mts
@@ -8,10 +8,8 @@ export default defineConfig({
   dts: true,
   inputOptions: {
     resolve: {
-      alias: {
-        '#src': './src',
-      },
-    },
+      conditionNames: ['@seek/<%- moduleName %>/source']
+    }
   },
   checks: {
     legacyCjs: false,

--- a/template/oss-npm-package/tsdown.config.mts
+++ b/template/oss-npm-package/tsdown.config.mts
@@ -8,8 +8,8 @@ export default defineConfig({
   dts: true,
   inputOptions: {
     resolve: {
-      conditionNames: ['@seek/<%- moduleName %>/source']
-    }
+      conditionNames: ['@seek/<%- moduleName %>/source'],
+    },
   },
   checks: {
     legacyCjs: false,

--- a/template/oss-npm-package/vitest.config.ts
+++ b/template/oss-npm-package/vitest.config.ts
@@ -1,0 +1,26 @@
+import { Vitest } from 'skuba';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(
+  Vitest.mergePreset({
+    ssr: {
+      resolve: {
+        conditions: ['@seek/<%- moduleName %>/source'],
+      },
+    },
+    test: {
+      env: {
+        DEPLOYMENT: 'test',
+      },
+      coverage: {
+        thresholds: {
+          branches: 100,
+          functions: 100,
+          lines: 100,
+          statements: 100,
+        },
+        exclude: ['src/testing'],
+      },
+    },
+  }),
+);


### PR DESCRIPTION
init doesn't properly work with the oss-template because the base config vitest.config file references serviceName instead of moduleName.